### PR TITLE
Make UpdateTransport log to INFO and not WARN

### DIFF
--- a/fairmq/FairMQChannel.cxx
+++ b/fairmq/FairMQChannel.cxx
@@ -327,9 +327,9 @@ void FairMQChannel::UpdateTransport(const string& transport)
     {
         unique_lock<mutex> lock(fChannelMutex);
         fIsValid = false;
-        LOG(WARN) << fName << ": " << transport;
+        LOG(INFO) << fName << ": " << transport;
         fTransportType = fair::mq::TransportTypes.at(transport);
-        LOG(WARN) << fName << ": " << fair::mq::TransportNames.at(fTransportType);
+        LOG(INFO) << fName << ": " << fair::mq::TransportNames.at(fTransportType);
         fModified = true;
     }
     catch (exception& e)

--- a/fairmq/tools/Process.cxx
+++ b/fairmq/tools/Process.cxx
@@ -11,6 +11,7 @@
 #include <boost/process.hpp>
 
 #include <iostream>
+#include <sstream>
 
 using namespace std;
 


### PR DESCRIPTION
At the moment the AliceO2 DPL has problems in marking problematic devices
because of the log level too high of such informative messages.