### PR TITLE
Run state handlers on the main thread [breaking change]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,10 @@ option(BUILD_DOCS "Build FairMQ documentation." OFF)
 
 
 # Dependencies #################################################################
+set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
+set(THREADS_PREFER_PTHREAD_FLAG TRUE)
+find_package(Threads REQUIRED)
+
 if(BUILD_FAIRMQ)
   find_package2(PUBLIC Boost VERSION 1.64 REQUIRED
     COMPONENTS program_options thread system filesystem regex date_time signals

--- a/fairmq/CMakeLists.txt
+++ b/fairmq/CMakeLists.txt
@@ -223,6 +223,7 @@ target_link_libraries(FairMQ
     INTERFACE # only consumers link against interface dependencies
 
     PUBLIC # libFairMQ AND consumers of libFairMQ link aginst public dependencies
+    pthread
     dl
     Boost::boost
     Boost::program_options

--- a/fairmq/CMakeLists.txt
+++ b/fairmq/CMakeLists.txt
@@ -223,7 +223,7 @@ target_link_libraries(FairMQ
     INTERFACE # only consumers link against interface dependencies
 
     PUBLIC # libFairMQ AND consumers of libFairMQ link aginst public dependencies
-    pthread
+    Threads::Threads
     dl
     Boost::boost
     Boost::program_options

--- a/fairmq/DeviceRunner.cxx
+++ b/fairmq/DeviceRunner.cxx
@@ -13,9 +13,9 @@
 using namespace fair::mq;
 
 DeviceRunner::DeviceRunner(int argc, char* const argv[])
-    : fDevice(nullptr)
-    , fRawCmdLineArgs(tools::ToStrVector(argc, argv, false))
+    : fRawCmdLineArgs(tools::ToStrVector(argc, argv, false))
     , fConfig()
+    , fDevice(nullptr)
     , fPluginManager(fRawCmdLineArgs)
     , fEvents()
 {}
@@ -83,7 +83,7 @@ auto DeviceRunner::Run() -> int
     fDevice->SetConfig(fConfig);
 
     // Initialize plugin services
-    fPluginManager.EmplacePluginServices(&fConfig, *fDevice);
+    fPluginManager.EmplacePluginServices(fConfig, *fDevice);
 
     // Instantiate and run plugins
     fPluginManager.InstantiatePlugins();

--- a/fairmq/DeviceRunner.cxx
+++ b/fairmq/DeviceRunner.cxx
@@ -13,11 +13,12 @@
 using namespace fair::mq;
 
 DeviceRunner::DeviceRunner(int argc, char* const argv[])
-: fRawCmdLineArgs{tools::ToStrVector(argc, argv, false)}
-, fPluginManager{PluginManager::MakeFromCommandLineOptions(fRawCmdLineArgs)}
-, fDevice{nullptr}
-{
-}
+    : fRawCmdLineArgs(tools::ToStrVector(argc, argv, false))
+    , fPluginManager(PluginManager::MakeFromCommandLineOptions(fRawCmdLineArgs))
+    , fConfig()
+    , fDevice(nullptr)
+    , fEvents()
+{}
 
 auto DeviceRunner::Run() -> int
 {
@@ -86,6 +87,9 @@ auto DeviceRunner::Run() -> int
 
     // Instantiate and run plugins
     fPluginManager->InstantiatePlugins();
+
+    // Run the device
+    fDevice->RunStateMachine();
 
     // Wait for control plugin to release device control
     fPluginManager->WaitForPluginsToReleaseDeviceControl();

--- a/fairmq/DeviceRunner.h
+++ b/fairmq/DeviceRunner.h
@@ -61,10 +61,10 @@ class DeviceRunner
     template<typename H>
     auto RemoveHook() -> void { fEvents.Unsubscribe<H>("runner"); }
 
+    std::unique_ptr<FairMQDevice> fDevice;
     std::vector<std::string> fRawCmdLineArgs;
-    std::shared_ptr<PluginManager> fPluginManager;
     FairMQProgOptions fConfig;
-    std::shared_ptr<FairMQDevice> fDevice;
+    PluginManager fPluginManager;
 
   private:
     EventManager fEvents;

--- a/fairmq/DeviceRunner.h
+++ b/fairmq/DeviceRunner.h
@@ -61,9 +61,9 @@ class DeviceRunner
     template<typename H>
     auto RemoveHook() -> void { fEvents.Unsubscribe<H>("runner"); }
 
-    std::unique_ptr<FairMQDevice> fDevice;
     std::vector<std::string> fRawCmdLineArgs;
     FairMQProgOptions fConfig;
+    std::unique_ptr<FairMQDevice> fDevice;
     PluginManager fPluginManager;
 
   private:

--- a/fairmq/FairMQDevice.h
+++ b/fairmq/FairMQDevice.h
@@ -416,6 +416,8 @@ class FairMQDevice : public FairMQStateMachine
     void SetRawCmdLineArgs(const std::vector<std::string>& args) { fRawCmdLineArgs = args; }
     std::vector<std::string> GetRawCmdLineArgs() const { return fRawCmdLineArgs; }
 
+    void RunStateMachine() { ProcessWork(); };
+
   protected:
     std::shared_ptr<FairMQTransportFactory> fTransportFactory; ///< Default transport factory
     std::unordered_map<fair::mq::Transport, std::shared_ptr<FairMQTransportFactory>> fTransports; ///< Container for transports

--- a/fairmq/FairMQStateMachine.h
+++ b/fairmq/FairMQStateMachine.h
@@ -79,10 +79,10 @@ class FairMQStateMachine
     void CallStateChangeCallbacks(const State state) const;
 
     std::string GetCurrentStateName() const;
+    static std::string GetStateName(const State);
     int GetCurrentState() const;
     bool CheckCurrentState(int state) const;
     bool CheckCurrentState(std::string state) const;
-    bool Terminated();
 
     // actions to be overwritten by derived classes
     virtual void InitWrapper() {}
@@ -94,8 +94,10 @@ class FairMQStateMachine
     virtual void Exit() {}
     virtual void Unblock() {}
 
+    void ProcessWork();
+
   private:
-    int GetEventNumber(const std::string& event);
+    static int GetEventNumber(const std::string& event);
 
     std::mutex fChangeStateMutex;
 

--- a/fairmq/Plugin.h
+++ b/fairmq/Plugin.h
@@ -116,9 +116,9 @@ class Plugin
 } /* namespace fair */
 
 #define REGISTER_FAIRMQ_PLUGIN(KLASS, NAME, VERSION, MAINTAINER, HOMEPAGE, PROGOPTIONS) \
-static auto Make_##NAME##_Plugin(fair::mq::PluginServices* pluginServices) -> std::shared_ptr<fair::mq::Plugin> \
+static auto Make_##NAME##_Plugin(fair::mq::PluginServices* pluginServices) -> std::unique_ptr<fair::mq::Plugin> \
 { \
-    return std::make_shared<KLASS>(std::string{#NAME}, VERSION, std::string{MAINTAINER}, std::string{HOMEPAGE}, pluginServices); \
+    return fair::mq::tools::make_unique<KLASS>(std::string{#NAME}, VERSION, std::string{MAINTAINER}, std::string{HOMEPAGE}, pluginServices); \
 } \
 BOOST_DLL_ALIAS(Make_##NAME##_Plugin, make_##NAME##_plugin) \
 BOOST_DLL_ALIAS(PROGOPTIONS, get_##NAME##_plugin_progoptions)

--- a/fairmq/PluginManager.h
+++ b/fairmq/PluginManager.h
@@ -51,6 +51,11 @@ class PluginManager
 
     PluginManager();
 
+    ~PluginManager()
+    {
+        LOG(debug) << "Shutting down Plugin Manager";
+    }
+
     auto SetSearchPaths(const std::vector<boost::filesystem::path>&) -> void;
     auto AppendSearchPath(const boost::filesystem::path&) -> void;
     auto PrependSearchPath(const boost::filesystem::path&) -> void;

--- a/fairmq/PluginManager.h
+++ b/fairmq/PluginManager.h
@@ -70,7 +70,6 @@ class PluginManager
     struct PluginInstantiationError : std::runtime_error { using std::runtime_error::runtime_error; };
 
     static auto ProgramOptions() -> boost::program_options::options_description;
-    static auto MakeFromCommandLineOptions(const std::vector<std::string>) -> PluginManager;
     struct ProgramOptionsParseError : std::runtime_error { using std::runtime_error::runtime_error; };
 
     static auto LibPrefix() -> const std::string& { return fgkLibPrefix; }

--- a/fairmq/PluginManager.h
+++ b/fairmq/PluginManager.h
@@ -47,9 +47,10 @@ namespace mq
 class PluginManager
 {
   public:
-    using PluginFactory = std::shared_ptr<fair::mq::Plugin>(PluginServices&);
+    using PluginFactory = std::unique_ptr<fair::mq::Plugin>(PluginServices&);
 
     PluginManager();
+    PluginManager(const std::vector<std::string> args);
 
     ~PluginManager()
     {
@@ -69,7 +70,7 @@ class PluginManager
     struct PluginInstantiationError : std::runtime_error { using std::runtime_error::runtime_error; };
 
     static auto ProgramOptions() -> boost::program_options::options_description;
-    static auto MakeFromCommandLineOptions(const std::vector<std::string>) -> std::shared_ptr<PluginManager>;
+    static auto MakeFromCommandLineOptions(const std::vector<std::string>) -> PluginManager;
     struct ProgramOptionsParseError : std::runtime_error { using std::runtime_error::runtime_error; };
 
     static auto LibPrefix() -> const std::string& { return fgkLibPrefix; }
@@ -116,10 +117,10 @@ class PluginManager
     static const std::string fgkLibPrefix;
     std::vector<boost::filesystem::path> fSearchPaths;
     std::map<std::string, std::function<PluginFactory>> fPluginFactories;
-    std::map<std::string, std::shared_ptr<Plugin>> fPlugins;
+    std::unique_ptr<PluginServices> fPluginServices;
+    std::map<std::string, std::unique_ptr<Plugin>> fPlugins;
     std::vector<std::string> fPluginOrder;
     std::map<std::string, boost::program_options::options_description> fPluginProgOptions;
-    std::unique_ptr<PluginServices> fPluginServices;
 }; /* class PluginManager */
 
 } /* namespace mq */

--- a/fairmq/PluginServices.cxx
+++ b/fairmq/PluginServices.cxx
@@ -98,7 +98,7 @@ auto PluginServices::ChangeDeviceState(const std::string& controller, const Devi
 
     if (fDeviceController == controller)
     {
-        fDevice->ChangeState(fkDeviceStateTransitionMap.at(next));
+        fDevice.ChangeState(fkDeviceStateTransitionMap.at(next));
     }
     else
     {

--- a/fairmq/PluginServices.h
+++ b/fairmq/PluginServices.h
@@ -38,7 +38,7 @@ class PluginServices
 {
   public:
     PluginServices() = delete;
-    PluginServices(FairMQProgOptions* config, FairMQDevice& device)
+    PluginServices(FairMQProgOptions& config, FairMQDevice& device)
         : fConfig(config)
         , fDevice(device)
         , fDeviceController()
@@ -172,7 +172,7 @@ class PluginServices
     // Config API
     struct PropertyNotFoundError : std::runtime_error { using std::runtime_error::runtime_error; };
 
-    auto PropertyExists(const std::string& key) const -> bool { return fConfig->Count(key) > 0; }
+    auto PropertyExists(const std::string& key) const -> bool { return fConfig.Count(key) > 0; }
 
     /// @brief Set config property
     /// @param key
@@ -187,7 +187,7 @@ class PluginServices
         auto currentState = GetCurrentDeviceState();
         if (currentState == DeviceState::InitializingDevice)
         {
-            fConfig->SetValue(key, val);
+            fConfig.SetValue(key, val);
         }
         else
         {
@@ -205,7 +205,7 @@ class PluginServices
     template<typename T>
     auto GetProperty(const std::string& key) const -> T {
         if (PropertyExists(key)) {
-            return fConfig->GetValue<T>(key);
+            return fConfig.GetValue<T>(key);
         }
         throw PropertyNotFoundError(fair::mq::tools::ToString("Config has no key: ", key));
     }
@@ -217,16 +217,16 @@ class PluginServices
     /// If a type is not supported, the user can provide support by overloading the ostream operator for this type
     auto GetPropertyAsString(const std::string& key) const -> std::string {
         if (PropertyExists(key)) {
-            return fConfig->GetStringValue(key);
+            return fConfig.GetStringValue(key);
         }
         throw PropertyNotFoundError(fair::mq::tools::ToString("Config has no key: ", key));
     }
 
-    auto GetChannelInfo() const -> std::unordered_map<std::string, int> { return fConfig->GetChannelInfo(); }
+    auto GetChannelInfo() const -> std::unordered_map<std::string, int> { return fConfig.GetChannelInfo(); }
 
     /// @brief Discover the list of property keys
     /// @return list of property keys
-    auto GetPropertyKeys() const -> std::vector<std::string> { return fConfig->GetPropertyKeys(); }
+    auto GetPropertyKeys() const -> std::vector<std::string> { return fConfig.GetPropertyKeys(); }
 
     /// @brief Subscribe to property updates of type T
     /// @param subscriber
@@ -236,13 +236,13 @@ class PluginServices
     template<typename T>
     auto SubscribeToPropertyChange(const std::string& subscriber, std::function<void(const std::string& key, T)> callback) const -> void
     {
-        fConfig->Subscribe<T>(subscriber, callback);
+        fConfig.Subscribe<T>(subscriber, callback);
     }
 
     /// @brief Unsubscribe from property updates of type T
     /// @param subscriber
     template<typename T>
-    auto UnsubscribeFromPropertyChange(const std::string& subscriber) -> void { fConfig->Unsubscribe<T>(subscriber); }
+    auto UnsubscribeFromPropertyChange(const std::string& subscriber) -> void { fConfig.Unsubscribe<T>(subscriber); }
 
     /// @brief Subscribe to property updates
     /// @param subscriber
@@ -251,12 +251,12 @@ class PluginServices
     /// Subscribe to property changes with a callback to monitor property changes in an event based fashion. Will convert the property to string.
     auto SubscribeToPropertyChangeAsString(const std::string& subscriber, std::function<void(const std::string& key, std::string)> callback) const -> void
     {
-        fConfig->SubscribeAsString(subscriber, callback);
+        fConfig.SubscribeAsString(subscriber, callback);
     }
 
     /// @brief Unsubscribe from property updates that convert to string
     /// @param subscriber
-    auto UnsubscribeFromPropertyChangeAsString(const std::string& subscriber) -> void { fConfig->UnsubscribeAsString(subscriber); }
+    auto UnsubscribeFromPropertyChangeAsString(const std::string& subscriber) -> void { fConfig.UnsubscribeAsString(subscriber); }
 
     auto CycleLogConsoleSeverityUp() -> void { Logger::CycleConsoleSeverityUp(); }
     auto CycleLogConsoleSeverityDown() -> void { Logger::CycleConsoleSeverityDown(); }
@@ -271,7 +271,7 @@ class PluginServices
     static const std::unordered_map<DeviceStateTransition, FairMQDevice::Event, tools::HashEnum<DeviceStateTransition>> fkDeviceStateTransitionMap;
 
   private:
-    FairMQProgOptions* fConfig; // TODO make it a shared pointer, once old AliceO2 code is cleaned up
+    FairMQProgOptions& fConfig;
     FairMQDevice& fDevice;
     boost::optional<std::string> fDeviceController;
     mutable std::mutex fDeviceControllerMutex;

--- a/fairmq/PluginServices.h
+++ b/fairmq/PluginServices.h
@@ -47,6 +47,11 @@ class PluginServices
     {
     }
 
+    ~PluginServices()
+    {
+        LOG(debug) << "Shutting down Plugin Services";
+    }
+
     PluginServices(const PluginServices&) = delete;
     PluginServices operator=(const PluginServices&) = delete;
 

--- a/fairmq/devices/FairMQBenchmarkSampler.h
+++ b/fairmq/devices/FairMQBenchmarkSampler.h
@@ -17,6 +17,7 @@
 
 #include <string>
 #include <thread>
+#include <atomic>
 
 #include "FairMQDevice.h"
 
@@ -38,7 +39,7 @@ class FairMQBenchmarkSampler : public FairMQDevice
   protected:
     bool fSameMessage;
     int fMsgSize;
-    int fMsgCounter;
+    std::atomic<int> fMsgCounter;
     int fMsgRate;
     uint64_t fNumIterations;
     uint64_t fMaxIterations;

--- a/fairmq/plugins/Control.h
+++ b/fairmq/plugins/Control.h
@@ -37,17 +37,21 @@ class Control : public Plugin
     auto PrintInteractiveHelp() -> void;
     auto StaticMode() -> void;
     auto WaitForNextState() -> DeviceState;
-    auto SignalHandler(int signal) -> void;
+    auto SignalHandler() -> void;
+    auto HandleShutdownSignal() -> void;
     auto RunShutdownSequence() -> void;
     auto RunStartupSequence() -> void;
     auto EmptyEventQueue() -> void;
 
     std::thread fControllerThread;
     std::thread fSignalHandlerThread;
+    std::thread fShutdownThread;
     std::queue<DeviceState> fEvents;
     std::mutex fEventsMutex;
+    std::mutex fShutdownMutex;
     std::condition_variable fNewEvent;
     std::atomic<bool> fDeviceTerminationRequested;
+    std::atomic<bool> fHasShutdown;
 }; /* class Control */
 
 auto ControlPluginProgramOptions() -> Plugin::ProgOptions;

--- a/fairmq/runFairMQDevice.h
+++ b/fairmq/runFairMQDevice.h
@@ -46,7 +46,7 @@ int main(int argc, char* argv[])
         // });
 
         runner.AddHook<InstantiateDevice>([](DeviceRunner& r){
-            r.fDevice = std::shared_ptr<FairMQDevice>{getDevice(r.fConfig)};
+            r.fDevice = std::unique_ptr<FairMQDevice>{getDevice(r.fConfig)};
         });
 
         return runner.Run();

--- a/test/plugin_services/Fixture.h
+++ b/test/plugin_services/Fixture.h
@@ -44,7 +44,6 @@ struct PluginServices : ::testing::Test {
     {
         fRunStateMachineThread = std::thread(&FairMQDevice::RunStateMachine, mDevice.get());
         mDevice->SetTransport("zeromq");
-
     }
 
     ~PluginServices()

--- a/test/plugin_services/_control.cxx
+++ b/test/plugin_services/_control.cxx
@@ -39,9 +39,9 @@ TEST_F(PluginServices, OnlySingleController)
     EXPECT_EQ(mServices.GetDeviceController(), string{"foo"});
 
     // park device
-    mDevice->WaitForEndOfState(FairMQDevice::DEVICE_READY);
+    mDevice.WaitForEndOfState(FairMQDevice::DEVICE_READY);
     mServices.ChangeDeviceState("foo", DeviceStateTransition::ResetDevice);
-    mDevice->WaitForEndOfState(FairMQDevice::RESET_DEVICE);
+    mDevice.WaitForEndOfState(FairMQDevice::RESET_DEVICE);
     mServices.ChangeDeviceState("foo", DeviceStateTransition::End);
 }
 
@@ -72,7 +72,7 @@ TEST_F(PluginServices, Control)
     ASSERT_EQ(mServices.GetCurrentDeviceState(), DeviceState::DeviceReady);
 
     mServices.ChangeDeviceState("foo", DeviceStateTransition::ResetDevice);
-    mDevice->WaitForEndOfState(FairMQDevice::RESET_DEVICE);
+    mDevice.WaitForEndOfState(FairMQDevice::RESET_DEVICE);
     mServices.ChangeDeviceState("foo", DeviceStateTransition::End);
 }
 

--- a/test/plugins/_plugin.cxx
+++ b/test/plugins/_plugin.cxx
@@ -16,6 +16,7 @@
 #include <sstream>
 #include <string>
 #include <vector>
+#include <thread>
 
 namespace
 {
@@ -38,7 +39,7 @@ auto control(shared_ptr<FairMQDevice> device) -> void
 
 TEST(Plugin, Operators)
 {
-    FairMQProgOptions config{};
+    FairMQProgOptions config;
     auto device = make_shared<FairMQDevice>();
     PluginServices services{&config, device};
     Plugin p1{"dds", {1, 0, 0}, "Foo Bar <foo.bar@test.net>", "https://git.test.net/dds.git", &services};
@@ -46,19 +47,27 @@ TEST(Plugin, Operators)
     Plugin p3{"file", {1, 0, 0}, "Foo Bar <foo.bar@test.net>", "https://git.test.net/file.git", &services};
     EXPECT_EQ(p1, p2);
     EXPECT_NE(p1, p3);
-    control(device);
+    thread t(control, device);
+    device->RunStateMachine();
+    if (t.joinable()) {
+        t.join();
+    }
 }
 
 TEST(Plugin, OstreamOperators)
 {
-    FairMQProgOptions config{};
+    FairMQProgOptions config;
     auto device = make_shared<FairMQDevice>();
     PluginServices services{&config, device};
     Plugin p1{"dds", {1, 0, 0}, "Foo Bar <foo.bar@test.net>", "https://git.test.net/dds.git", &services};
     stringstream ss;
     ss << p1;
     EXPECT_EQ(ss.str(), string{"'dds', version '1.0.0', maintainer 'Foo Bar <foo.bar@test.net>', homepage 'https://git.test.net/dds.git'"});
-    control(device);
+    thread t(control, device);
+    device->RunStateMachine();
+    if (t.joinable()) {
+        t.join();
+    }
 }
 
 TEST(PluginVersion, Operators)

--- a/test/plugins/_plugin_manager.cxx
+++ b/test/plugins/_plugin_manager.cxx
@@ -104,14 +104,14 @@ TEST(PluginManager, LoadPluginStatic)
 TEST(PluginManager, Factory)
 {
     const auto args = vector<string>{"-l", "debug", "--help", "-S", ">/lib", "</home/user/lib", "/usr/local/lib", "/usr/lib"};
-    auto mgr = PluginManager::MakeFromCommandLineOptions(args);
+    PluginManager mgr(args);
     const auto path1 = path{"/home/user/lib"};
     const auto path2 = path{"/usr/local/lib"};
     const auto path3 = path{"/usr/lib"};
     const auto path4 = path{"/lib"};
     const auto expected = vector<path>{path1, path2, path3, path4};
-    ASSERT_TRUE(static_cast<bool>(mgr));
-    ASSERT_TRUE(mgr->SearchPaths() == expected);
+    // ASSERT_TRUE(static_cast<bool>(mgr));
+    ASSERT_TRUE(mgr.SearchPaths() == expected);
 }
 
 TEST(PluginManager, SearchPathValidation)

--- a/test/plugins/_plugin_manager_prelink.cxx
+++ b/test/plugins/_plugin_manager_prelink.cxx
@@ -17,7 +17,7 @@ using namespace std;
 
 TEST(PluginManager, LoadPluginPrelinkedDynamic)
 {
-    auto mgr = PluginManager{};
+    PluginManager mgr;
 
     ASSERT_NO_THROW(mgr.LoadPlugin("p:test_dummy"));
     ASSERT_NO_THROW(mgr.LoadPlugin("p:test_dummy2"));


### PR DESCRIPTION
- Run state handlers (e.g. InitTask(), Run(), ...) on the main thread. This solves some cases that require user code to be run on the main thread (@sawenzel). All the state handlers will be called in the same thread where the newly introduced `device.RunStateMachine()` method is called. It returns when state machine is done (after `END` event). To keep the device responsive when user code is run, state machine controller has to be run in an extra thread. This is a **breaking change** for anyone who does not use our control plugins and has a custom main function. The solution is to add a separate thread either for all the `ChangeState(...)` calls, or for `device.RunStateMachine()`. For an example fix you can see `test/device/_multiple_devices.cxx` inside this PR.
- Reduce number of action handlers in the state machine - reuse same where possible.
- Fix some race conditions inside control plugin.
- Fix control plugin signal handler to comply with signal handler requirements.
- Simplify ownership structure inside DeviceRunner/PluginManager.

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
