### PR TITLE
Fix race condition in the control plugin

### DIFF
--- a/fairmq/plugins/Control.cxx
+++ b/fairmq/plugins/Control.cxx
@@ -229,7 +229,7 @@ auto Control::WaitForNextState() -> DeviceState
     unique_lock<mutex> lock{fEventsMutex};
     while (fEvents.empty())
     {
-        fNewEvent.wait(lock);
+        fNewEvent.wait_for(lock, chrono::milliseconds(50));
     }
 
     auto result = fEvents.front();


### PR DESCRIPTION
Fix race condition in the control plugin.

Resolves #83.

Tracing down the error in #83 reveals that `Control::WaitForNextState()` misses the condition variable notification that is sent by the state change handler. Adding a timeout forces him to check the condition even without notification.

However further investigation is necessary as to why the problem appears in the first place - the locks in the aforementioned methods are setup to prevent this from happening.

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
