### PR TITLE
Control plugin: add ability to switch log levels interactively

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ if(BUILD_FAIRMQ)
   find_package2(PUBLIC Boost VERSION 1.64 REQUIRED
     COMPONENTS program_options thread system filesystem regex date_time signals
   )
-  find_package2(PUBLIC FairLogger VERSION 1.0.6 REQUIRED)
+  find_package2(PUBLIC FairLogger VERSION 1.2.0 REQUIRED)
   find_package2(PRIVATE ZeroMQ VERSION 4.1.5 REQUIRED)
 endif()
 

--- a/fairmq/Plugin.h
+++ b/fairmq/Plugin.h
@@ -99,6 +99,11 @@ class Plugin
     auto SubscribeToPropertyChangeAsString(std::function<void(const std::string& key, std::string newValue)> callback) -> void { fPluginServices->SubscribeToPropertyChangeAsString(fkName, callback); }
     auto UnsubscribeFromPropertyChangeAsString() -> void { fPluginServices->UnsubscribeFromPropertyChangeAsString(fkName); }
 
+    auto CycleLogConsoleSeverityUp() -> void { fPluginServices->CycleLogConsoleSeverityUp(); }
+    auto CycleLogConsoleSeverityDown() -> void { fPluginServices->CycleLogConsoleSeverityDown(); }
+    auto CycleLogVerbosityUp() -> void { fPluginServices->CycleLogVerbosityUp(); }
+    auto CycleLogVerbosityDown() -> void { fPluginServices->CycleLogVerbosityDown(); }
+
   private:
     const std::string fkName;
     const Version fkVersion;

--- a/fairmq/PluginServices.h
+++ b/fairmq/PluginServices.h
@@ -253,6 +253,10 @@ class PluginServices
     /// @param subscriber
     auto UnsubscribeFromPropertyChangeAsString(const std::string& subscriber) -> void { fConfig->UnsubscribeAsString(subscriber); }
 
+    auto CycleLogConsoleSeverityUp() -> void { Logger::CycleConsoleSeverityUp(); }
+    auto CycleLogConsoleSeverityDown() -> void { Logger::CycleConsoleSeverityDown(); }
+    auto CycleLogVerbosityUp() -> void { Logger::CycleVerbosityUp(); }
+    auto CycleLogVerbosityDown() -> void { Logger::CycleVerbosityDown(); }
 
     static const std::unordered_map<std::string, DeviceState> fkDeviceStateStrMap;
     static const std::unordered_map<DeviceState, std::string, tools::HashEnum<DeviceState>> fkStrDeviceStateMap;

--- a/fairmq/plugins/Control.cxx
+++ b/fairmq/plugins/Control.cxx
@@ -107,6 +107,7 @@ auto Control::InteractiveMode() -> void
         struct termios t;
         tcgetattr(STDIN_FILENO, &t); // get the current terminal I/O structure
         t.c_lflag &= ~ICANON; // disable canonical input
+        t.c_lflag &= ~ECHO; // do not echo input chars
         tcsetattr(STDIN_FILENO, TCSANOW, &t); // apply the new settings
 
         PrintInteractiveHelp();
@@ -154,6 +155,22 @@ auto Control::InteractiveMode() -> void
                         LOG(info) << "\n\n --> [d] reset device\n";
                         ChangeDeviceState(DeviceStateTransition::ResetDevice);
                     break;
+                    case 'k':
+                        LOG(info) << "\n\n --> [k] increase log severity\n";
+                        CycleLogConsoleSeverityUp();
+                    break;
+                    case 'l':
+                        LOG(info) << "\n\n --> [l] decrease log severity\n";
+                        CycleLogConsoleSeverityDown();
+                    break;
+                    case 'n':
+                        LOG(info) << "\n\n --> [n] increase log verbosity\n";
+                        CycleLogVerbosityUp();
+                    break;
+                    case 'm':
+                        LOG(info) << "\n\n --> [m] decrease log verbosity\n";
+                        CycleLogVerbosityDown();
+                    break;
                     case 'h':
                         LOG(info) << "\n\n --> [h] help\n";
                         PrintInteractiveHelp();
@@ -181,6 +198,7 @@ auto Control::InteractiveMode() -> void
 
         tcgetattr(STDIN_FILENO, &t); // get the current terminal I/O structure
         t.c_lflag |= ICANON; // re-enable canonical input
+        t.c_lflag |= ECHO; // echo input chars
         tcsetattr(STDIN_FILENO, TCSANOW, &t); // apply the new settings
 
         if (!fDeviceTerminationRequested)
@@ -197,8 +215,11 @@ auto Control::InteractiveMode() -> void
 
 auto Control::PrintInteractiveHelp() -> void
 {
-    LOG(info) << "Use keys to control the state machine:\n\n"
-              << "[h] help, [p] pause, [r] run, [s] stop, [t] reset task, [d] reset device, [q] end, [j] init task, [i] init device\n";
+    stringstream ss;
+    ss << "\nFollowing control commands are available:\n\n"
+       << "[h] help, [p] pause, [r] run, [s] stop, [t] reset task, [d] reset device, [q] end, [j] init task, [i] init device\n"
+       << "[k] increase log severity [l] decrease log severity [n] increase log verbosity [m] decrease log verbosity\n\n";
+    cout << ss.str() << flush;
 }
 
 auto Control::WaitForNextState() -> DeviceState

--- a/fairmq/shmem/Monitor.cxx
+++ b/fairmq/shmem/Monitor.cxx
@@ -170,6 +170,7 @@ void Monitor::Interactive()
     struct termios t;
     tcgetattr(STDIN_FILENO, &t); // get the current terminal I/O structure
     t.c_lflag &= ~ICANON; // disable canonical input
+    t.c_lflag &= ~ECHO; // do not echo input chars
     tcsetattr(STDIN_FILENO, TCSANOW, &t); // apply the new settings
 
     cout << endl;
@@ -238,6 +239,7 @@ void Monitor::Interactive()
 
     tcgetattr(STDIN_FILENO, &t); // get the current terminal I/O structure
     t.c_lflag |= ICANON; // re-enable canonical input
+    t.c_lflag |= ECHO; // echo input chars
     tcsetattr(STDIN_FILENO, TCSANOW, &t); // apply the new settings
 }
 


### PR DESCRIPTION
These changes depend on FairLogger 1.2.0, that are submitted for FairSoft May18 release.