### PR TITLE
Test timeout parts

### DIFF
--- a/cmake/GTestHelper.cmake
+++ b/cmake/GTestHelper.cmake
@@ -51,7 +51,7 @@ function(add_testsuite suitename)
     cmake_parse_arguments(testsuite
         ""
         "TIMEOUT;RUN_SERIAL"
-        "SOURCES;LINKS;DEPENDS;INCLUDES"
+        "SOURCES;LINKS;DEPENDS;INCLUDES;DEFINITIONS"
         ${ARGN}
     )
 
@@ -68,6 +68,9 @@ function(add_testsuite suitename)
     endif()
     if(testsuite_INCLUDES)
         target_include_directories(${target} PUBLIC ${testsuite_INCLUDES})
+    endif()
+    if(testsuite_DEFINITIONS)
+        target_compile_definitions("${target}" PUBLIC ${testsuite_DEFINITIONS})
     endif()
 
     add_test(NAME "${suitename}" WORKING_DIRECTORY ${CMAKE_BINARY_DIR} COMMAND ${target})
@@ -86,7 +89,7 @@ function(add_testhelper helpername)
     cmake_parse_arguments(testhelper
         ""
         ""
-        "SOURCES;LINKS;DEPENDS;INCLUDES"
+        "SOURCES;LINKS;DEPENDS;INCLUDES;DEFINITIONS"
         ${ARGN}
     )
 
@@ -102,6 +105,9 @@ function(add_testhelper helpername)
     if(testhelper_INCLUDES)
         target_include_directories(${target} PUBLIC ${testhelper_INCLUDES})
     endif()
+    if(testhelper_DEFINITIONS)
+        target_compile_definitions(${target} PUBLIC ${testhelper_DEFINITIONS})
+    endif()
 
     list(APPEND ALL_TEST_TARGETS ${target})
     set(ALL_TEST_TARGETS ${ALL_TEST_TARGETS} PARENT_SCOPE)
@@ -111,7 +117,7 @@ function(add_testlib libname)
     cmake_parse_arguments(testlib
         "HIDDEN"
         "VERSION"
-        "SOURCES;LINKS;DEPENDS;INCLUDES"
+        "SOURCES;LINKS;DEPENDS;INCLUDES;DEFINITIONS"
         ${ARGN}
     )
 
@@ -132,6 +138,9 @@ function(add_testlib libname)
     endif()
     if(testlib_VERSION)
         set_target_properties(${target} PROPERTIES VERSION ${testlib_VERSION})
+    endif()
+    if(testlib_DEFINITIONS)
+        target_compile_definitions(${target} PUBLIC ${testlib_DEFINITIONS})
     endif()
 
     list(APPEND ALL_TEST_TARGETS ${target})

--- a/fairmq/zeromq/FairMQSocketZMQ.cxx
+++ b/fairmq/zeromq/FairMQSocketZMQ.cxx
@@ -283,7 +283,7 @@ int64_t FairMQSocketZMQ::SendImpl(vector<FairMQMessagePtr>& msgVec, const int fl
     } // If there's only one part, send it as a regular message
     else if (vecSize == 1)
     {
-        return Send(msgVec.back(), flags);
+        return SendImpl(msgVec.back(), flags, timeout);
     }
     else // if the vector is empty, something might be wrong
     {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -30,6 +30,9 @@ add_testhelper(runTestDevice
     LINKS FairMQ
 )
 
+if(BUILD_NANOMSG_TRANSPORT)
+  set(definitions DEFINITIONS BUILD_NANOMSG_TRANSPORT)
+endif()
 
 set(MQ_CONFIG "${CMAKE_BINARY_DIR}/test/testsuite_FairMQ.IOPatterns_config.json")
 set(RUN_TEST_DEVICE "${CMAKE_BINARY_DIR}/test/testhelper_runTestDevice")
@@ -55,6 +58,7 @@ add_testsuite(FairMQ.Protocols
              ${CMAKE_CURRENT_BINARY_DIR}
     TIMEOUT 30
     RUN_SERIAL ON
+    ${definitions}
 )
 
 add_testsuite(FairMQ.Parts
@@ -77,6 +81,7 @@ add_testsuite(FairMQ.MessageResize
     INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}/message_resize
              ${CMAKE_CURRENT_BINARY_DIR}
     TIMEOUT 5
+    ${definitions}
 )
 
 add_testsuite(FairMQ.Device

--- a/test/device/_device_config.cxx
+++ b/test/device/_device_config.cxx
@@ -105,7 +105,7 @@ class DeviceConfig : public ::testing::Test
 
 TEST_F(DeviceConfig, SetConfig)
 {
-    string transport = "nanomsg";
+    string transport = "zeromq";
     string returnedTransport = TestDeviceSetConfig(transport);
 
     EXPECT_EQ(transport, returnedTransport);
@@ -113,7 +113,7 @@ TEST_F(DeviceConfig, SetConfig)
 
 TEST_F(DeviceConfig, SetTransport)
 {
-    string transport = "nanomsg";
+    string transport = "zeromq";
     string returnedTransport = TestDeviceSetTransport(transport);
 
     EXPECT_EQ(transport, returnedTransport);

--- a/test/helper/devices/TestTransferTimeout.cxx
+++ b/test/helper/devices/TestTransferTimeout.cxx
@@ -21,33 +21,88 @@ class TransferTimeout : public FairMQDevice
   protected:
     auto Run() -> void override
     {
-        auto sendCanceling = false;
-        auto receiveCanceling = false;
+        bool sendMsgCanceling = false;
+        bool receiveMsgCanceling = false;
 
-        auto msg1 = FairMQMessagePtr{NewMessage()};
-        auto msg2 = FairMQMessagePtr{NewMessage()};
+        FairMQMessagePtr msg1(NewMessage());
+        FairMQMessagePtr msg2(NewMessage());
 
         if (Send(msg1, "data-out", 0, 100) == -2)
         {
-            LOG(info) << "send canceled";
-            sendCanceling = true;
+            LOG(info) << "send msg canceled";
+            sendMsgCanceling = true;
         }
         else
         {
-            LOG(error) << "send did not cancel";
+            LOG(error) << "send msg did not cancel";
         }
 
         if (Receive(msg2, "data-in", 0, 100) == -2)
         {
-            LOG(info) << "receive canceled";
-            receiveCanceling = true;
+            LOG(info) << "receive msg canceled";
+            receiveMsgCanceling = true;
         }
         else
         {
-            LOG(error) << "receive did not cancel";
+            LOG(error) << "receive msg did not cancel";
         }
 
-        if (sendCanceling && receiveCanceling)
+        bool send1PartCanceling = false;
+        bool receive1PartCanceling = false;
+
+        FairMQParts parts1;
+        parts1.AddPart(NewMessage(10));
+        FairMQParts parts2;
+
+        if (Send(parts1, "data-out", 0, 100) == -2)
+        {
+            LOG(info) << "send 1 part canceled";
+            send1PartCanceling = true;
+        }
+        else
+        {
+            LOG(error) << "send 1 part did not cancel";
+        }
+
+        if (Receive(parts2, "data-in", 0, 100) == -2)
+        {
+            LOG(info) << "receive 1 part canceled";
+            receive1PartCanceling = true;
+        }
+        else
+        {
+            LOG(error) << "receive 1 part did not cancel";
+        }
+
+        bool send2PartsCanceling = false;
+        bool receive2PartsCanceling = false;
+
+        FairMQParts parts3;
+        parts3.AddPart(NewMessage(10));
+        parts3.AddPart(NewMessage(10));
+        FairMQParts parts4;
+
+        if (Send(parts3, "data-out", 0, 100) == -2)
+        {
+            LOG(info) << "send 2 parts canceled";
+            send2PartsCanceling = true;
+        }
+        else
+        {
+            LOG(error) << "send 2 parts did not cancel";
+        }
+
+        if (Receive(parts4, "data-in", 0, 100) == -2)
+        {
+            LOG(info) << "receive 2 parts canceled";
+            receive2PartsCanceling = true;
+        }
+        else
+        {
+            LOG(error) << "receive 2 parts did not cancel";
+        }
+
+        if (sendMsgCanceling && receiveMsgCanceling && send1PartCanceling && receive1PartCanceling && send2PartsCanceling && receive2PartsCanceling)
         {
             LOG(info) << "Transfer timeout test successfull";
         }


### PR DESCRIPTION
 - Enable definitions propagation for tests.
 - Use always-available transport for _device_config test (the test does not depend on any particular transport).
 - Fix incorrect multipart transfer timeout handling for the ZeroMQ transport.
 - Fix missing multipart transfer timeout handling for the shared memory transport.
 - Include multipart transfer timeout testing in the unit tests.

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
