### PR TITLE
Cleanup of transport management in device/channel

### DIFF
--- a/fairmq/FairMQChannel.cxx
+++ b/fairmq/FairMQChannel.cxx
@@ -36,7 +36,7 @@ FairMQChannel::FairMQChannel()
     , fRateLogging(1)
     , fName("")
     , fIsValid(false)
-    , fTransportType(FairMQ::Transport::DEFAULT)
+    , fTransportType(fair::mq::Transport::DEFAULT)
     , fTransportFactory(nullptr)
     , fMultipart(false)
     , fModified(true)
@@ -57,7 +57,7 @@ FairMQChannel::FairMQChannel(const string& type, const string& method, const str
     , fRateLogging(1)
     , fName("")
     , fIsValid(false)
-    , fTransportType(FairMQ::Transport::DEFAULT)
+    , fTransportType(fair::mq::Transport::DEFAULT)
     , fTransportFactory(nullptr)
     , fMultipart(false)
     , fModified(true)
@@ -99,7 +99,7 @@ FairMQChannel::FairMQChannel(const FairMQChannel& chan)
     , fRateLogging(chan.fRateLogging)
     , fName(chan.fName)
     , fIsValid(false)
-    , fTransportType(FairMQ::Transport::DEFAULT)
+    , fTransportType(fair::mq::Transport::DEFAULT)
     , fTransportFactory(nullptr)
     , fMultipart(chan.fMultipart)
     , fModified(chan.fModified)
@@ -120,7 +120,7 @@ FairMQChannel& FairMQChannel::operator=(const FairMQChannel& chan)
     fSocket = nullptr;
     fName = chan.fName;
     fIsValid = false;
-    fTransportType = FairMQ::Transport::DEFAULT;
+    fTransportType = fair::mq::Transport::DEFAULT;
     fTransportFactory = nullptr;
 
     return *this;
@@ -587,7 +587,7 @@ bool FairMQChannel::ValidateChannel()
         }
 
         // validate channel transport
-        if (FairMQ::TransportTypes.find(fTransportName) == FairMQ::TransportTypes.end())
+        if (fair::mq::TransportTypes.find(fTransportName) == fair::mq::TransportTypes.end())
         {
             ss << "INVALID";
             LOG(debug) << ss.str();

--- a/fairmq/FairMQChannel.cxx
+++ b/fairmq/FairMQChannel.cxx
@@ -28,7 +28,7 @@ FairMQChannel::FairMQChannel()
     , fType("unspecified")
     , fMethod("unspecified")
     , fAddress("unspecified")
-    , fTransport("default")
+    , fTransportName("default")
     , fSndBufSize(1000)
     , fRcvBufSize(1000)
     , fSndKernelSize(0)
@@ -49,7 +49,7 @@ FairMQChannel::FairMQChannel(const string& type, const string& method, const str
     , fType(type)
     , fMethod(method)
     , fAddress(address)
-    , fTransport("default")
+    , fTransportName("default")
     , fSndBufSize(1000)
     , fRcvBufSize(1000)
     , fSndKernelSize(0)
@@ -70,7 +70,7 @@ FairMQChannel::FairMQChannel(const string& name, const string& type, std::shared
     , fType(type)
     , fMethod("unspecified")
     , fAddress("unspecified")
-    , fTransport("default") // TODO refactor, either use string representation or enum type
+    , fTransportName("default") // TODO refactor, either use string representation or enum type
     , fSndBufSize(1000)
     , fRcvBufSize(1000)
     , fSndKernelSize(0)
@@ -91,7 +91,7 @@ FairMQChannel::FairMQChannel(const FairMQChannel& chan)
     , fType(chan.fType)
     , fMethod(chan.fMethod)
     , fAddress(chan.fAddress)
-    , fTransport(chan.fTransport)
+    , fTransportName(chan.fTransportName)
     , fSndBufSize(chan.fSndBufSize)
     , fRcvBufSize(chan.fRcvBufSize)
     , fSndKernelSize(chan.fSndKernelSize)
@@ -111,7 +111,7 @@ FairMQChannel& FairMQChannel::operator=(const FairMQChannel& chan)
     fType = chan.fType;
     fMethod = chan.fMethod;
     fAddress = chan.fAddress;
-    fTransport = chan.fTransport;
+    fTransportName = chan.fTransportName;
     fSndBufSize = chan.fSndBufSize;
     fRcvBufSize = chan.fRcvBufSize;
     fSndKernelSize = chan.fSndKernelSize;
@@ -194,16 +194,16 @@ string FairMQChannel::GetAddress() const
     }
 }
 
-string FairMQChannel::GetTransport() const
+string FairMQChannel::GetTransportName() const
 {
     try
     {
         unique_lock<mutex> lock(fChannelMutex);
-        return fTransport;
+        return fTransportName;
     }
     catch (exception& e)
     {
-        LOG(error) << "Exception caught in FairMQChannel::GetTransport: " << e.what();
+        LOG(error) << "Exception caught in FairMQChannel::GetTransportName: " << e.what();
         exit(EXIT_FAILURE);
     }
 }
@@ -332,7 +332,7 @@ void FairMQChannel::UpdateTransport(const string& transport)
     {
         unique_lock<mutex> lock(fChannelMutex);
         fIsValid = false;
-        fTransport = transport;
+        fTransportName = transport;
         fModified = true;
     }
     catch (exception& e)
@@ -587,13 +587,11 @@ bool FairMQChannel::ValidateChannel()
         }
 
         // validate channel transport
-        // const string channelTransportNames[] = { "default", "zeromq", "nanomsg", "shmem" };
-        // const set<string> channelTransports(channelTransportNames, channelTransportNames + sizeof(channelTransportNames) / sizeof(string));
-        if (FairMQ::TransportTypes.find(fTransport) == FairMQ::TransportTypes.end())
+        if (FairMQ::TransportTypes.find(fTransportName) == FairMQ::TransportTypes.end())
         {
             ss << "INVALID";
             LOG(debug) << ss.str();
-            LOG(error) << "Invalid channel transport: \"" << fTransport << "\"";
+            LOG(error) << "Invalid channel transport: \"" << fTransportName << "\"";
             exit(EXIT_FAILURE);
         }
 

--- a/fairmq/FairMQChannel.h
+++ b/fairmq/FairMQChannel.h
@@ -301,7 +301,7 @@ class FairMQChannel
     std::string fType;
     std::string fMethod;
     std::string fAddress;
-    std::string fTransportName;
+    fair::mq::Transport fTransportType;
     int fSndBufSize;
     int fRcvBufSize;
     int fSndKernelSize;
@@ -311,7 +311,6 @@ class FairMQChannel
     std::string fName;
     std::atomic<bool> fIsValid;
 
-    fair::mq::Transport fTransportType;
     std::shared_ptr<FairMQTransportFactory> fTransportFactory;
 
     bool CheckCompatibility(std::unique_ptr<FairMQMessage>& msg) const;

--- a/fairmq/FairMQChannel.h
+++ b/fairmq/FairMQChannel.h
@@ -92,7 +92,7 @@ class FairMQChannel
 
     /// Get channel transport ("default", "zeromq", "nanomsg" or "shmem")
     /// @return Returns channel transport (e.g. "default", "zeromq", "nanomsg" or "shmem")
-    std::string GetTransport() const;
+    std::string GetTransportName() const;
 
     /// Get socket send buffer size (in number of messages)
     /// @return Returns socket send buffer size (in number of messages)
@@ -301,7 +301,7 @@ class FairMQChannel
     std::string fType;
     std::string fMethod;
     std::string fAddress;
-    std::string fTransport;
+    std::string fTransportName;
     int fSndBufSize;
     int fRcvBufSize;
     int fSndKernelSize;

--- a/fairmq/FairMQChannel.h
+++ b/fairmq/FairMQChannel.h
@@ -311,7 +311,7 @@ class FairMQChannel
     std::string fName;
     std::atomic<bool> fIsValid;
 
-    FairMQ::Transport fTransportType;
+    fair::mq::Transport fTransportType;
     std::shared_ptr<FairMQTransportFactory> fTransportFactory;
 
     bool CheckCompatibility(std::unique_ptr<FairMQMessage>& msg) const;

--- a/fairmq/FairMQDevice.cxx
+++ b/fairmq/FairMQDevice.cxx
@@ -555,10 +555,10 @@ void FairMQDevice::HandleMultipleChannelInput()
     fMultitransportInputs.clear();
     for (const auto& k : fInputChannelKeys)
     {
-        FairMQ::Transport t = fChannels.at(k).at(0).fTransportType;
+        fair::mq::Transport t = fChannels.at(k).at(0).fTransportType;
         if (fMultitransportInputs.find(t) == fMultitransportInputs.end())
         {
-            fMultitransportInputs.insert(pair<FairMQ::Transport, vector<string>>(t, vector<string>()));
+            fMultitransportInputs.insert(pair<fair::mq::Transport, vector<string>>(t, vector<string>()));
             fMultitransportInputs.at(t).push_back(k);
         }
         else
@@ -762,7 +762,7 @@ void FairMQDevice::Pause()
 
 shared_ptr<FairMQTransportFactory> FairMQDevice::AddTransport(const string& transport)
 {
-    auto i = fTransports.find(FairMQ::TransportTypes.at(transport));
+    auto i = fTransports.find(fair::mq::TransportTypes.at(transport));
 
     if (i == fTransports.end())
     {
@@ -770,7 +770,7 @@ shared_ptr<FairMQTransportFactory> FairMQDevice::AddTransport(const string& tran
 
         LOG(debug) << "Adding '" << transport << "' transport to the device.";
 
-        pair<FairMQ::Transport, shared_ptr<FairMQTransportFactory>> trPair(FairMQ::TransportTypes.at(transport), tr);
+        pair<fair::mq::Transport, shared_ptr<FairMQTransportFactory>> trPair(fair::mq::TransportTypes.at(transport), tr);
         fTransports.insert(trPair);
 
         return tr;

--- a/fairmq/FairMQDevice.cxx
+++ b/fairmq/FairMQDevice.cxx
@@ -42,7 +42,7 @@ FairMQDevice::FairMQDevice()
     , fPortRangeMin(22000)
     , fPortRangeMax(32000)
     , fNetworkInterface()
-    , fDefaultTransport("default")
+    , fDefaultTransportName("default")
     , fInitializationTimeoutInS(120)
     , fDataCallbacks(false)
     , fMsgInputs()
@@ -72,7 +72,7 @@ FairMQDevice::FairMQDevice(const fair::mq::tools::Version version)
     , fPortRangeMin(22000)
     , fPortRangeMax(32000)
     , fNetworkInterface()
-    , fDefaultTransport("default")
+    , fDefaultTransportName("default")
     , fInitializationTimeoutInS(120)
     , fDataCallbacks(false)
     , fMsgInputs()
@@ -246,15 +246,15 @@ bool FairMQDevice::AttachChannel(FairMQChannel& ch)
 {
     if (!ch.fTransportFactory)
     {
-        if (ch.fTransport == "default" || ch.fTransport == fDefaultTransport)
+        if (ch.fTransportName == "default" || ch.fTransportName == fDefaultTransportName)
         {
             LOG(debug) << ch.fName << ": using default transport";
             ch.InitTransport(fTransportFactory);
         }
         else
         {
-            LOG(debug) << ch.fName << ": channel transport (" << fDefaultTransport << ") overriden to " << ch.fTransport;
-            ch.InitTransport(AddTransport(ch.fTransport));
+            LOG(debug) << ch.fName << ": channel transport (" << fDefaultTransportName << ") overriden to " << ch.fTransportName;
+            ch.InitTransport(AddTransport(ch.fTransportName));
         }
         ch.fTransportType = ch.fTransportFactory->GetType();
     }
@@ -804,7 +804,7 @@ void FairMQDevice::CreateOwnConfig()
     fNumIoThreads = fConfig->GetValue<int>("io-threads");
     fInitializationTimeoutInS = fConfig->GetValue<int>("initialization-timeout");
     fRate = fConfig->GetValue<float>("rate");
-    fDefaultTransport = fConfig->GetValue<string>("transport");
+    fDefaultTransportName = fConfig->GetValue<string>("transport");
 }
 
 void FairMQDevice::SetTransport(const string& transport)
@@ -844,8 +844,8 @@ void FairMQDevice::SetConfig(FairMQProgOptions& config)
     fNumIoThreads = config.GetValue<int>("io-threads");
     fInitializationTimeoutInS = config.GetValue<int>("initialization-timeout");
     fRate = fConfig->GetValue<float>("rate");
-    fDefaultTransport = config.GetValue<string>("transport");
-    SetTransport(fDefaultTransport);
+    fDefaultTransportName = config.GetValue<string>("transport");
+    SetTransport(fDefaultTransportName);
 }
 
 void FairMQDevice::LogSocketRates()

--- a/fairmq/FairMQDevice.h
+++ b/fairmq/FairMQDevice.h
@@ -253,7 +253,7 @@ class FairMQDevice : public FairMQStateMachine
         // if more than one channel provided, check compatibility
         if (chans.size() > 1)
         {
-            FairMQ::Transport type = fChannels.at(chans.at(0)).at(0).Transport()->GetType();
+            fair::mq::Transport type = fChannels.at(chans.at(0)).at(0).Transport()->GetType();
 
             for (unsigned int i = 1; i < chans.size(); ++i)
             {
@@ -273,7 +273,7 @@ class FairMQDevice : public FairMQStateMachine
         // if more than one channel provided, check compatibility
         if (channels.size() > 1)
         {
-            FairMQ::Transport type = channels.at(0)->Transport()->GetType();
+            fair::mq::Transport type = channels.at(0)->Transport()->GetType();
 
             for (unsigned int i = 1; i < channels.size(); ++i)
             {
@@ -415,7 +415,7 @@ class FairMQDevice : public FairMQStateMachine
 
   protected:
     std::shared_ptr<FairMQTransportFactory> fTransportFactory; ///< Transport factory
-    std::unordered_map<FairMQ::Transport, std::shared_ptr<FairMQTransportFactory>> fTransports; ///< Container for transports
+    std::unordered_map<fair::mq::Transport, std::shared_ptr<FairMQTransportFactory>> fTransports; ///< Container for transports
 
   public:
     std::unordered_map<std::string, std::vector<FairMQChannel>> fChannels; ///< Device channels
@@ -521,7 +521,7 @@ class FairMQDevice : public FairMQStateMachine
     bool fDataCallbacks;
     std::unordered_map<std::string, InputMsgCallback> fMsgInputs;
     std::unordered_map<std::string, InputMultipartCallback> fMultipartInputs;
-    std::unordered_map<FairMQ::Transport, std::vector<std::string>> fMultitransportInputs;
+    std::unordered_map<fair::mq::Transport, std::vector<std::string>> fMultitransportInputs;
     std::unordered_map<std::string, std::pair<uint16_t, uint16_t>> fChannelRegistry;
     std::vector<std::string> fInputChannelKeys;
     std::mutex fMultitransportMutex;

--- a/fairmq/FairMQDevice.h
+++ b/fairmq/FairMQDevice.h
@@ -196,7 +196,7 @@ class FairMQDevice : public FairMQStateMachine
     /// @brief Getter for default transport factory
     auto Transport() const -> const FairMQTransportFactory*
     {
-        return fTransportFactory.get();;
+        return fTransportFactory.get();
     }
 
     template<typename... Args>
@@ -293,7 +293,7 @@ class FairMQDevice : public FairMQStateMachine
 
     /// Adds a transport to the device if it doesn't exist
     /// @param transport  Transport string ("zeromq"/"nanomsg"/"shmem")
-    std::shared_ptr<FairMQTransportFactory> AddTransport(const std::string& transport);
+    std::shared_ptr<FairMQTransportFactory> AddTransport(const fair::mq::Transport transport);
     /// Sets the default transport for the device
     /// @param transport  Transport string ("zeromq"/"nanomsg"/"shmem")
     void SetTransport(const std::string& transport = "zeromq");
@@ -407,14 +407,14 @@ class FairMQDevice : public FairMQStateMachine
     void SetNetworkInterface(const std::string& networkInterface) { fNetworkInterface = networkInterface; }
     std::string GetNetworkInterface() const { return fNetworkInterface; }
 
-    void SetDefaultTransportName(const std::string& defaultTransportName) { fDefaultTransportName = defaultTransportName; }
-    std::string GetDefaultTransportName() const { return fDefaultTransportName; }
+    void SetDefaultTransport(const std::string& name) { fDefaultTransportType = fair::mq::TransportTypes.at(name); }
+    std::string GetDefaultTransport() const { return fair::mq::TransportNames.at(fDefaultTransportType); }
 
     void SetInitializationTimeoutInS(int initializationTimeoutInS) { fInitializationTimeoutInS = initializationTimeoutInS; }
     int GetInitializationTimeoutInS() const { return fInitializationTimeoutInS; }
 
   protected:
-    std::shared_ptr<FairMQTransportFactory> fTransportFactory; ///< Transport factory
+    std::shared_ptr<FairMQTransportFactory> fTransportFactory; ///< Default transport factory
     std::unordered_map<fair::mq::Transport, std::shared_ptr<FairMQTransportFactory>> fTransports; ///< Container for transports
 
   public:
@@ -472,7 +472,7 @@ class FairMQDevice : public FairMQStateMachine
     int fPortRangeMax; ///< Maximum value for the port range (if dynamic)
 
     std::string fNetworkInterface; ///< Network interface to use for dynamic binding
-    std::string fDefaultTransportName; ///< Default transport for the device
+    fair::mq::Transport fDefaultTransportType; ///< Default transport for the device
 
     int fInitializationTimeoutInS; ///< Timeout for the initialization (in seconds)
 

--- a/fairmq/FairMQDevice.h
+++ b/fairmq/FairMQDevice.h
@@ -196,7 +196,7 @@ class FairMQDevice : public FairMQStateMachine
     /// @brief Getter for default transport factory
     auto Transport() const -> const FairMQTransportFactory*
     {
-        return fTransports.at(fair::mq::TransportTypes[GetDefaultTransport()]).get();
+        return fTransportFactory.get();;
     }
 
     template<typename... Args>
@@ -407,8 +407,8 @@ class FairMQDevice : public FairMQStateMachine
     void SetNetworkInterface(const std::string& networkInterface) { fNetworkInterface = networkInterface; }
     std::string GetNetworkInterface() const { return fNetworkInterface; }
 
-    void SetDefaultTransport(const std::string& defaultTransport) { fDefaultTransport = defaultTransport; }
-    std::string GetDefaultTransport() const { return fDefaultTransport; }
+    void SetDefaultTransportName(const std::string& defaultTransportName) { fDefaultTransportName = defaultTransportName; }
+    std::string GetDefaultTransportName() const { return fDefaultTransportName; }
 
     void SetInitializationTimeoutInS(int initializationTimeoutInS) { fInitializationTimeoutInS = initializationTimeoutInS; }
     int GetInitializationTimeoutInS() const { return fInitializationTimeoutInS; }
@@ -472,7 +472,7 @@ class FairMQDevice : public FairMQStateMachine
     int fPortRangeMax; ///< Maximum value for the port range (if dynamic)
 
     std::string fNetworkInterface; ///< Network interface to use for dynamic binding
-    std::string fDefaultTransport; ///< Default transport for the device
+    std::string fDefaultTransportName; ///< Default transport for the device
 
     int fInitializationTimeoutInS; ///< Timeout for the initialization (in seconds)
 

--- a/fairmq/FairMQMessage.h
+++ b/fairmq/FairMQMessage.h
@@ -28,7 +28,7 @@ class FairMQMessage
 
     virtual bool SetUsedSize(const size_t size) = 0;
 
-    virtual FairMQ::Transport GetType() const = 0;
+    virtual fair::mq::Transport GetType() const = 0;
 
     virtual void Copy(const std::unique_ptr<FairMQMessage>& msg) __attribute__((deprecated("Use 'Copy(const FairMQMessage& msg)'"))) = 0;
     virtual void Copy(const FairMQMessage& msg) = 0;

--- a/fairmq/FairMQTransportFactory.h
+++ b/fairmq/FairMQTransportFactory.h
@@ -29,7 +29,7 @@ class FairMQTransportFactory
   private:
     /// Topology wide unique id
     const std::string fkId;
- 
+
   public:
     /// ctor
     /// @param id Topology wide unique id, usually the device id.
@@ -69,7 +69,7 @@ class FairMQTransportFactory
     virtual FairMQUnmanagedRegionPtr CreateUnmanagedRegion(const size_t size, FairMQRegionCallback callback = nullptr) const = 0;
 
     /// Get transport type
-    virtual FairMQ::Transport GetType() const = 0;
+    virtual fair::mq::Transport GetType() const = 0;
 
     virtual void Interrupt() = 0;
     virtual void Resume() = 0;

--- a/fairmq/Transports.h
+++ b/fairmq/Transports.h
@@ -15,8 +15,9 @@
 #include <string>
 #include <unordered_map>
 
-/// TODO deprecate this namespace
-namespace FairMQ
+namespace fair
+{
+namespace mq
 {
 
 enum class Transport
@@ -28,7 +29,6 @@ enum class Transport
     OFI
 };
 
-
 static std::unordered_map<std::string, Transport> TransportTypes {
     { "default", Transport::DEFAULT },
     { "zeromq", Transport::ZMQ },
@@ -37,16 +37,6 @@ static std::unordered_map<std::string, Transport> TransportTypes {
     { "ofi", Transport::OFI }
 };
 
-}
-
-namespace fair
-{
-namespace mq
-{
-
-using Transport = ::FairMQ::Transport;
-using ::FairMQ::TransportTypes;
-
 } /* namespace mq */
 } /* namespace fair */
 
@@ -54,8 +44,24 @@ namespace std
 {
 
 template<>
-struct hash<FairMQ::Transport> : fair::mq::tools::HashEnum<FairMQ::Transport> {};
+struct hash<fair::mq::Transport> : fair::mq::tools::HashEnum<fair::mq::Transport> {};
 
 } /* namespace std */
+
+namespace fair
+{
+namespace mq
+{
+
+static std::unordered_map<Transport, std::string> TransportNames {
+    { Transport::DEFAULT, "default" },
+    { Transport::ZMQ, "zeromq" },
+    { Transport::NN, "nanomsg" },
+    { Transport::SHM, "shmem" },
+    { Transport::OFI, "ofi" }
+};
+
+} /* namespace mq */
+} /* namespace fair */
 
 #endif /* FAIR_MQ_TRANSPORTS_H */

--- a/fairmq/Transports.h
+++ b/fairmq/Transports.h
@@ -29,14 +29,6 @@ enum class Transport
     OFI
 };
 
-static std::unordered_map<std::string, Transport> TransportTypes {
-    { "default", Transport::DEFAULT },
-    { "zeromq", Transport::ZMQ },
-    { "nanomsg", Transport::NN },
-    { "shmem", Transport::SHM },
-    { "ofi", Transport::OFI }
-};
-
 } /* namespace mq */
 } /* namespace fair */
 
@@ -52,6 +44,14 @@ namespace fair
 {
 namespace mq
 {
+
+static std::unordered_map<std::string, Transport> TransportTypes {
+    { "default", Transport::DEFAULT },
+    { "zeromq", Transport::ZMQ },
+    { "nanomsg", Transport::NN },
+    { "shmem", Transport::SHM },
+    { "ofi", Transport::OFI }
+};
 
 static std::unordered_map<Transport, std::string> TransportNames {
     { Transport::DEFAULT, "default" },

--- a/fairmq/nanomsg/FairMQMessageNN.cxx
+++ b/fairmq/nanomsg/FairMQMessageNN.cxx
@@ -22,7 +22,7 @@
 
 using namespace std;
 
-FairMQ::Transport FairMQMessageNN::fTransportType = FairMQ::Transport::NN;
+fair::mq::Transport FairMQMessageNN::fTransportType = fair::mq::Transport::NN;
 
 FairMQMessageNN::FairMQMessageNN()
     : fMessage(nullptr)
@@ -172,7 +172,7 @@ void FairMQMessageNN::SetMessage(void* data, const size_t size)
     fSize = size;
 }
 
-FairMQ::Transport FairMQMessageNN::GetType() const
+fair::mq::Transport FairMQMessageNN::GetType() const
 {
     return fTransportType;
 }

--- a/fairmq/nanomsg/FairMQMessageNN.h
+++ b/fairmq/nanomsg/FairMQMessageNN.h
@@ -46,7 +46,7 @@ class FairMQMessageNN : public FairMQMessage
 
     bool SetUsedSize(const size_t size) override;
 
-    FairMQ::Transport GetType() const override;
+    fair::mq::Transport GetType() const override;
 
     void Copy(const FairMQMessage& msg) override;
     void Copy(const FairMQMessagePtr& msg) override;
@@ -59,7 +59,7 @@ class FairMQMessageNN : public FairMQMessage
     size_t fHint;
     bool fReceiving;
     FairMQUnmanagedRegion* fRegionPtr;
-    static FairMQ::Transport fTransportType;
+    static fair::mq::Transport fTransportType;
 
     void* GetMessage() const;
     void CloseMessage();

--- a/fairmq/nanomsg/FairMQTransportFactoryNN.cxx
+++ b/fairmq/nanomsg/FairMQTransportFactoryNN.cxx
@@ -12,7 +12,7 @@
 
 using namespace std;
 
-FairMQ::Transport FairMQTransportFactoryNN::fTransportType = FairMQ::Transport::NN;
+fair::mq::Transport FairMQTransportFactoryNN::fTransportType = fair::mq::Transport::NN;
 
 FairMQTransportFactoryNN::FairMQTransportFactoryNN(const string& id, const FairMQProgOptions* /*config*/)
     : FairMQTransportFactory(id)
@@ -70,7 +70,7 @@ FairMQUnmanagedRegionPtr FairMQTransportFactoryNN::CreateUnmanagedRegion(const s
     return unique_ptr<FairMQUnmanagedRegion>(new FairMQUnmanagedRegionNN(size, callback));
 }
 
-FairMQ::Transport FairMQTransportFactoryNN::GetType() const
+fair::mq::Transport FairMQTransportFactoryNN::GetType() const
 {
     return fTransportType;
 }

--- a/fairmq/nanomsg/FairMQTransportFactoryNN.h
+++ b/fairmq/nanomsg/FairMQTransportFactoryNN.h
@@ -39,13 +39,13 @@ class FairMQTransportFactoryNN : public FairMQTransportFactory
 
     FairMQUnmanagedRegionPtr CreateUnmanagedRegion(const size_t size, FairMQRegionCallback callback) const override;
 
-    FairMQ::Transport GetType() const override;
+    fair::mq::Transport GetType() const override;
 
     void Interrupt() override { FairMQSocketNN::Interrupt(); }
     void Resume() override { FairMQSocketNN::Resume(); }
 
   private:
-    static FairMQ::Transport fTransportType;
+    static fair::mq::Transport fTransportType;
 };
 
 #endif /* FAIRMQTRANSPORTFACTORYNN_H_ */

--- a/fairmq/options/FairMQParser.cxx
+++ b/fairmq/options/FairMQParser.cxx
@@ -147,7 +147,7 @@ void ChannelParser(const boost::property_tree::ptree& tree, FairMQMap& channelMa
                 commonChannel.UpdateType(q.second.get<string>("type", commonChannel.GetType()));
                 commonChannel.UpdateMethod(q.second.get<string>("method", commonChannel.GetMethod()));
                 commonChannel.UpdateAddress(q.second.get<string>("address", commonChannel.GetAddress()));
-                commonChannel.UpdateTransport(q.second.get<string>("transport", commonChannel.GetTransport()));
+                commonChannel.UpdateTransport(q.second.get<string>("transport", commonChannel.GetTransportName()));
                 commonChannel.UpdateSndBufSize(q.second.get<int>("sndBufSize", commonChannel.GetSndBufSize()));
                 commonChannel.UpdateRcvBufSize(q.second.get<int>("rcvBufSize", commonChannel.GetRcvBufSize()));
                 commonChannel.UpdateSndKernelSize(q.second.get<int>("sndKernelSize", commonChannel.GetSndKernelSize()));
@@ -166,7 +166,7 @@ void ChannelParser(const boost::property_tree::ptree& tree, FairMQMap& channelMa
                     LOG(debug) << "\ttype          = " << commonChannel.GetType();
                     LOG(debug) << "\tmethod        = " << commonChannel.GetMethod();
                     LOG(debug) << "\taddress       = " << commonChannel.GetAddress();
-                    LOG(debug) << "\ttransport     = " << commonChannel.GetTransport();
+                    LOG(debug) << "\ttransport     = " << commonChannel.GetTransportName();
                     LOG(debug) << "\tsndBufSize    = " << commonChannel.GetSndBufSize();
                     LOG(debug) << "\trcvBufSize    = " << commonChannel.GetRcvBufSize();
                     LOG(debug) << "\tsndKernelSize = " << commonChannel.GetSndKernelSize();
@@ -208,7 +208,7 @@ void SocketParser(const boost::property_tree::ptree& tree, vector<FairMQChannel>
                 channel.UpdateType(q.second.get<string>("type", channel.GetType()));
                 channel.UpdateMethod(q.second.get<string>("method", channel.GetMethod()));
                 channel.UpdateAddress(q.second.get<string>("address", channel.GetAddress()));
-                channel.UpdateTransport(q.second.get<string>("transport", channel.GetTransport()));
+                channel.UpdateTransport(q.second.get<string>("transport", channel.GetTransportName()));
                 channel.UpdateSndBufSize(q.second.get<int>("sndBufSize", channel.GetSndBufSize()));
                 channel.UpdateRcvBufSize(q.second.get<int>("rcvBufSize", channel.GetRcvBufSize()));
                 channel.UpdateSndKernelSize(q.second.get<int>("sndKernelSize", channel.GetSndKernelSize()));
@@ -219,7 +219,7 @@ void SocketParser(const boost::property_tree::ptree& tree, vector<FairMQChannel>
                 LOG(debug) << "\ttype          = " << channel.GetType();
                 LOG(debug) << "\tmethod        = " << channel.GetMethod();
                 LOG(debug) << "\taddress       = " << channel.GetAddress();
-                LOG(debug) << "\ttransport     = " << channel.GetTransport();
+                LOG(debug) << "\ttransport     = " << channel.GetTransportName();
                 LOG(debug) << "\tsndBufSize    = " << channel.GetSndBufSize();
                 LOG(debug) << "\trcvBufSize    = " << channel.GetRcvBufSize();
                 LOG(debug) << "\tsndKernelSize = " << channel.GetSndKernelSize();
@@ -247,7 +247,7 @@ void SocketParser(const boost::property_tree::ptree& tree, vector<FairMQChannel>
         LOG(debug) << "\ttype          = " << channel.GetType();
         LOG(debug) << "\tmethod        = " << channel.GetMethod();
         LOG(debug) << "\taddress       = " << channel.GetAddress();
-        LOG(debug) << "\ttransport     = " << channel.GetTransport();
+        LOG(debug) << "\ttransport     = " << channel.GetTransportName();
         LOG(debug) << "\tsndBufSize    = " << channel.GetSndBufSize();
         LOG(debug) << "\trcvBufSize    = " << channel.GetRcvBufSize();
         LOG(debug) << "\tsndKernelSize = " << channel.GetSndKernelSize();

--- a/fairmq/options/FairMQProgOptions.cxx
+++ b/fairmq/options/FairMQProgOptions.cxx
@@ -196,7 +196,7 @@ void FairMQProgOptions::UpdateMQValues()
             UpdateVarMap<string>(typeKey, channel.GetType());
             UpdateVarMap<string>(methodKey, channel.GetMethod());
             UpdateVarMap<string>(addressKey, channel.GetAddress());
-            UpdateVarMap<string>(transportKey, channel.GetTransport());
+            UpdateVarMap<string>(transportKey, channel.GetTransportName());
             UpdateVarMap<int>(sndBufSizeKey, channel.GetSndBufSize());
             UpdateVarMap<int>(rcvBufSizeKey, channel.GetRcvBufSize());
             UpdateVarMap<int>(sndKernelSizeKey, channel.GetSndKernelSize());

--- a/fairmq/shmem/FairMQMessageSHM.cxx
+++ b/fairmq/shmem/FairMQMessageSHM.cxx
@@ -23,7 +23,7 @@ namespace bipc = boost::interprocess;
 namespace bpt = boost::posix_time;
 
 atomic<bool> FairMQMessageSHM::fInterrupted(false);
-FairMQ::Transport FairMQMessageSHM::fTransportType = FairMQ::Transport::SHM;
+fair::mq::Transport FairMQMessageSHM::fTransportType = fair::mq::Transport::SHM;
 
 FairMQMessageSHM::FairMQMessageSHM(Manager& manager)
     : fManager(manager)
@@ -284,7 +284,7 @@ bool FairMQMessageSHM::SetUsedSize(const size_t size)
     }
 }
 
-FairMQ::Transport FairMQMessageSHM::GetType() const
+fair::mq::Transport FairMQMessageSHM::GetType() const
 {
     return fTransportType;
 }

--- a/fairmq/shmem/FairMQMessageSHM.h
+++ b/fairmq/shmem/FairMQMessageSHM.h
@@ -44,7 +44,7 @@ class FairMQMessageSHM : public FairMQMessage
 
     bool SetUsedSize(const size_t size) override;
 
-    FairMQ::Transport GetType() const override;
+    fair::mq::Transport GetType() const override;
 
     void Copy(const FairMQMessage& msg) override;
     void Copy(const FairMQMessagePtr& msg) override;
@@ -57,7 +57,7 @@ class FairMQMessageSHM : public FairMQMessage
     bool fQueued;
     bool fMetaCreated;
     static std::atomic<bool> fInterrupted;
-    static FairMQ::Transport fTransportType;
+    static fair::mq::Transport fTransportType;
     size_t fRegionId;
     mutable fair::mq::shmem::Region* fRegionPtr;
     boost::interprocess::managed_shared_memory::handle_t fHandle;

--- a/fairmq/shmem/FairMQTransportFactorySHM.cxx
+++ b/fairmq/shmem/FairMQTransportFactorySHM.cxx
@@ -32,7 +32,7 @@ namespace bfs = boost::filesystem;
 namespace bpt = boost::posix_time;
 namespace bipc = boost::interprocess;
 
-FairMQ::Transport FairMQTransportFactorySHM::fTransportType = FairMQ::Transport::SHM;
+fair::mq::Transport FairMQTransportFactorySHM::fTransportType = fair::mq::Transport::SHM;
 
 FairMQTransportFactorySHM::FairMQTransportFactorySHM(const string& id, const FairMQProgOptions* config)
     : FairMQTransportFactory(id)
@@ -316,7 +316,7 @@ FairMQTransportFactorySHM::~FairMQTransportFactorySHM()
     }
 }
 
-FairMQ::Transport FairMQTransportFactorySHM::GetType() const
+fair::mq::Transport FairMQTransportFactorySHM::GetType() const
 {
     return fTransportType;
 }

--- a/fairmq/shmem/FairMQTransportFactorySHM.h
+++ b/fairmq/shmem/FairMQTransportFactorySHM.h
@@ -47,7 +47,7 @@ class FairMQTransportFactorySHM : public FairMQTransportFactory
 
     FairMQUnmanagedRegionPtr CreateUnmanagedRegion(const size_t size, FairMQRegionCallback callback = nullptr) const override;
 
-    FairMQ::Transport GetType() const override;
+    fair::mq::Transport GetType() const override;
 
     void Interrupt() override { FairMQSocketSHM::Interrupt(); }
     void Resume() override { FairMQSocketSHM::Resume(); }
@@ -58,7 +58,7 @@ class FairMQTransportFactorySHM : public FairMQTransportFactory
     void SendHeartbeats();
     void StartMonitor();
 
-    static FairMQ::Transport fTransportType;
+    static fair::mq::Transport fTransportType;
     std::string fDeviceId;
     std::string fSessionName;
     void* fContext;

--- a/fairmq/zeromq/FairMQMessageZMQ.cxx
+++ b/fairmq/zeromq/FairMQMessageZMQ.cxx
@@ -20,7 +20,7 @@
 
 using namespace std;
 
-FairMQ::Transport FairMQMessageZMQ::fTransportType = FairMQ::Transport::ZMQ;
+fair::mq::Transport FairMQMessageZMQ::fTransportType = fair::mq::Transport::ZMQ;
 
 FairMQMessageZMQ::FairMQMessageZMQ()
     : fUsedSizeModified(false)
@@ -190,7 +190,7 @@ void FairMQMessageZMQ::ApplyUsedSize()
     }
 }
 
-FairMQ::Transport FairMQMessageZMQ::GetType() const
+fair::mq::Transport FairMQMessageZMQ::GetType() const
 {
     return fTransportType;
 }

--- a/fairmq/zeromq/FairMQMessageZMQ.h
+++ b/fairmq/zeromq/FairMQMessageZMQ.h
@@ -46,7 +46,7 @@ class FairMQMessageZMQ : public FairMQMessage
     bool SetUsedSize(const size_t size) override;
     void ApplyUsedSize();
 
-    FairMQ::Transport GetType() const override;
+    fair::mq::Transport GetType() const override;
 
     void Copy(const FairMQMessagePtr& msg) override;
     void Copy(const FairMQMessage& msg) override;
@@ -58,7 +58,7 @@ class FairMQMessageZMQ : public FairMQMessage
     size_t fUsedSize;
     std::unique_ptr<zmq_msg_t> fMsg;
     std::unique_ptr<zmq_msg_t> fViewMsg; // view on a subset of fMsg (treating it as user buffer)
-    static FairMQ::Transport fTransportType;
+    static fair::mq::Transport fTransportType;
 
     zmq_msg_t* GetMessage() const;
     void CloseMessage();

--- a/fairmq/zeromq/FairMQTransportFactoryZMQ.cxx
+++ b/fairmq/zeromq/FairMQTransportFactoryZMQ.cxx
@@ -11,7 +11,7 @@
 
 using namespace std;
 
-FairMQ::Transport FairMQTransportFactoryZMQ::fTransportType = FairMQ::Transport::ZMQ;
+fair::mq::Transport FairMQTransportFactoryZMQ::fTransportType = fair::mq::Transport::ZMQ;
 
 FairMQTransportFactoryZMQ::FairMQTransportFactoryZMQ(const string& id, const FairMQProgOptions* config)
     : FairMQTransportFactory(id)
@@ -100,7 +100,7 @@ FairMQUnmanagedRegionPtr FairMQTransportFactoryZMQ::CreateUnmanagedRegion(const 
     return unique_ptr<FairMQUnmanagedRegion>(new FairMQUnmanagedRegionZMQ(size, callback));
 }
 
-FairMQ::Transport FairMQTransportFactoryZMQ::GetType() const
+fair::mq::Transport FairMQTransportFactoryZMQ::GetType() const
 {
     return fTransportType;
 }

--- a/fairmq/zeromq/FairMQTransportFactoryZMQ.h
+++ b/fairmq/zeromq/FairMQTransportFactoryZMQ.h
@@ -48,13 +48,13 @@ class FairMQTransportFactoryZMQ : public FairMQTransportFactory
 
     FairMQUnmanagedRegionPtr CreateUnmanagedRegion(const size_t size, FairMQRegionCallback callback) const override;
 
-    FairMQ::Transport GetType() const override;
+    fair::mq::Transport GetType() const override;
 
     void Interrupt() override { FairMQSocketZMQ::Interrupt(); }
     void Resume() override { FairMQSocketZMQ::Resume(); }
 
   private:
-    static FairMQ::Transport fTransportType;
+    static fair::mq::Transport fTransportType;
     void* fContext;
 };
 


### PR DESCRIPTION
- Use directly available `fTransportFactory` as the return value of `FairMQDevice::Transport()` instead of accessing the map.
- Fix namespaces in Transport.h
- Add conversion maps for string/enum version of transport labels.
- In Channel/Device the enum transport labels can be used instead of string.