### PR TITLE
Change missing options in transport from warning to debug

### DIFF
--- a/fairmq/shmem/FairMQTransportFactorySHM.cxx
+++ b/fairmq/shmem/FairMQTransportFactorySHM.cxx
@@ -69,7 +69,7 @@ FairMQTransportFactorySHM::FairMQTransportFactorySHM(const string& id, const Fai
     }
     else
     {
-        LOG(warn) << "FairMQProgOptions not available! Using defaults.";
+        LOG(debug) << "FairMQProgOptions not available! Using defaults.";
     }
 
     fSessionName.resize(8, '_'); // shorten the session name, to accommodate for name size limit on some systems (MacOS)

--- a/fairmq/zeromq/FairMQTransportFactoryZMQ.cxx
+++ b/fairmq/zeromq/FairMQTransportFactoryZMQ.cxx
@@ -39,7 +39,7 @@ FairMQTransportFactoryZMQ::FairMQTransportFactoryZMQ(const string& id, const Fai
     }
     else
     {
-        LOG(warn) << "FairMQProgOptions not available! Using defaults.";
+        LOG(debug) << "FairMQProgOptions not available! Using defaults.";
     }
 
     if (zmq_ctx_set(fContext, ZMQ_IO_THREADS, numIoThreads) != 0)


### PR DESCRIPTION
Transport has meaningful defaults if FairMQProgOptions is missing

Resolves #50.

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
