### PR TITLE
Resolve hanging process in case of uncaught exception

### DIFF
--- a/fairmq/DeviceRunner.cxx
+++ b/fairmq/DeviceRunner.cxx
@@ -111,12 +111,10 @@ auto DeviceRunner::RunWithExceptionHandlers() -> int
     try {
         return Run();
     } catch (std::exception& e) {
-        LOG(error) << "Unhandled exception reached the top of main: " << e.what()
-                   << ", application will now exit";
+        LOG(error) << "Uncaught exception reached the top of DeviceRunner: " << e.what();
         return 1;
     } catch (...) {
-        LOG(error) << "Non-exception instance being thrown. Please make sure you use "
-                      "std::runtime_exception() instead. Application will now exit.";
+        LOG(error) << "Uncaught exception reached the top of DeviceRunner.";
         return 1;
     }
 }

--- a/fairmq/FairMQDevice.cxx
+++ b/fairmq/FairMQDevice.cxx
@@ -24,6 +24,7 @@
 #include <functional>
 #include <sstream>
 #include <iomanip>
+#include <future>
 #include <algorithm> // std::max
 
 using namespace std;
@@ -491,7 +492,7 @@ void FairMQDevice::RunWrapper()
     LOG(info) << "DEVICE: Running...";
 
     // start the rate logger thread
-    thread rateLogger(&FairMQDevice::LogSocketRates, this);
+    future<void> rateLogger = async(launch::async, &FairMQDevice::LogSocketRates, this);
 
     // notify transports to resume transfers
     {
@@ -552,7 +553,7 @@ void FairMQDevice::RunWrapper()
 
     CallAndHandleError(std::bind(&FairMQDevice::PostRun, this));
 
-    rateLogger.join();
+    rateLogger.get();
 }
 
 void FairMQDevice::HandleSingleChannelInput()

--- a/fairmq/FairMQDevice.h
+++ b/fairmq/FairMQDevice.h
@@ -512,9 +512,6 @@ class FairMQDevice : public FairMQStateMachine
     /// Handles the Reset() method
     void ResetWrapper();
 
-    /// Used to call user code and handle uncaught exceptions
-    void CallAndHandleError(std::function<void()> callable);
-
     /// Unblocks blocking channel send/receive calls
     void Unblock();
 

--- a/fairmq/FairMQDevice.h
+++ b/fairmq/FairMQDevice.h
@@ -462,39 +462,30 @@ class FairMQDevice : public FairMQStateMachine
     std::string fId; ///< Device ID
 
     /// Additional user initialization (can be overloaded in child classes). Prefer to use InitTask().
-    /// Executed in a worker thread
     virtual void Init();
 
     /// Task initialization (can be overloaded in child classes)
-    /// Executed in a worker thread
     virtual void InitTask();
 
     /// Runs the device (to be overloaded in child classes)
-    /// Executed in a worker thread
     virtual void Run();
 
     /// Called in the RUNNING state once before executing the Run()/ConditionalRun() method
-    /// Executed in a worker thread
     virtual void PreRun();
 
     /// Called during RUNNING state repeatedly until it returns false or device state changes
-    /// Executed in a worker thread
     virtual bool ConditionalRun();
 
     /// Called in the RUNNING state once after executing the Run()/ConditionalRun() method
-    /// Executed in a worker thread
     virtual void PostRun();
 
     /// Handles the PAUSE state
-    /// Executed in a worker thread
     virtual void Pause();
 
     /// Resets the user task (to be overloaded in child classes)
-    /// Executed in a worker thread
     virtual void ResetTask();
 
     /// Resets the device (can be overloaded in child classes)
-    /// Executed in a worker thread
     virtual void Reset();
 
   private:
@@ -520,6 +511,9 @@ class FairMQDevice : public FairMQStateMachine
     void ResetTaskWrapper();
     /// Handles the Reset() method
     void ResetWrapper();
+
+    /// Used to call user code and handle uncaught exceptions
+    void CallAndHandleError(std::function<void()> callable);
 
     /// Unblocks blocking channel send/receive calls
     void Unblock();

--- a/fairmq/PluginServices.h
+++ b/fairmq/PluginServices.h
@@ -21,6 +21,7 @@
 #include <unordered_map>
 #include <mutex>
 #include <condition_variable>
+#include <stdexcept>
 
 namespace fair
 {

--- a/fairmq/devices/FairMQBenchmarkSampler.cxx
+++ b/fairmq/devices/FairMQBenchmarkSampler.cxx
@@ -88,7 +88,6 @@ void FairMQBenchmarkSampler::Run()
             }
         }
 
-
         if (fMsgRate > 0)
         {
             rateLimiter.maybe_sleep();

--- a/fairmq/plugins/Control.cxx
+++ b/fairmq/plugins/Control.cxx
@@ -209,6 +209,11 @@ try
             }
         }
 
+        if (GetCurrentDeviceState() == DeviceState::Error)
+        {
+            throw DeviceErrorState("Controlled device transitioned to error state.");
+        }
+
         if (fDeviceShutdownRequested)
         {
             break;
@@ -272,6 +277,11 @@ try
         while (fEvents.empty() && !fDeviceShutdownRequested)
         {
             fNewEvent.wait_for(lock, chrono::milliseconds(50));
+        }
+
+        if (fEvents.front() == DeviceState::Error)
+        {
+            throw DeviceErrorState("Controlled device transitioned to error state.");
         }
     }
 

--- a/fairmq/plugins/Control.cxx
+++ b/fairmq/plugins/Control.cxx
@@ -339,7 +339,7 @@ auto Control::RunShutdownSequence() -> void
 {
     auto nextState = GetCurrentDeviceState();
     EmptyEventQueue();
-    while (nextState != DeviceState::Exiting)
+    while (nextState != DeviceState::Exiting && nextState != DeviceState::Error)
     {
         switch (nextState)
         {
@@ -359,7 +359,7 @@ auto Control::RunShutdownSequence() -> void
                 ChangeDeviceState(DeviceStateTransition::Resume);
                 break;
             default:
-                // ignore other states
+                LOG(debug) << "Controller ignoring event: " << nextState;
                 break;
         }
 

--- a/fairmq/plugins/Control.cxx
+++ b/fairmq/plugins/Control.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2017 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2017-2018 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -11,6 +11,7 @@
 #include <termios.h> // for the interactive mode
 #include <poll.h> // for the interactive mode
 #include <csignal> // catching system signals
+#include <cstdlib>
 #include <functional>
 #include <atomic>
 
@@ -18,11 +19,18 @@ using namespace std;
 
 namespace
 {
-    std::atomic<sig_atomic_t> gSignalStatus(0);
+    std::atomic<sig_atomic_t> gLastSignal(0);
+    std::atomic<int> gSignalCount(0);
 
     extern "C" auto signal_handler(int signal) -> void
     {
-        gSignalStatus = signal;
+        ++gSignalCount;
+        gLastSignal = signal;
+
+        if (gSignalCount > 1)
+        {
+            std::abort();
+        }
     }
 }
 
@@ -37,14 +45,23 @@ Control::Control(const string& name, const Plugin::Version version, const string
     : Plugin(name, version, maintainer, homepage, pluginServices)
     , fControllerThread()
     , fSignalHandlerThread()
-    , fShutdownThread()
     , fEvents()
     , fEventsMutex()
-    , fShutdownMutex()
+    , fControllerMutex()
     , fNewEvent()
-    , fDeviceTerminationRequested(false)
-    , fHasShutdown(false)
+    , fDeviceShutdownRequested(false)
+    , fDeviceHasShutdown(false)
+    , fPluginShutdownRequested(false)
 {
+    SubscribeToDeviceStateChange([&](DeviceState newState)
+    {
+        {
+            lock_guard<mutex> lock{fEventsMutex};
+            fEvents.push(newState);
+        }
+        fNewEvent.notify_one();
+    });
+
     try
     {
         TakeDeviceControl();
@@ -97,123 +114,121 @@ auto ControlPluginProgramOptions() -> Plugin::ProgOptions
 }
 
 auto Control::InteractiveMode() -> void
+try
 {
-    try
+    RunStartupSequence();
+
+    char input; // hold the user console input
+    pollfd cinfd[1];
+    cinfd[0].fd = fileno(stdin);
+    cinfd[0].events = POLLIN;
+
+    struct termios t;
+    tcgetattr(STDIN_FILENO, &t); // get the current terminal I/O structure
+    t.c_lflag &= ~ICANON; // disable canonical input
+    t.c_lflag &= ~ECHO; // do not echo input chars
+    tcsetattr(STDIN_FILENO, TCSANOW, &t); // apply the new settings
+
+    PrintInteractiveHelp();
+
+    bool keepRunning = true;
+
+    while (keepRunning)
     {
-        RunStartupSequence();
-
-        char input; // hold the user console input
-        pollfd cinfd[1];
-        cinfd[0].fd = fileno(stdin);
-        cinfd[0].events = POLLIN;
-
-        struct termios t;
-        tcgetattr(STDIN_FILENO, &t); // get the current terminal I/O structure
-        t.c_lflag &= ~ICANON; // disable canonical input
-        t.c_lflag &= ~ECHO; // do not echo input chars
-        tcsetattr(STDIN_FILENO, TCSANOW, &t); // apply the new settings
-
-        PrintInteractiveHelp();
-
-        bool keepRunning = true;
-
-        while (keepRunning)
+        if (poll(cinfd, 1, 500))
         {
-            if (poll(cinfd, 1, 500))
+            if (fDeviceShutdownRequested)
             {
-                if (fDeviceTerminationRequested)
-                {
-                    break;
-                }
-
-                cin >> input;
-
-                switch (input)
-                {
-                    case 'i':
-                        LOG(info) << "\n\n --> [i] init device\n";
-                        ChangeDeviceState(DeviceStateTransition::InitDevice);
-                    break;
-                    case 'j':
-                        LOG(info) << "\n\n --> [j] init task\n";
-                        ChangeDeviceState(DeviceStateTransition::InitTask);
-                    break;
-                    case 'p':
-                        LOG(info) << "\n\n --> [p] pause\n";
-                        ChangeDeviceState(DeviceStateTransition::Pause);
-                    break;
-                    case 'r':
-                        LOG(info) << "\n\n --> [r] run\n";
-                        ChangeDeviceState(DeviceStateTransition::Run);
-                    break;
-                    case 's':
-                        LOG(info) << "\n\n --> [s] stop\n";
-                        ChangeDeviceState(DeviceStateTransition::Stop);
-                    break;
-                    case 't':
-                        LOG(info) << "\n\n --> [t] reset task\n";
-                        ChangeDeviceState(DeviceStateTransition::ResetTask);
-                    break;
-                    case 'd':
-                        LOG(info) << "\n\n --> [d] reset device\n";
-                        ChangeDeviceState(DeviceStateTransition::ResetDevice);
-                    break;
-                    case 'k':
-                        LOG(info) << "\n\n --> [k] increase log severity\n";
-                        CycleLogConsoleSeverityUp();
-                    break;
-                    case 'l':
-                        LOG(info) << "\n\n --> [l] decrease log severity\n";
-                        CycleLogConsoleSeverityDown();
-                    break;
-                    case 'n':
-                        LOG(info) << "\n\n --> [n] increase log verbosity\n";
-                        CycleLogVerbosityUp();
-                    break;
-                    case 'm':
-                        LOG(info) << "\n\n --> [m] decrease log verbosity\n";
-                        CycleLogVerbosityDown();
-                    break;
-                    case 'h':
-                        LOG(info) << "\n\n --> [h] help\n";
-                        PrintInteractiveHelp();
-                    break;
-                    // case 'x':
-                    //     LOG(info) << "\n\n --> [x] ERROR\n";
-                    //     ChangeDeviceState(DeviceStateTransition::ERROR_FOUND);
-                    //     break;
-                    case 'q':
-                        LOG(info) << "\n\n --> [q] end\n";
-                        keepRunning = false;
-                    break;
-                    default:
-                        LOG(info) << "Invalid input: [" << input << "]";
-                        PrintInteractiveHelp();
-                    break;
-                }
+                break;
             }
 
-            if (fDeviceTerminationRequested)
+            cin >> input;
+
+            switch (input)
             {
-                keepRunning = false;
+                case 'i':
+                    LOG(info) << "\n\n --> [i] init device\n";
+                    ChangeDeviceState(DeviceStateTransition::InitDevice);
+                break;
+                case 'j':
+                    LOG(info) << "\n\n --> [j] init task\n";
+                    ChangeDeviceState(DeviceStateTransition::InitTask);
+                break;
+                case 'p':
+                    LOG(info) << "\n\n --> [p] pause\n";
+                    ChangeDeviceState(DeviceStateTransition::Pause);
+                break;
+                case 'r':
+                    LOG(info) << "\n\n --> [r] run\n";
+                    ChangeDeviceState(DeviceStateTransition::Run);
+                break;
+                case 's':
+                    LOG(info) << "\n\n --> [s] stop\n";
+                    ChangeDeviceState(DeviceStateTransition::Stop);
+                break;
+                case 't':
+                    LOG(info) << "\n\n --> [t] reset task\n";
+                    ChangeDeviceState(DeviceStateTransition::ResetTask);
+                break;
+                case 'd':
+                    LOG(info) << "\n\n --> [d] reset device\n";
+                    ChangeDeviceState(DeviceStateTransition::ResetDevice);
+                break;
+                case 'k':
+                    LOG(info) << "\n\n --> [k] increase log severity\n";
+                    CycleLogConsoleSeverityUp();
+                break;
+                case 'l':
+                    LOG(info) << "\n\n --> [l] decrease log severity\n";
+                    CycleLogConsoleSeverityDown();
+                break;
+                case 'n':
+                    LOG(info) << "\n\n --> [n] increase log verbosity\n";
+                    CycleLogVerbosityUp();
+                break;
+                case 'm':
+                    LOG(info) << "\n\n --> [m] decrease log verbosity\n";
+                    CycleLogVerbosityDown();
+                break;
+                case 'h':
+                    LOG(info) << "\n\n --> [h] help\n";
+                    PrintInteractiveHelp();
+                break;
+                // case 'x':
+                //     LOG(info) << "\n\n --> [x] ERROR\n";
+                //     ChangeDeviceState(DeviceStateTransition::ERROR_FOUND);
+                //     break;
+                case 'q':
+                    LOG(info) << "\n\n --> [q] end\n";
+                    keepRunning = false;
+                break;
+                default:
+                    LOG(info) << "Invalid input: [" << input << "]";
+                    PrintInteractiveHelp();
+                break;
             }
         }
 
-        tcgetattr(STDIN_FILENO, &t); // get the current terminal I/O structure
-        t.c_lflag |= ICANON; // re-enable canonical input
-        t.c_lflag |= ECHO; // echo input chars
-        tcsetattr(STDIN_FILENO, TCSANOW, &t); // apply the new settings
-
-        if (!fDeviceTerminationRequested)
+        if (fDeviceShutdownRequested)
         {
-            RunShutdownSequence();
+            break;
         }
     }
-    catch (PluginServices::DeviceControlError& e)
-    {
-        // If we are here, it means another plugin has taken control. That's fine, just print the exception message and do nothing else.
-        LOG(debug) << e.what();
-    }
+
+    tcgetattr(STDIN_FILENO, &t); // get the current terminal I/O structure
+    t.c_lflag |= ICANON; // re-enable canonical input
+    t.c_lflag |= ECHO; // echo input chars
+    tcsetattr(STDIN_FILENO, TCSANOW, &t); // apply the new settings
+
+    RunShutdownSequence();
+}
+catch (PluginServices::DeviceControlError& e)
+{
+    // If we are here, it means another plugin has taken control. That's fine, just print the exception message and do nothing else.
+    LOG(debug) << e.what();
+}
+catch (DeviceErrorState&)
+{
 }
 
 auto Control::PrintInteractiveHelp() -> void
@@ -234,137 +249,119 @@ auto Control::WaitForNextState() -> DeviceState
     }
 
     auto result = fEvents.front();
+
+    if (result == DeviceState::Error)
+    {
+        throw DeviceErrorState("Controlled device transitioned to error state.");
+    }
+
     fEvents.pop();
+
     return result;
 }
 
 auto Control::StaticMode() -> void
+try
 {
-    try
+    RunStartupSequence();
+
     {
-        RunStartupSequence();
-
+        // Wait for next state, which is DeviceState::Ready,
+        // or for device shutdown request (Ctrl-C)
+        unique_lock<mutex> lock{fEventsMutex};
+        while (fEvents.empty() && !fDeviceShutdownRequested)
         {
-            // Wait for next state, which is DeviceState::Ready,
-            // or for device termination request
-            unique_lock<mutex> lock{fEventsMutex};
-            while (fEvents.empty() && !fDeviceTerminationRequested)
-            {
-                fNewEvent.wait(lock);
-            }
-        }
-
-        if (!fDeviceTerminationRequested)
-        {
-            RunShutdownSequence();
+            fNewEvent.wait_for(lock, chrono::milliseconds(50));
         }
     }
-    catch (PluginServices::DeviceControlError& e)
-    {
-        // If we are here, it means another plugin has taken control. That's fine, just print the exception message and do nothing else.
-        LOG(debug) << e.what();
-    }
+
+    RunShutdownSequence();
+}
+catch (PluginServices::DeviceControlError& e)
+{
+    // If we are here, it means another plugin has taken control. That's fine, just print the exception message and do nothing else.
+    LOG(debug) << e.what();
+}
+catch (DeviceErrorState&)
+{
 }
 
 auto Control::SignalHandler() -> void
 {
-    while (true)
+    while (gSignalCount == 0 && !fPluginShutdownRequested)
     {
-        if (gSignalStatus != 0 && !fHasShutdown)
-        {
-            LOG(info) << "Received device shutdown request (signal " << gSignalStatus << ").";
-            LOG(info) << "Waiting for graceful device shutdown. Hit Ctrl-C again to abort immediately.";
-
-            if (!fDeviceTerminationRequested)
-            {
-                fDeviceTerminationRequested = true;
-                gSignalStatus = 0;
-                fShutdownThread = thread(&Control::HandleShutdownSignal, this);
-            }
-            else
-            {
-                LOG(warn) << "Received 2nd device shutdown request (signal " << gSignalStatus << ").";
-                LOG(warn) << "Aborting immediately!";
-                abort();
-            }
-        }
-        else if (fHasShutdown)
-        {
-            break;
-        }
-
         this_thread::sleep_for(chrono::milliseconds(100));
     }
-}
 
-auto Control::HandleShutdownSignal() -> void
-{
-    StealDeviceControl();
-
-    UnsubscribeFromDeviceStateChange(); // In case, static or interactive mode have subscribed already
-    SubscribeToDeviceStateChange([&](DeviceState newState)
+    if (!fPluginShutdownRequested)
     {
-        {
-            lock_guard<mutex> lock{fEventsMutex};
-            fEvents.push(newState);
-        }
-        fNewEvent.notify_one();
-    });
+        LOG(info) << "Received device shutdown request (signal " << gLastSignal << ").";
+        LOG(info) << "Waiting for graceful device shutdown. Hit Ctrl-C again to abort immediately.";
 
-    RunShutdownSequence();
+        // Signal and wait for controller thread, if we are controller
+        fDeviceShutdownRequested = true;
+        {
+            unique_lock<mutex> lock(fControllerMutex);
+            if (fControllerThread.joinable()) fControllerThread.join();
+        }
+
+        if (!fDeviceHasShutdown)
+        {
+            // Take over control and attempt graceful shutdown
+            StealDeviceControl();
+            try
+            {
+                RunShutdownSequence();
+            }
+            catch (PluginServices::DeviceControlError& e)
+            {
+                LOG(info) << "Graceful device shutdown failed: " << e.what() << " If hanging, hit Ctrl-C again to abort immediately.";
+            }
+            catch (...)
+            {
+                LOG(info) << "Graceful device shutdown failed. If hanging, hit Ctrl-C again to abort immediately.";
+            }
+        }
+    }
 }
 
 auto Control::RunShutdownSequence() -> void
 {
-    lock_guard<mutex> lock(fShutdownMutex);
-    if (!fHasShutdown)
+    auto nextState = GetCurrentDeviceState();
+    EmptyEventQueue();
+    while (nextState != DeviceState::Exiting)
     {
-        auto nextState = GetCurrentDeviceState();
-        EmptyEventQueue();
-        while (nextState != DeviceState::Exiting)
+        switch (nextState)
         {
-            switch (nextState)
-            {
-                case DeviceState::Idle:
-                    ChangeDeviceState(DeviceStateTransition::End);
-                    break;
-                case DeviceState::DeviceReady:
-                    ChangeDeviceState(DeviceStateTransition::ResetDevice);
-                    break;
-                case DeviceState::Ready:
-                    ChangeDeviceState(DeviceStateTransition::ResetTask);
-                    break;
-                case DeviceState::Running:
-                    ChangeDeviceState(DeviceStateTransition::Stop);
-                    break;
-                case DeviceState::Paused:
-                    ChangeDeviceState(DeviceStateTransition::Resume);
-                    break;
-                default:
-                    // ignore other states
-                    break;
-            }
-
-            nextState = WaitForNextState();
+            case DeviceState::Idle:
+                ChangeDeviceState(DeviceStateTransition::End);
+                break;
+            case DeviceState::DeviceReady:
+                ChangeDeviceState(DeviceStateTransition::ResetDevice);
+                break;
+            case DeviceState::Ready:
+                ChangeDeviceState(DeviceStateTransition::ResetTask);
+                break;
+            case DeviceState::Running:
+                ChangeDeviceState(DeviceStateTransition::Stop);
+                break;
+            case DeviceState::Paused:
+                ChangeDeviceState(DeviceStateTransition::Resume);
+                break;
+            default:
+                // ignore other states
+                break;
         }
 
-        fHasShutdown = true;
-        UnsubscribeFromDeviceStateChange();
-        ReleaseDeviceControl();
+        nextState = WaitForNextState();
     }
+
+    fDeviceHasShutdown = true;
+    ReleaseDeviceControl();
 }
 
 auto Control::RunStartupSequence() -> void
 {
-    SubscribeToDeviceStateChange([&](DeviceState newState)
-    {
-        {
-            lock_guard<mutex> lock{fEventsMutex};
-            fEvents.push(newState);
-        }
-        fNewEvent.notify_one();
-    });
-
     ChangeDeviceState(DeviceStateTransition::InitDevice);
     while (WaitForNextState() != DeviceState::DeviceReady) {}
     ChangeDeviceState(DeviceStateTransition::InitTask);
@@ -381,9 +378,16 @@ auto Control::EmptyEventQueue() -> void
 
 Control::~Control()
 {
-    if (fControllerThread.joinable()) fControllerThread.join();
+    // Notify threads to exit
+    fPluginShutdownRequested = true;
+
+    {
+        unique_lock<mutex> lock(fControllerMutex);
+        if (fControllerThread.joinable()) fControllerThread.join();
+    }
     if (fSignalHandlerThread.joinable()) fSignalHandlerThread.join();
-    if (fShutdownThread.joinable()) fShutdownThread.join();
+
+    UnsubscribeFromDeviceStateChange();
 }
 
 } /* namespace plugins */

--- a/fairmq/plugins/Control.h
+++ b/fairmq/plugins/Control.h
@@ -18,6 +18,7 @@
 #include <queue>
 #include <thread>
 #include <atomic>
+#include <stdexcept>
 
 namespace fair
 {
@@ -35,24 +36,25 @@ class Control : public Plugin
 
   private:
     auto InteractiveMode() -> void;
-    auto PrintInteractiveHelp() -> void;
+    static auto PrintInteractiveHelp() -> void;
     auto StaticMode() -> void;
     auto WaitForNextState() -> DeviceState;
     auto SignalHandler() -> void;
-    auto HandleShutdownSignal() -> void;
     auto RunShutdownSequence() -> void;
     auto RunStartupSequence() -> void;
     auto EmptyEventQueue() -> void;
 
     std::thread fControllerThread;
     std::thread fSignalHandlerThread;
-    std::thread fShutdownThread;
     std::queue<DeviceState> fEvents;
     std::mutex fEventsMutex;
-    std::mutex fShutdownMutex;
+    std::mutex fControllerMutex;
     std::condition_variable fNewEvent;
-    std::atomic<bool> fDeviceTerminationRequested;
-    std::atomic<bool> fHasShutdown;
+    std::atomic<bool> fDeviceShutdownRequested;
+    std::atomic<bool> fDeviceHasShutdown;
+    std::atomic<bool> fPluginShutdownRequested;
+
+    struct DeviceErrorState : std::runtime_error { using std::runtime_error::runtime_error; };
 }; /* class Control */
 
 auto ControlPluginProgramOptions() -> Plugin::ProgOptions;

--- a/fairmq/runFairMQDevice.h
+++ b/fairmq/runFairMQDevice.h
@@ -56,12 +56,12 @@ int main(int argc, char* argv[])
     }
     catch (std::exception& e)
     {
-        LOG(error) << "Unhandled exception reached the top of main: " << e.what() << ", application will now exit";
+        LOG(error) << "Uncaught exception reached the top of main: " << e.what();
         return 1;
     }
     catch (...)
     {
-        LOG(error) << "Non-exception instance being thrown. Please make sure you use std::runtime_exception() instead. Application will now exit.";
+        LOG(error) << "Uncaught exception reached the top of main.";
         return 1;
     }
 }

--- a/fairmq/tools/Process.h
+++ b/fairmq/tools/Process.h
@@ -32,10 +32,13 @@ struct execute_result
  * and exit code.
  *
  * @param[in] cmd Command to execute
- * @param[in] log_prefix How to prefix each captured output line with
+ * @param[in] prefix How to prefix each captured output line with
+ * @param[in] input Data which is sent to stdin of the child process
  * @return Captured stdout output and exit code
  */
-execute_result execute(const std::string& cmd, const std::string& prefix = "");
+execute_result execute(const std::string& cmd,
+                       const std::string& prefix = "",
+                       const std::string& input = "");
 
 } /* namespace tools */
 } /* namespace mq */

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -103,7 +103,7 @@ add_testsuite(FairMQ.Device
     INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}
              ${CMAKE_CURRENT_SOURCE_DIR}/device
              ${CMAKE_CURRENT_BINARY_DIR}
-    TIMEOUT 5
+    TIMEOUT 15
     RUN_SERIAL ON
 )
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -27,6 +27,7 @@ add_testhelper(runTestDevice
     helper/devices/TestSub.cxx
     helper/devices/TestTransferTimeout.cxx
     helper/devices/TestWaitFor.cxx
+    helper/devices/TestExceptions.cxx
 
     LINKS FairMQ
 )
@@ -95,6 +96,7 @@ add_testsuite(FairMQ.Device
     device/_device_version.cxx
     device/_device_config.cxx
     device/_waitfor.cxx
+    device/_exceptions.cxx
 
     LINKS FairMQ
     DEPENDS testhelper_runTestDevice

--- a/test/device/_exceptions.cxx
+++ b/test/device/_exceptions.cxx
@@ -45,7 +45,10 @@ void RunExceptionIn(const std::string& state)
     exit(result.exit_code);
 }
 
-TEST(Exceptions, InInit) { EXPECT_EXIT(RunExceptionIn("Init"), ::testing::ExitedWithCode(1), ""); }
+TEST(Exceptions, InInit)
+{
+    EXPECT_EXIT(RunExceptionIn("Init"), ::testing::ExitedWithCode(1), "");
+}
 TEST(Exceptions, InInitTask)
 {
     EXPECT_EXIT(RunExceptionIn("InitTask"), ::testing::ExitedWithCode(1), "");
@@ -54,7 +57,10 @@ TEST(Exceptions, InPreRun)
 {
     EXPECT_EXIT(RunExceptionIn("PreRun"), ::testing::ExitedWithCode(1), "");
 }
-TEST(Exceptions, InRun) { EXPECT_EXIT(RunExceptionIn("Run"), ::testing::ExitedWithCode(1), ""); }
+TEST(Exceptions, InRun)
+{
+    EXPECT_EXIT(RunExceptionIn("Run"), ::testing::ExitedWithCode(1), "");
+}
 TEST(Exceptions, InPostRun)
 {
     EXPECT_EXIT(RunExceptionIn("PostRun"), ::testing::ExitedWithCode(1), "");

--- a/test/device/_exceptions.cxx
+++ b/test/device/_exceptions.cxx
@@ -1,0 +1,71 @@
+/********************************************************************************
+ *    Copyright (C) 2018 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ *                                                                              *
+ *              This software is distributed under the terms of the             *
+ *              GNU Lesser General Public Licence (LGPL) version 3,             *
+ *                  copied verbatim in the file "LICENSE"                       *
+ ********************************************************************************/
+
+#include "runner.h"
+
+#include <gtest/gtest.h>
+#include <boost/process.hpp>
+#include <fairmq/Tools.h>
+
+#include <string>
+#include <thread>
+#include <iostream>
+
+namespace
+{
+
+using namespace std;
+using namespace fair::mq::test;
+using namespace fair::mq::tools;
+
+void RunExceptionIn(const std::string& state)
+{
+    size_t session{fair::mq::tools::UuidHash()};
+
+    execute_result result{"", 100};
+    thread device_thread([&]() {
+        stringstream cmd;
+        cmd << runTestDevice
+            << " --id exceptions_" << state << "_"
+            << " --control static"
+            << " --session " << session
+            << " --color false";
+        result = execute(cmd.str(), "[EXCEPTION IN " + state + "]");
+    });
+
+    device_thread.join();
+
+    ASSERT_NE(std::string::npos, result.console_out.find("exception in " + state + "()"));
+
+    exit(result.exit_code);
+}
+
+TEST(Exceptions, InInit) { EXPECT_EXIT(RunExceptionIn("Init"), ::testing::ExitedWithCode(1), ""); }
+TEST(Exceptions, InInitTask)
+{
+    EXPECT_EXIT(RunExceptionIn("InitTask"), ::testing::ExitedWithCode(1), "");
+}
+TEST(Exceptions, InPreRun)
+{
+    EXPECT_EXIT(RunExceptionIn("PreRun"), ::testing::ExitedWithCode(1), "");
+}
+TEST(Exceptions, InRun) { EXPECT_EXIT(RunExceptionIn("Run"), ::testing::ExitedWithCode(1), ""); }
+TEST(Exceptions, InPostRun)
+{
+    EXPECT_EXIT(RunExceptionIn("PostRun"), ::testing::ExitedWithCode(1), "");
+}
+TEST(Exceptions, InResetTask)
+{
+    EXPECT_EXIT(RunExceptionIn("ResetTask"), ::testing::ExitedWithCode(1), "");
+}
+TEST(Exceptions, InReset)
+{
+    EXPECT_EXIT(RunExceptionIn("Reset"), ::testing::ExitedWithCode(1), "");
+}
+
+} // namespace

--- a/test/device/_exceptions.cxx
+++ b/test/device/_exceptions.cxx
@@ -23,7 +23,7 @@ using namespace std;
 using namespace fair::mq::test;
 using namespace fair::mq::tools;
 
-void RunExceptionIn(const std::string& state)
+void RunExceptionIn(const std::string& state, const std::string& input = "")
 {
     size_t session{fair::mq::tools::UuidHash()};
 
@@ -32,10 +32,10 @@ void RunExceptionIn(const std::string& state)
         stringstream cmd;
         cmd << runTestDevice
             << " --id exceptions_" << state << "_"
-            << " --control static"
+            << " --control " << ((input == "") ? "static" : "interactive")
             << " --session " << session
             << " --color false";
-        result = execute(cmd.str(), "[EXCEPTION IN " + state + "]");
+        result = execute(cmd.str(), "[EXCEPTION IN " + state + "]", input);
     });
 
     device_thread.join();
@@ -45,33 +45,81 @@ void RunExceptionIn(const std::string& state)
     exit(result.exit_code);
 }
 
-TEST(Exceptions, InInit)
+TEST(Exceptions, InInit_______static)
 {
     EXPECT_EXIT(RunExceptionIn("Init"), ::testing::ExitedWithCode(1), "");
 }
-TEST(Exceptions, InInitTask)
+TEST(Exceptions, InInitTask___static)
 {
     EXPECT_EXIT(RunExceptionIn("InitTask"), ::testing::ExitedWithCode(1), "");
 }
-TEST(Exceptions, InPreRun)
+TEST(Exceptions, InPreRun_____static)
 {
     EXPECT_EXIT(RunExceptionIn("PreRun"), ::testing::ExitedWithCode(1), "");
 }
-TEST(Exceptions, InRun)
+TEST(Exceptions, InRun________static)
 {
     EXPECT_EXIT(RunExceptionIn("Run"), ::testing::ExitedWithCode(1), "");
 }
-TEST(Exceptions, InPostRun)
+TEST(Exceptions, InPostRun____static)
 {
     EXPECT_EXIT(RunExceptionIn("PostRun"), ::testing::ExitedWithCode(1), "");
 }
-TEST(Exceptions, InResetTask)
+TEST(Exceptions, InResetTask__static)
 {
     EXPECT_EXIT(RunExceptionIn("ResetTask"), ::testing::ExitedWithCode(1), "");
 }
-TEST(Exceptions, InReset)
+TEST(Exceptions, InReset______static)
 {
     EXPECT_EXIT(RunExceptionIn("Reset"), ::testing::ExitedWithCode(1), "");
+}
+TEST(Exceptions, InInit_______interactive)
+{
+    EXPECT_EXIT(RunExceptionIn("Init", "q"), ::testing::ExitedWithCode(1), "");
+}
+TEST(Exceptions, InInitTask___interactive)
+{
+    EXPECT_EXIT(RunExceptionIn("InitTask", "q"), ::testing::ExitedWithCode(1), "");
+}
+TEST(Exceptions, InPreRun_____interactive)
+{
+    EXPECT_EXIT(RunExceptionIn("PreRun", "q"), ::testing::ExitedWithCode(1), "");
+}
+TEST(Exceptions, InRun________interactive)
+{
+    EXPECT_EXIT(RunExceptionIn("Run", "q"), ::testing::ExitedWithCode(1), "");
+}
+TEST(Exceptions, InPostRun____interactive)
+{
+    EXPECT_EXIT(RunExceptionIn("PostRun", "q"), ::testing::ExitedWithCode(1), "");
+}
+TEST(Exceptions, InResetTask__interactive)
+{
+    EXPECT_EXIT(RunExceptionIn("ResetTask", "q"), ::testing::ExitedWithCode(1), "");
+}
+TEST(Exceptions, InReset______interactive)
+{
+    EXPECT_EXIT(RunExceptionIn("Reset", "q"), ::testing::ExitedWithCode(1), "");
+}
+TEST(Exceptions, InInit_______interactive_invalid)
+{
+    EXPECT_EXIT(RunExceptionIn("Init", "_"), ::testing::ExitedWithCode(1), "");
+}
+TEST(Exceptions, InInitTask___interactive_invalid)
+{
+    EXPECT_EXIT(RunExceptionIn("InitTask", "_"), ::testing::ExitedWithCode(1), "");
+}
+TEST(Exceptions, InPreRun_____interactive_invalid)
+{
+    EXPECT_EXIT(RunExceptionIn("PreRun", "_"), ::testing::ExitedWithCode(1), "");
+}
+TEST(Exceptions, InRun________interactive_invalid)
+{
+    EXPECT_EXIT(RunExceptionIn("Run", "_"), ::testing::ExitedWithCode(1), "");
+}
+TEST(Exceptions, InPostRun____interactive_invalid)
+{
+    EXPECT_EXIT(RunExceptionIn("PostRun", "_"), ::testing::ExitedWithCode(1), "");
 }
 
 } // namespace

--- a/test/helper/devices/TestExceptions.cxx
+++ b/test/helper/devices/TestExceptions.cxx
@@ -1,0 +1,84 @@
+/********************************************************************************
+ *   Copyright (C) 2018 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH     *
+ *                                                                              *
+ *              This software is distributed under the terms of the             *
+ *              GNU Lesser General Public Licence (LGPL) version 3,             *
+ *                  copied verbatim in the file "LICENSE"                       *
+ ********************************************************************************/
+
+#include <FairMQDevice.h>
+#include <FairMQLogger.h>
+
+#include <iostream>
+#include <stdexcept>
+
+namespace fair
+{
+namespace mq
+{
+namespace test
+{
+
+class TestExceptions : public FairMQDevice
+{
+  public:
+    auto Init() -> void override
+    {
+        std::string state("Init");
+        if (std::string::npos != GetId().find("_" + state + "_")) {
+            throw std::runtime_error("exception in " + state + "()");
+        }
+    }
+
+    auto InitTask() -> void override
+    {
+        std::string state("InitTask");
+        if (std::string::npos != GetId().find("_" + state + "_")) {
+            throw std::runtime_error("exception in " + state + "()");
+        }
+    }
+
+    auto PreRun() -> void override
+    {
+        std::string state("PreRun");
+        if (std::string::npos != GetId().find("_" + state + "_")) {
+            throw std::runtime_error("exception in " + state + "()");
+        }
+    }
+
+    auto Run() -> void override
+    {
+        std::string state("Run");
+        if (std::string::npos != GetId().find("_" + state + "_")) {
+            throw std::runtime_error("exception in " + state + "()");
+        }
+    }
+
+    auto PostRun() -> void override
+    {
+        std::string state("PostRun");
+        if (std::string::npos != GetId().find("_" + state + "_")) {
+            throw std::runtime_error("exception in " + state + "()");
+        }
+    }
+
+    auto ResetTask() -> void override
+    {
+        std::string state("ResetTask");
+        if (std::string::npos != GetId().find("_" + state + "_")) {
+            throw std::runtime_error("exception in " + state + "()");
+        }
+    }
+
+    auto Reset() -> void override
+    {
+        std::string state("Reset");
+        if (std::string::npos != GetId().find("_" + state + "_")) {
+            throw std::runtime_error("exception in " + state + "()");
+        }
+    }
+};
+
+} // namespace test
+} // namespace mq
+} // namespace fair

--- a/test/helper/runTestDevice.cxx
+++ b/test/helper/runTestDevice.cxx
@@ -18,6 +18,7 @@
 #include "devices/TestSub.cxx"
 #include "devices/TestTransferTimeout.cxx"
 #include "devices/TestWaitFor.cxx"
+#include "devices/TestExceptions.cxx"
 
 #include <runFairMQDevice.h>
 
@@ -86,6 +87,10 @@ auto getDevice(const FairMQProgOptions& config) -> FairMQDevicePtr
     else if (0 == id.find("waitfor_"))
     {
         return new TestWaitFor;
+    }
+    else if (0 == id.find("exceptions_"))
+    {
+        return new TestExceptions;
     }
     else
     {


### PR DESCRIPTION
Proposal to solve #95.

@rbx It is not yet working as expected, when I throw in `Run()`:
```
[21:25:27][INFO] DEVICE: Running...
[21:25:27][STATE] Entering ERROR state
terminate called without an active exception
[1]    30405 abort (core dumped)  test/testhelper_runTestDevice --id waitfor_ --control static
```

as opposed to when I throw in `InitTask()` (this behaviour is what I want):
```
[21:24:48][STATE] Entering INITIALIZING_TASK state
[21:24:48][STATE] Entering ERROR state
[21:24:48][DEBUG] Shutting down Plugin Manager
[21:24:48][DEBUG] Unloaded plugin: 'control', version '1.3.3', maintainer 'FairRootGroup <fairroot@gsi.de>', homepage 'https://github.com/FairRootGroup/FairRoot'
[21:24:48][DEBUG] Shutting down Plugin Services
[21:24:48][DEBUG] Destructing device waitfor_
[21:24:48][STATE] Exiting FairMQ state machine
[21:24:48][ERROR] Unhandled exception reached the top of main: init task, application will now exit
```

I also touched a couple of things we can discuss tomorrow.

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
