### PR TITLE
Implement nanomsg linger

### DIFF
--- a/examples/region/fairmq-start-ex-region.sh.in
+++ b/examples/region/fairmq-start-ex-region.sh.in
@@ -14,12 +14,12 @@ SAMPLER+=" --severity debug"
 SAMPLER+=" --msg-size $msgSize"
 # SAMPLER+=" --rate 10"
 SAMPLER+=" --transport shmem"
-SAMPLER+=" --channel-config name=data,type=push,method=bind,address=tcp://127.0.0.1:7777"
+SAMPLER+=" --channel-config name=data,type=push,method=bind,address=tcp://127.0.0.1:7777,sndKernelSize=212992"
 xterm -geometry 80x23+0+0 -hold -e @EX_BIN_DIR@/$SAMPLER &
 
 SINK="fairmq-ex-region-sink"
 SINK+=" --id sink1"
 SINK+=" --severity debug"
 SINK+=" --transport shmem"
-SINK+=" --channel-config name=data,type=pull,method=connect,address=tcp://127.0.0.1:7777"
+SINK+=" --channel-config name=data,type=pull,method=connect,address=tcp://127.0.0.1:7777,rcvKernelSize=212992"
 xterm -geometry 80x23+500+0 -hold -e @EX_BIN_DIR@/$SINK &

--- a/fairmq/FairMQChannel.cxx
+++ b/fairmq/FairMQChannel.cxx
@@ -129,7 +129,7 @@ FairMQChannel& FairMQChannel::operator=(const FairMQChannel& chan)
     return *this;
 }
 
-FairMQSocket const & FairMQChannel::GetSocket() const
+FairMQSocket & FairMQChannel::GetSocket() const
 {
     assert(fSocket);
     return *fSocket;

--- a/fairmq/FairMQChannel.cxx
+++ b/fairmq/FairMQChannel.cxx
@@ -33,6 +33,7 @@ FairMQChannel::FairMQChannel()
     , fRcvBufSize(1000)
     , fSndKernelSize(0)
     , fRcvKernelSize(0)
+    , fLinger(500)
     , fRateLogging(1)
     , fName("")
     , fIsValid(false)
@@ -53,6 +54,7 @@ FairMQChannel::FairMQChannel(const string& type, const string& method, const str
     , fRcvBufSize(1000)
     , fSndKernelSize(0)
     , fRcvKernelSize(0)
+    , fLinger(500)
     , fRateLogging(1)
     , fName("")
     , fIsValid(false)
@@ -73,6 +75,7 @@ FairMQChannel::FairMQChannel(const string& name, const string& type, std::shared
     , fRcvBufSize(1000)
     , fSndKernelSize(0)
     , fRcvKernelSize(0)
+    , fLinger(500)
     , fRateLogging(1)
     , fName(name)
     , fIsValid(false)
@@ -93,6 +96,7 @@ FairMQChannel::FairMQChannel(const FairMQChannel& chan)
     , fRcvBufSize(chan.fRcvBufSize)
     , fSndKernelSize(chan.fSndKernelSize)
     , fRcvKernelSize(chan.fRcvKernelSize)
+    , fLinger(chan.fLinger)
     , fRateLogging(chan.fRateLogging)
     , fName(chan.fName)
     , fIsValid(false)
@@ -113,6 +117,7 @@ FairMQChannel& FairMQChannel::operator=(const FairMQChannel& chan)
     fRcvBufSize = chan.fRcvBufSize;
     fSndKernelSize = chan.fSndKernelSize;
     fRcvKernelSize = chan.fRcvKernelSize;
+    fLinger = chan.fLinger;
     fRateLogging = chan.fRateLogging;
     fName = chan.fName;
     fIsValid = false;
@@ -262,6 +267,20 @@ int FairMQChannel::GetRcvKernelSize() const
     }
 }
 
+int FairMQChannel::GetLinger() const
+{
+    try
+    {
+        unique_lock<mutex> lock(fChannelMutex);
+        return fLinger;
+    }
+    catch (exception& e)
+    {
+        LOG(error) << "Exception caught in FairMQChannel::GetLinger: " << e.what();
+        exit(EXIT_FAILURE);
+    }
+}
+
 int FairMQChannel::GetRateLogging() const
 {
     try
@@ -400,6 +419,22 @@ void FairMQChannel::UpdateRcvKernelSize(const int rcvKernelSize)
     catch (exception& e)
     {
         LOG(error) << "Exception caught in FairMQChannel::UpdateRcvKernelSize: " << e.what();
+        exit(EXIT_FAILURE);
+    }
+}
+
+void FairMQChannel::UpdateLinger(const int duration)
+{
+    try
+    {
+        unique_lock<mutex> lock(fChannelMutex);
+        fIsValid = false;
+        fLinger = duration;
+        fModified = true;
+    }
+    catch (exception& e)
+    {
+        LOG(error) << "Exception caught in FairMQChannel::UpdateLinger: " << e.what();
         exit(EXIT_FAILURE);
     }
 }

--- a/fairmq/FairMQChannel.cxx
+++ b/fairmq/FairMQChannel.cxx
@@ -65,7 +65,7 @@ FairMQChannel::FairMQChannel(const string& type, const string& method, const str
 {
 }
 
-FairMQChannel::FairMQChannel(const string& name, const string& type, std::shared_ptr<FairMQTransportFactory> factory)
+FairMQChannel::FairMQChannel(const string& name, const string& type, shared_ptr<FairMQTransportFactory> factory)
     : fSocket(factory->CreateSocket(type, name))
     , fType(type)
     , fMethod("unspecified")

--- a/fairmq/FairMQChannel.h
+++ b/fairmq/FairMQChannel.h
@@ -51,7 +51,7 @@ class FairMQChannel
     /// Default destructor
     virtual ~FairMQChannel();
 
-    FairMQSocket const & GetSocket() const;
+    FairMQSocket& GetSocket() const;
 
     auto Bind(const std::string& address) -> bool
     {

--- a/fairmq/FairMQChannel.h
+++ b/fairmq/FairMQChannel.h
@@ -111,6 +111,10 @@ class FairMQChannel
     /// @return Returns socket kernel transmit receive buffer size (in bytes)
     int GetRcvKernelSize() const;
 
+    /// Get linger duration (in milliseconds)
+    /// @return Returns linger duration (in milliseconds)
+    int GetLinger() const;
+
     /// Get socket rate logging interval (in seconds)
     /// @return Returns socket rate logging interval (in seconds)
     int GetRateLogging() const;
@@ -146,6 +150,10 @@ class FairMQChannel
     /// Set socket kernel transmit receive buffer size (in bytes)
     /// @param rcvKernelSize Socket receive buffer size (in bytes)
     void UpdateRcvKernelSize(const int rcvKernelSize);
+
+    /// Set linger duration (in milliseconds)
+    /// @param duration linger duration (in milliseconds)
+    void UpdateLinger(const int duration);
 
     /// Set socket rate logging interval (in seconds)
     /// @param rateLogging Socket rate logging interval (in seconds)
@@ -307,6 +315,7 @@ class FairMQChannel
     int fRcvBufSize;
     int fSndKernelSize;
     int fRcvKernelSize;
+    int fLinger;
     int fRateLogging;
 
     std::string fName;

--- a/fairmq/FairMQDevice.cxx
+++ b/fairmq/FairMQDevice.cxx
@@ -296,20 +296,20 @@ bool FairMQDevice::AttachChannel(FairMQChannel& ch)
         }
 
         // set linger duration (how long socket should wait for outstanding transfers before shutdown)
-        ch.fSocket->SetOption("linger", &(ch.fLinger), sizeof(ch.fLinger));
+        ch.fSocket->SetLinger(ch.fLinger);
 
         // set high water marks
-        ch.fSocket->SetOption("snd-hwm", &(ch.fSndBufSize), sizeof(ch.fSndBufSize));
-        ch.fSocket->SetOption("rcv-hwm", &(ch.fRcvBufSize), sizeof(ch.fRcvBufSize));
+        ch.fSocket->SetSndBufSize(ch.fSndBufSize);
+        ch.fSocket->SetRcvBufSize(ch.fRcvBufSize);
 
         // set kernel transmit size (set it only if value is not the default value)
         if (ch.fSndKernelSize != 0)
         {
-            ch.fSocket->SetOption("snd-size", &(ch.fSndKernelSize), sizeof(ch.fSndKernelSize));
+            ch.fSocket->SetSndKernelSize(ch.fSndKernelSize);
         }
         if (ch.fRcvKernelSize != 0)
         {
-            ch.fSocket->SetOption("rcv-size", &(ch.fRcvKernelSize), sizeof(ch.fRcvKernelSize));
+            ch.fSocket->SetRcvKernelSize(ch.fRcvKernelSize);
         }
 
         // attach

--- a/fairmq/FairMQDevice.cxx
+++ b/fairmq/FairMQDevice.cxx
@@ -302,7 +302,7 @@ bool FairMQDevice::AttachChannel(FairMQChannel& ch)
         ch.fSocket->SetOption("snd-hwm", &(ch.fSndBufSize), sizeof(ch.fSndBufSize));
         ch.fSocket->SetOption("rcv-hwm", &(ch.fRcvBufSize), sizeof(ch.fRcvBufSize));
 
-        // set kernel transmit size
+        // set kernel transmit size (set it only if value is not the default value)
         if (ch.fSndKernelSize != 0)
         {
             ch.fSocket->SetOption("snd-size", &(ch.fSndKernelSize), sizeof(ch.fSndKernelSize));

--- a/fairmq/FairMQSocket.h
+++ b/fairmq/FairMQSocket.h
@@ -35,9 +35,6 @@ class FairMQSocket
     virtual int64_t TrySend(std::vector<std::unique_ptr<FairMQMessage>>& msgVec) = 0;
     virtual int64_t TryReceive(std::vector<std::unique_ptr<FairMQMessage>>& msgVec) = 0;
 
-    virtual void* GetSocket() const = 0;
-    virtual int GetSocket(int nothing) const = 0;
-
     virtual void Close() = 0;
 
     virtual void SetOption(const std::string& option, const void* value, size_t valueSize) = 0;

--- a/fairmq/FairMQSocket.h
+++ b/fairmq/FairMQSocket.h
@@ -43,6 +43,17 @@ class FairMQSocket
     virtual void SetOption(const std::string& option, const void* value, size_t valueSize) = 0;
     virtual void GetOption(const std::string& option, void* value, size_t* valueSize) = 0;
 
+    virtual void SetLinger(const int value) = 0;
+    virtual int GetLinger() const = 0;
+    virtual void SetSndBufSize(const int value) = 0;
+    virtual int GetSndBufSize() const = 0;
+    virtual void SetRcvBufSize(const int value) = 0;
+    virtual int GetRcvBufSize() const = 0;
+    virtual void SetSndKernelSize(const int value) = 0;
+    virtual int GetSndKernelSize() const = 0;
+    virtual void SetRcvKernelSize(const int value) = 0;
+    virtual int GetRcvKernelSize() const = 0;
+
     virtual unsigned long GetBytesTx() const = 0;
     virtual unsigned long GetBytesRx() const = 0;
     virtual unsigned long GetMessagesTx() const = 0;

--- a/fairmq/FairMQTransportFactory.h
+++ b/fairmq/FairMQTransportFactory.h
@@ -73,6 +73,7 @@ class FairMQTransportFactory
 
     virtual void Interrupt() = 0;
     virtual void Resume() = 0;
+    virtual void Reset() = 0;
 
     virtual ~FairMQTransportFactory() {};
 

--- a/fairmq/FairMQTransportFactory.h
+++ b/fairmq/FairMQTransportFactory.h
@@ -63,8 +63,6 @@ class FairMQTransportFactory
     virtual FairMQPollerPtr CreatePoller(const std::vector<const FairMQChannel*>& channels) const = 0;
     /// Create a poller for specific channels (all subchannels)
     virtual FairMQPollerPtr CreatePoller(const std::unordered_map<std::string, std::vector<FairMQChannel>>& channelsMap, const std::vector<std::string>& channelList) const = 0;
-    /// Create a poller for two sockets
-    virtual FairMQPollerPtr CreatePoller(const FairMQSocket& cmdSocket, const FairMQSocket& dataSocket) const = 0;
 
     virtual FairMQUnmanagedRegionPtr CreateUnmanagedRegion(const size_t size, FairMQRegionCallback callback = nullptr) const = 0;
 

--- a/fairmq/nanomsg/FairMQMessageNN.h
+++ b/fairmq/nanomsg/FairMQMessageNN.h
@@ -24,7 +24,7 @@
 
 class FairMQSocketNN;
 
-class FairMQMessageNN : public FairMQMessage
+class FairMQMessageNN final : public FairMQMessage
 {
     friend class FairMQSocketNN;
 

--- a/fairmq/nanomsg/FairMQPollerNN.h
+++ b/fairmq/nanomsg/FairMQPollerNN.h
@@ -26,7 +26,7 @@
 class FairMQChannel;
 struct nn_pollfd;
 
-class FairMQPollerNN : public FairMQPoller
+class FairMQPollerNN final : public FairMQPoller
 {
     friend class FairMQChannel;
     friend class FairMQTransportFactoryNN;
@@ -41,13 +41,13 @@ class FairMQPollerNN : public FairMQPoller
 
     void SetItemEvents(nn_pollfd& item, const int type);
 
-    virtual void Poll(const int timeout);
-    virtual bool CheckInput(const int index);
-    virtual bool CheckOutput(const int index);
-    virtual bool CheckInput(const std::string& channelKey, const int index);
-    virtual bool CheckOutput(const std::string& channelKey, const int index);
+    void Poll(const int timeout) override;
+    bool CheckInput(const int index) override;
+    bool CheckOutput(const int index) override;
+    bool CheckInput(const std::string& channelKey, const int index) override;
+    bool CheckOutput(const std::string& channelKey, const int index) override;
 
-    virtual ~FairMQPollerNN();
+    ~FairMQPollerNN() override;
 
   private:
     FairMQPollerNN(const FairMQSocket& cmdSocket, const FairMQSocket& dataSocket);

--- a/fairmq/nanomsg/FairMQPollerNN.h
+++ b/fairmq/nanomsg/FairMQPollerNN.h
@@ -50,8 +50,6 @@ class FairMQPollerNN final : public FairMQPoller
     ~FairMQPollerNN() override;
 
   private:
-    FairMQPollerNN(const FairMQSocket& cmdSocket, const FairMQSocket& dataSocket);
-
     nn_pollfd* fItems;
     int fNumItems;
 

--- a/fairmq/nanomsg/FairMQSocketNN.cxx
+++ b/fairmq/nanomsg/FairMQSocketNN.cxx
@@ -39,6 +39,7 @@ FairMQSocketNN::FairMQSocketNN(const string& type, const string& name, const str
     , fMessagesRx(0)
     , fSndTimeout(100)
     , fRcvTimeout(100)
+    , fLinger(500)
 {
     if (type == "router" || type == "dealer")
     {
@@ -453,6 +454,13 @@ void FairMQSocketNN::SetOption(const string& option, const void* value, size_t v
 
     if (option == "snd-hwm" || option == "rcv-hwm")
     {
+        return;
+    }
+
+    if (option == "linger")
+    {
+        int val = *(static_cast<int*>(const_cast<void*>(value)));
+        fLinger = val;
         return;
     }
 

--- a/fairmq/nanomsg/FairMQSocketNN.cxx
+++ b/fairmq/nanomsg/FairMQSocketNN.cxx
@@ -416,12 +416,7 @@ void FairMQSocketNN::Resume()
     fInterrupted = false;
 }
 
-void* FairMQSocketNN::GetSocket() const
-{
-    return nullptr; // dummy method to comply with the interface. functionality not possible in zeromq.
-}
-
-int FairMQSocketNN::GetSocket(int /*nothing*/) const
+int FairMQSocketNN::GetSocket() const
 {
     return fSocket;
 }
@@ -445,8 +440,7 @@ void FairMQSocketNN::SetOption(const string& option, const void* value, size_t v
 
     if (option == "linger")
     {
-        int val = *(static_cast<int*>(const_cast<void*>(value)));
-        fLinger = val;
+        fLinger = *static_cast<int*>(const_cast<void*>(value));
         return;
     }
 
@@ -459,6 +453,19 @@ void FairMQSocketNN::SetOption(const string& option, const void* value, size_t v
 
 void FairMQSocketNN::GetOption(const string& option, void* value, size_t* valueSize)
 {
+    if (option == "linger")
+    {
+        *static_cast<int*>(value) = fLinger;
+        return;
+    }
+
+    if (option == "snd-hwm" || option == "rcv-hwm")
+    {
+        *static_cast<int*>(value) = -1;
+        return;
+    }
+
+
     int rc = nn_getsockopt(fSocket, NN_SOL_SOCKET, GetConstant(option), value, valueSize);
     if (rc < 0)
     {

--- a/fairmq/nanomsg/FairMQSocketNN.cxx
+++ b/fairmq/nanomsg/FairMQSocketNN.cxx
@@ -156,11 +156,7 @@ int FairMQSocketNN::SendImpl(FairMQMessagePtr& msg, const int flags, const int t
 
             return nbytes;
         }
-#if NN_VERSION_CURRENT>2 // backwards-compatibility with nanomsg version<=0.6
         else if (nn_errno() == ETIMEDOUT)
-#else
-        else if (nn_errno() == EAGAIN)
-#endif
         {
             if (!fInterrupted && ((flags & NN_DONTWAIT) == 0))
             {
@@ -214,11 +210,7 @@ int FairMQSocketNN::ReceiveImpl(FairMQMessagePtr& msg, const int flags, const in
             msgPtr->fReceiving = true;
             return nbytes;
         }
-#if NN_VERSION_CURRENT>2 // backwards-compatibility with nanomsg version<=0.6
         else if (nn_errno() == ETIMEDOUT)
-#else
-        else if (nn_errno() == EAGAIN)
-#endif
         {
             if (!fInterrupted && ((flags & NN_DONTWAIT) == 0))
             {
@@ -288,11 +280,7 @@ int64_t FairMQSocketNN::SendImpl(vector<FairMQMessagePtr>& msgVec, const int fla
             ++fMessagesTx;
             return nbytes;
         }
-#if NN_VERSION_CURRENT>2 // backwards-compatibility with nanomsg version<=0.6
         else if (nn_errno() == ETIMEDOUT)
-#else
-        else if (nn_errno() == EAGAIN)
-#endif
         {
             if (!fInterrupted && ((flags & NN_DONTWAIT) == 0))
             {
@@ -375,11 +363,7 @@ int64_t FairMQSocketNN::ReceiveImpl(vector<FairMQMessagePtr>& msgVec, const int 
             nn_freemsg(ptr);
             return nbytes;
         }
-#if NN_VERSION_CURRENT>2 // backwards-compatibility with nanomsg version<=0.6
         else if (nn_errno() == ETIMEDOUT)
-#else
-        else if (nn_errno() == EAGAIN)
-#endif
         {
             if (!fInterrupted && ((flags & NN_DONTWAIT) == 0))
             {

--- a/fairmq/nanomsg/FairMQSocketNN.h
+++ b/fairmq/nanomsg/FairMQSocketNN.h
@@ -37,8 +37,7 @@ class FairMQSocketNN final : public FairMQSocket
     int64_t TrySend(std::vector<std::unique_ptr<FairMQMessage>>& msgVec) override;
     int64_t TryReceive(std::vector<std::unique_ptr<FairMQMessage>>& msgVec) override;
 
-    void* GetSocket() const override;
-    int GetSocket(int nothing) const override;
+    int GetSocket() const;
 
     void Close() override;
 

--- a/fairmq/nanomsg/FairMQSocketNN.h
+++ b/fairmq/nanomsg/FairMQSocketNN.h
@@ -15,8 +15,12 @@
 #include "FairMQSocket.h"
 #include "FairMQMessage.h"
 
+class FairMQTransportFactoryNN;
+
 class FairMQSocketNN : public FairMQSocket
 {
+    friend class FairMQTransportFactoryNN;
+
   public:
     FairMQSocketNN(const std::string& type, const std::string& name, const std::string& id = "");
     FairMQSocketNN(const FairMQSocketNN&) = delete;
@@ -69,6 +73,7 @@ class FairMQSocketNN : public FairMQSocket
 
     int fSndTimeout;
     int fRcvTimeout;
+    int fLinger;
 
     int SendImpl(FairMQMessagePtr& msg, const int flags, const int timeout);
     int ReceiveImpl(FairMQMessagePtr& msg, const int flags, const int timeout);

--- a/fairmq/nanomsg/FairMQSocketNN.h
+++ b/fairmq/nanomsg/FairMQSocketNN.h
@@ -15,12 +15,8 @@
 #include "FairMQSocket.h"
 #include "FairMQMessage.h"
 
-class FairMQTransportFactoryNN;
-
 class FairMQSocketNN final : public FairMQSocket
 {
-    friend class FairMQTransportFactoryNN;
-
   public:
     FairMQSocketNN(const std::string& type, const std::string& name, const std::string& id = "");
     FairMQSocketNN(const FairMQSocketNN&) = delete;
@@ -51,6 +47,17 @@ class FairMQSocketNN final : public FairMQSocket
 
     void SetOption(const std::string& option, const void* value, size_t valueSize) override;
     void GetOption(const std::string& option, void* value, size_t* valueSize) override;
+
+    void SetLinger(const int value) override;
+    int GetLinger() const override;
+    void SetSndBufSize(const int value) override;
+    int GetSndBufSize() const override;
+    void SetRcvBufSize(const int value) override;
+    int GetRcvBufSize() const override;
+    void SetSndKernelSize(const int value) override;
+    int GetSndKernelSize() const override;
+    void SetRcvKernelSize(const int value) override;
+    int GetRcvKernelSize() const override;
 
     unsigned long GetBytesTx() const override;
     unsigned long GetBytesRx() const override;

--- a/fairmq/nanomsg/FairMQSocketNN.h
+++ b/fairmq/nanomsg/FairMQSocketNN.h
@@ -17,7 +17,7 @@
 
 class FairMQTransportFactoryNN;
 
-class FairMQSocketNN : public FairMQSocket
+class FairMQSocketNN final : public FairMQSocket
 {
     friend class FairMQTransportFactoryNN;
 

--- a/fairmq/nanomsg/FairMQTransportFactoryNN.cxx
+++ b/fairmq/nanomsg/FairMQTransportFactoryNN.cxx
@@ -65,11 +65,6 @@ FairMQPollerPtr FairMQTransportFactoryNN::CreatePoller(const unordered_map<strin
     return unique_ptr<FairMQPoller>(new FairMQPollerNN(channelsMap, channelList));
 }
 
-FairMQPollerPtr FairMQTransportFactoryNN::CreatePoller(const FairMQSocket& cmdSocket, const FairMQSocket& dataSocket) const
-{
-    return unique_ptr<FairMQPoller>(new FairMQPollerNN(cmdSocket, dataSocket));
-}
-
 FairMQUnmanagedRegionPtr FairMQTransportFactoryNN::CreateUnmanagedRegion(const size_t size, FairMQRegionCallback callback) const
 {
     return unique_ptr<FairMQUnmanagedRegion>(new FairMQUnmanagedRegionNN(size, callback));

--- a/fairmq/nanomsg/FairMQTransportFactoryNN.cxx
+++ b/fairmq/nanomsg/FairMQTransportFactoryNN.cxx
@@ -82,11 +82,11 @@ fair::mq::Transport FairMQTransportFactoryNN::GetType() const
 
 void FairMQTransportFactoryNN::Reset()
 {
-    auto result = max_element(fSockets.begin(), fSockets.end(), [](FairMQSocket* s1, FairMQSocket* s2) {
-        return static_cast<FairMQSocketNN*>(s1)->fLinger < static_cast<FairMQSocketNN*>(s2)->fLinger;
+    auto it = max_element(fSockets.begin(), fSockets.end(), [](FairMQSocket* s1, FairMQSocket* s2) {
+        return static_cast<FairMQSocketNN*>(s1)->GetLinger() < static_cast<FairMQSocketNN*>(s2)->GetLinger();
     });
-    if (result != fSockets.end()) {
-        this_thread::sleep_for(chrono::milliseconds(static_cast<FairMQSocketNN*>(*result)->fLinger));
+    if (it != fSockets.end()) {
+        this_thread::sleep_for(chrono::milliseconds(static_cast<FairMQSocketNN*>(*it)->GetLinger()));
     }
     fSockets.clear();
 }

--- a/fairmq/nanomsg/FairMQTransportFactoryNN.h
+++ b/fairmq/nanomsg/FairMQTransportFactoryNN.h
@@ -35,7 +35,6 @@ class FairMQTransportFactoryNN final : public FairMQTransportFactory
     FairMQPollerPtr CreatePoller(const std::vector<FairMQChannel>& channels) const override;
     FairMQPollerPtr CreatePoller(const std::vector<const FairMQChannel*>& channels) const override;
     FairMQPollerPtr CreatePoller(const std::unordered_map<std::string, std::vector<FairMQChannel>>& channelsMap, const std::vector<std::string>& channelList) const override;
-    FairMQPollerPtr CreatePoller(const FairMQSocket& cmdSocket, const FairMQSocket& dataSocket) const override;
 
     FairMQUnmanagedRegionPtr CreateUnmanagedRegion(const size_t size, FairMQRegionCallback callback) const override;
 

--- a/fairmq/nanomsg/FairMQTransportFactoryNN.h
+++ b/fairmq/nanomsg/FairMQTransportFactoryNN.h
@@ -19,7 +19,7 @@
 #include <vector>
 #include <string>
 
-class FairMQTransportFactoryNN : public FairMQTransportFactory
+class FairMQTransportFactoryNN final : public FairMQTransportFactory
 {
   public:
     FairMQTransportFactoryNN(const std::string& id = "", const FairMQProgOptions* config = nullptr);

--- a/fairmq/nanomsg/FairMQTransportFactoryNN.h
+++ b/fairmq/nanomsg/FairMQTransportFactoryNN.h
@@ -43,9 +43,11 @@ class FairMQTransportFactoryNN : public FairMQTransportFactory
 
     void Interrupt() override { FairMQSocketNN::Interrupt(); }
     void Resume() override { FairMQSocketNN::Resume(); }
+    void Reset() override;
 
   private:
     static fair::mq::Transport fTransportType;
+    mutable std::vector<FairMQSocket*> fSockets;
 };
 
 #endif /* FAIRMQTRANSPORTFACTORYNN_H_ */

--- a/fairmq/nanomsg/FairMQUnmanagedRegionNN.h
+++ b/fairmq/nanomsg/FairMQUnmanagedRegionNN.h
@@ -13,7 +13,7 @@
 
 #include <cstddef> // size_t
 
-class FairMQUnmanagedRegionNN : public FairMQUnmanagedRegion
+class FairMQUnmanagedRegionNN final : public FairMQUnmanagedRegion
 {
     friend class FairMQSocketNN;
 

--- a/fairmq/ofi/Message.h
+++ b/fairmq/ofi/Message.h
@@ -30,7 +30,7 @@ namespace ofi
  *
  * @todo TODO insert long description
  */
-class Message : public fair::mq::Message
+class Message final : public fair::mq::Message
 {
   public:
     Message();

--- a/fairmq/ofi/Poller.h
+++ b/fairmq/ofi/Poller.h
@@ -33,7 +33,7 @@ class TransportFactory;
  *
  * @todo TODO insert long description
  */
-class Poller : public FairMQPoller
+class Poller final : public FairMQPoller
 {
     friend class FairMQChannel;
     friend class TransportFactory;

--- a/fairmq/ofi/Poller.h
+++ b/fairmq/ofi/Poller.h
@@ -57,8 +57,6 @@ class Poller final : public FairMQPoller
     ~Poller() override;
 
   private:
-    Poller(const FairMQSocket& cmdSocket, const FairMQSocket& dataSocket);
-
     zmq_pollitem_t* fItems;
     int fNumItems;
 

--- a/fairmq/ofi/Socket.cxx
+++ b/fairmq/ofi/Socket.cxx
@@ -619,6 +619,84 @@ auto Socket::GetOption(const string& option, void* value, size_t* valueSize) -> 
     }
 }
 
+int Socket::GetLinger() const
+{
+    int value = 0;
+    size_t valueSize;
+    if (zmq_getsockopt(fControlSocket, ZMQ_LINGER, &value, &valueSize) < 0) {
+        throw SocketError(tools::ToString("failed getting ZMQ_LINGER, reason: ", zmq_strerror(errno)));
+    }
+    return value;
+}
+
+void Socket::SetSndBufSize(const int value)
+{
+    if (zmq_setsockopt(fControlSocket, ZMQ_SNDHWM, &value, sizeof(value)) < 0) {
+        throw SocketError(tools::ToString("failed setting ZMQ_SNDHWM, reason: ", zmq_strerror(errno)));
+    }
+}
+
+int Socket::GetSndBufSize() const
+{
+    int value = 0;
+    size_t valueSize;
+    if (zmq_getsockopt(fControlSocket, ZMQ_SNDHWM, &value, &valueSize) < 0) {
+        throw SocketError(tools::ToString("failed getting ZMQ_SNDHWM, reason: ", zmq_strerror(errno)));
+    }
+    return value;
+}
+
+void Socket::SetRcvBufSize(const int value)
+{
+    if (zmq_setsockopt(fControlSocket, ZMQ_RCVHWM, &value, sizeof(value)) < 0) {
+        throw SocketError(tools::ToString("failed setting ZMQ_RCVHWM, reason: ", zmq_strerror(errno)));
+    }
+}
+
+int Socket::GetRcvBufSize() const
+{
+    int value = 0;
+    size_t valueSize;
+    if (zmq_getsockopt(fControlSocket, ZMQ_RCVHWM, &value, &valueSize) < 0) {
+        throw SocketError(tools::ToString("failed getting ZMQ_RCVHWM, reason: ", zmq_strerror(errno)));
+    }
+    return value;
+}
+
+void Socket::SetSndKernelSize(const int value)
+{
+    if (zmq_setsockopt(fControlSocket, ZMQ_SNDBUF, &value, sizeof(value)) < 0) {
+        throw SocketError(tools::ToString("failed getting ZMQ_SNDBUF, reason: ", zmq_strerror(errno)));
+    }
+}
+
+int Socket::GetSndKernelSize() const
+{
+    int value = 0;
+    size_t valueSize;
+    if (zmq_getsockopt(fControlSocket, ZMQ_SNDBUF, &value, &valueSize) < 0) {
+        throw SocketError(tools::ToString("failed getting ZMQ_SNDBUF, reason: ", zmq_strerror(errno)));
+    }
+    return value;
+}
+
+void Socket::SetRcvKernelSize(const int value)
+{
+    if (zmq_setsockopt(fControlSocket, ZMQ_RCVBUF, &value, sizeof(value)) < 0) {
+        throw SocketError(tools::ToString("failed getting ZMQ_RCVBUF, reason: ", zmq_strerror(errno)));
+    }
+}
+
+int Socket::GetRcvKernelSize() const
+{
+    int value = 0;
+    size_t valueSize;
+    if (zmq_getsockopt(fControlSocket, ZMQ_RCVBUF, &value, &valueSize) < 0) {
+        throw SocketError(tools::ToString("failed getting ZMQ_RCVBUF, reason: ", zmq_strerror(errno)));
+    }
+    return value;
+}
+
 auto Socket::GetConstant(const string& constant) -> int
 {
     if (constant == "")

--- a/fairmq/ofi/Socket.h
+++ b/fairmq/ofi/Socket.h
@@ -32,7 +32,7 @@ namespace ofi
  *
  * @todo TODO insert long description
  */
-class Socket : public fair::mq::Socket
+class Socket final : public fair::mq::Socket
 {
   public:
     Socket(Context& factory, const std::string& type, const std::string& name, const std::string& id = "");

--- a/fairmq/ofi/Socket.h
+++ b/fairmq/ofi/Socket.h
@@ -54,8 +54,7 @@ class Socket final : public fair::mq::Socket
     auto TrySend(std::vector<MessagePtr>& msgVec) -> int64_t override;
     auto TryReceive(std::vector<MessagePtr>& msgVec) -> int64_t override;
 
-    auto GetSocket() const -> void* override { return fControlSocket; }
-    auto GetSocket(int nothing) const -> int override { return -1; }
+    auto GetSocket() const -> void* { return fControlSocket; }
 
     void SetLinger(const int value) override;
     int GetLinger() const override;

--- a/fairmq/ofi/Socket.h
+++ b/fairmq/ofi/Socket.h
@@ -57,6 +57,17 @@ class Socket final : public fair::mq::Socket
     auto GetSocket() const -> void* override { return fControlSocket; }
     auto GetSocket(int nothing) const -> int override { return -1; }
 
+    void SetLinger(const int value) override;
+    int GetLinger() const override;
+    void SetSndBufSize(const int value) override;
+    int GetSndBufSize() const override;
+    void SetRcvBufSize(const int value) override;
+    int GetRcvBufSize() const override;
+    void SetSndKernelSize(const int value) override;
+    int GetSndKernelSize() const override;
+    void SetRcvKernelSize(const int value) override;
+    int GetRcvKernelSize() const override;
+
     auto Close() -> void override;
 
     auto SetOption(const std::string& option, const void* value, size_t valueSize) -> void override;

--- a/fairmq/ofi/TransportFactory.cxx
+++ b/fairmq/ofi/TransportFactory.cxx
@@ -76,11 +76,6 @@ auto TransportFactory::CreatePoller(const unordered_map<string, vector<FairMQCha
     return PollerPtr{new Poller(channelsMap, channelList)};
 }
 
-auto TransportFactory::CreatePoller(const FairMQSocket& cmdSocket, const FairMQSocket& dataSocket) const -> PollerPtr
-{
-    return PollerPtr{new Poller(cmdSocket, dataSocket)};
-}
-
 auto TransportFactory::CreateUnmanagedRegion(const size_t size, FairMQRegionCallback callback) const -> UnmanagedRegionPtr
 {
     throw runtime_error{"Not yet implemented UMR."};

--- a/fairmq/ofi/TransportFactory.h
+++ b/fairmq/ofi/TransportFactory.h
@@ -43,7 +43,6 @@ class TransportFactory final : public FairMQTransportFactory
     auto CreatePoller(const std::vector<FairMQChannel>& channels) const -> PollerPtr override;
     auto CreatePoller(const std::vector<const FairMQChannel*>& channels) const -> PollerPtr override;
     auto CreatePoller(const std::unordered_map<std::string, std::vector<FairMQChannel>>& channelsMap, const std::vector<std::string>& channelList) const -> PollerPtr override;
-    auto CreatePoller(const FairMQSocket& cmdSocket, const FairMQSocket& dataSocket) const -> PollerPtr override;
 
     auto CreateUnmanagedRegion(const size_t size, FairMQRegionCallback callback = nullptr) const -> UnmanagedRegionPtr override;
 

--- a/fairmq/ofi/TransportFactory.h
+++ b/fairmq/ofi/TransportFactory.h
@@ -51,6 +51,7 @@ class TransportFactory : public FairMQTransportFactory
 
     void Interrupt() override {}
     void Resume() override {}
+    void Reset() override {}
 
   private:
     mutable Context fContext;

--- a/fairmq/ofi/TransportFactory.h
+++ b/fairmq/ofi/TransportFactory.h
@@ -26,7 +26,7 @@ namespace ofi
  *
  * @todo TODO insert long description
  */
-class TransportFactory : public FairMQTransportFactory
+class TransportFactory final : public FairMQTransportFactory
 {
   public:
     TransportFactory(const std::string& id = "", const FairMQProgOptions* config = nullptr);

--- a/fairmq/options/FairMQParser.cxx
+++ b/fairmq/options/FairMQParser.cxx
@@ -153,6 +153,7 @@ void ChannelParser(const boost::property_tree::ptree& tree, FairMQChannelMap& ch
                 commonChannel.UpdateRcvBufSize(q.second.get<int>("rcvBufSize", commonChannel.GetRcvBufSize()));
                 commonChannel.UpdateSndKernelSize(q.second.get<int>("sndKernelSize", commonChannel.GetSndKernelSize()));
                 commonChannel.UpdateRcvKernelSize(q.second.get<int>("rcvKernelSize", commonChannel.GetRcvKernelSize()));
+                commonChannel.UpdateLinger(q.second.get<int>("linger", commonChannel.GetLinger()));
                 commonChannel.UpdateRateLogging(q.second.get<int>("rateLogging", commonChannel.GetRateLogging()));
 
                 // temporary FairMQChannel container
@@ -172,6 +173,7 @@ void ChannelParser(const boost::property_tree::ptree& tree, FairMQChannelMap& ch
                     LOG(debug) << "\trcvBufSize    = " << commonChannel.GetRcvBufSize();
                     LOG(debug) << "\tsndKernelSize = " << commonChannel.GetSndKernelSize();
                     LOG(debug) << "\trcvKernelSize = " << commonChannel.GetRcvKernelSize();
+                    LOG(debug) << "\tlinger        = " << commonChannel.GetLinger();
                     LOG(debug) << "\trateLogging   = " << commonChannel.GetRateLogging();
 
                     for (int i = 0; i < numSockets; ++i)
@@ -214,6 +216,7 @@ void SocketParser(const boost::property_tree::ptree& tree, vector<FairMQChannel>
                 channel.UpdateRcvBufSize(q.second.get<int>("rcvBufSize", channel.GetRcvBufSize()));
                 channel.UpdateSndKernelSize(q.second.get<int>("sndKernelSize", channel.GetSndKernelSize()));
                 channel.UpdateRcvKernelSize(q.second.get<int>("rcvKernelSize", channel.GetRcvKernelSize()));
+                channel.UpdateLinger(q.second.get<int>("linger", channel.GetLinger()));
                 channel.UpdateRateLogging(q.second.get<int>("rateLogging", channel.GetRateLogging()));
 
                 LOG(debug) << "" << channelName << "[" << socketCounter << "]:";
@@ -225,6 +228,7 @@ void SocketParser(const boost::property_tree::ptree& tree, vector<FairMQChannel>
                 LOG(debug) << "\trcvBufSize    = " << channel.GetRcvBufSize();
                 LOG(debug) << "\tsndKernelSize = " << channel.GetSndKernelSize();
                 LOG(debug) << "\trcvKernelSize = " << channel.GetRcvKernelSize();
+                LOG(debug) << "\tlinger        = " << channel.GetLinger();
                 LOG(debug) << "\trateLogging   = " << channel.GetRateLogging();
 
                 channelList.push_back(channel);
@@ -253,6 +257,7 @@ void SocketParser(const boost::property_tree::ptree& tree, vector<FairMQChannel>
         LOG(debug) << "\trcvBufSize    = " << channel.GetRcvBufSize();
         LOG(debug) << "\tsndKernelSize = " << channel.GetSndKernelSize();
         LOG(debug) << "\trcvKernelSize = " << channel.GetRcvKernelSize();
+        LOG(debug) << "\tlinger        = " << channel.GetLinger();
         LOG(debug) << "\trateLogging   = " << channel.GetRateLogging();
 
         channelList.push_back(channel);

--- a/fairmq/options/FairMQProgOptions.cxx
+++ b/fairmq/options/FairMQProgOptions.cxx
@@ -268,6 +268,7 @@ void FairMQProgOptions::UpdateMQValues()
             string rcvBufSizeKey = "chans." + p.first + "." + to_string(index) + ".rcvBufSize";
             string sndKernelSizeKey = "chans." + p.first + "." + to_string(index) + ".sndKernelSize";
             string rcvKernelSizeKey = "chans." + p.first + "." + to_string(index) + ".rcvKernelSize";
+            string lingerKey = "chans." + p.first + "." + to_string(index) + ".linger";
             string rateLoggingKey = "chans." + p.first + "." + to_string(index) + ".rateLogging";
 
             fChannelKeyMap[typeKey] = ChannelKey{p.first, index, "type"};
@@ -278,6 +279,7 @@ void FairMQProgOptions::UpdateMQValues()
             fChannelKeyMap[rcvBufSizeKey] = ChannelKey{p.first, index, "rcvBufSize"};
             fChannelKeyMap[sndKernelSizeKey] = ChannelKey{p.first, index, "sndKernelSize"};
             fChannelKeyMap[rcvKernelSizeKey] = ChannelKey{p.first, index, "rcvkernelSize"};
+            fChannelKeyMap[lingerKey] = ChannelKey{p.first, index, "linger"};
             fChannelKeyMap[rateLoggingKey] = ChannelKey{p.first, index, "rateLogging"};
 
             UpdateVarMap<string>(typeKey, channel.GetType());
@@ -288,6 +290,7 @@ void FairMQProgOptions::UpdateMQValues()
             UpdateVarMap<int>(rcvBufSizeKey, channel.GetRcvBufSize());
             UpdateVarMap<int>(sndKernelSizeKey, channel.GetSndKernelSize());
             UpdateVarMap<int>(rcvKernelSizeKey, channel.GetRcvKernelSize());
+            UpdateVarMap<int>(lingerKey, channel.GetLinger());
             UpdateVarMap<int>(rateLoggingKey, channel.GetRateLogging());
 
             index++;
@@ -340,6 +343,12 @@ int FairMQProgOptions::UpdateChannelValue(const string& channelName, int index, 
     if (member == "rcvBufSize")
     {
         fFairMQChannelMap.at(channelName).at(index).UpdateRcvBufSize(val);
+        return 0;
+    }
+
+    if (member == "linger")
+    {
+        fFairMQChannelMap.at(channelName).at(index).UpdateLinger(val);
         return 0;
     }
 

--- a/fairmq/options/FairMQSuboptParser.h
+++ b/fairmq/options/FairMQSuboptParser.h
@@ -56,6 +56,7 @@ struct SUBOPT
         RCVBUFSIZE,     // size of the receive queue
         SNDKERNELSIZE,
         RCVKERNELSIZE,
+        LINGER,
         RATELOGGING,    // logging rate
         NUMSOCKETS,
         lastsocketkey
@@ -71,6 +72,7 @@ struct SUBOPT
         /*[RCVBUFSIZE]    = */ "rcvBufSize",
         /*[SNDKERNELSIZE] = */ "sndKernelSize",
         /*[RCVKERNELSIZE] = */ "rcvKernelSize",
+        /*[LINGER]        = */ "linger",
         /*[RATELOGGING]   = */ "rateLogging",
         /*[NUMSOCKETS]    = */ "numSockets",
         nullptr

--- a/fairmq/shmem/FairMQMessageSHM.h
+++ b/fairmq/shmem/FairMQMessageSHM.h
@@ -22,7 +22,7 @@
 
 class FairMQSocketSHM;
 
-class FairMQMessageSHM : public FairMQMessage
+class FairMQMessageSHM final : public FairMQMessage
 {
     friend class FairMQSocketSHM;
 

--- a/fairmq/shmem/FairMQPollerSHM.cxx
+++ b/fairmq/shmem/FairMQPollerSHM.cxx
@@ -13,6 +13,7 @@
  */
 
 #include "FairMQPollerSHM.h"
+#include "FairMQSocketSHM.h"
 #include "FairMQLogger.h"
 
 #include <zmq.h>
@@ -29,13 +30,13 @@ FairMQPollerSHM::FairMQPollerSHM(const vector<FairMQChannel>& channels)
 
     for (int i = 0; i < fNumItems; ++i)
     {
-        fItems[i].socket = channels.at(i).GetSocket().GetSocket();
+        fItems[i].socket = static_cast<const FairMQSocketSHM*>(&(channels.at(i).GetSocket()))->GetSocket();
         fItems[i].fd = 0;
         fItems[i].revents = 0;
 
         int type = 0;
         size_t size = sizeof(type);
-        zmq_getsockopt(channels.at(i).GetSocket().GetSocket(), ZMQ_TYPE, &type, &size);
+        zmq_getsockopt(static_cast<const FairMQSocketSHM*>(&(channels.at(i).GetSocket()))->GetSocket(), ZMQ_TYPE, &type, &size);
 
         SetItemEvents(fItems[i], type);
     }
@@ -51,13 +52,13 @@ FairMQPollerSHM::FairMQPollerSHM(const vector<const FairMQChannel*>& channels)
 
     for (int i = 0; i < fNumItems; ++i)
     {
-        fItems[i].socket = channels.at(i)->GetSocket().GetSocket();
+        fItems[i].socket = static_cast<const FairMQSocketSHM*>(&(channels.at(i)->GetSocket()))->GetSocket();
         fItems[i].fd = 0;
         fItems[i].revents = 0;
 
         int type = 0;
         size_t size = sizeof(type);
-        zmq_getsockopt(channels.at(i)->GetSocket().GetSocket(), ZMQ_TYPE, &type, &size);
+        zmq_getsockopt(static_cast<const FairMQSocketSHM*>(&(channels.at(i)->GetSocket()))->GetSocket(), ZMQ_TYPE, &type, &size);
 
         SetItemEvents(fItems[i], type);
     }
@@ -88,13 +89,13 @@ FairMQPollerSHM::FairMQPollerSHM(const unordered_map<string, vector<FairMQChanne
             {
                 index = fOffsetMap[channel] + i;
 
-                fItems[index].socket = channelsMap.at(channel).at(i).GetSocket().GetSocket();
+                fItems[index].socket = static_cast<const FairMQSocketSHM*>(&(channelsMap.at(channel).at(i).GetSocket()))->GetSocket();
                 fItems[index].fd = 0;
                 fItems[index].revents = 0;
 
                 int type = 0;
                 size_t size = sizeof(type);
-                zmq_getsockopt(channelsMap.at(channel).at(i).GetSocket().GetSocket(), ZMQ_TYPE, &type, &size);
+                zmq_getsockopt(static_cast<const FairMQSocketSHM*>(&(channelsMap.at(channel).at(i).GetSocket()))->GetSocket(), ZMQ_TYPE, &type, &size);
 
                 SetItemEvents(fItems[index], type);
             }
@@ -106,29 +107,6 @@ FairMQPollerSHM::FairMQPollerSHM(const unordered_map<string, vector<FairMQChanne
         LOG(error) << "out of range error: " << oor.what() << '\n';
         exit(EXIT_FAILURE);
     }
-}
-
-FairMQPollerSHM::FairMQPollerSHM(const FairMQSocket& cmdSocket, const FairMQSocket& dataSocket)
-    : fItems()
-    , fNumItems(2)
-    , fOffsetMap()
-{
-    fItems = new zmq_pollitem_t[fNumItems];
-
-    fItems[0].socket = cmdSocket.GetSocket();
-    fItems[0].fd = 0;
-    fItems[0].events = ZMQ_POLLIN;
-    fItems[0].revents = 0;
-
-    fItems[1].socket = dataSocket.GetSocket();
-    fItems[1].fd = 0;
-    fItems[1].revents = 0;
-
-    int type = 0;
-    size_t size = sizeof(type);
-    zmq_getsockopt(dataSocket.GetSocket(), ZMQ_TYPE, &type, &size);
-
-    SetItemEvents(fItems[1], type);
 }
 
 void FairMQPollerSHM::SetItemEvents(zmq_pollitem_t& item, const int type)

--- a/fairmq/shmem/FairMQPollerSHM.h
+++ b/fairmq/shmem/FairMQPollerSHM.h
@@ -43,8 +43,6 @@ class FairMQPollerSHM final : public FairMQPoller
     ~FairMQPollerSHM() override;
 
   private:
-    FairMQPollerSHM(const FairMQSocket& cmdSocket, const FairMQSocket& dataSocket);
-
     zmq_pollitem_t* fItems;
     int fNumItems;
 

--- a/fairmq/shmem/FairMQPollerSHM.h
+++ b/fairmq/shmem/FairMQPollerSHM.h
@@ -19,7 +19,7 @@
 
 class FairMQChannel;
 
-class FairMQPollerSHM : public FairMQPoller
+class FairMQPollerSHM final : public FairMQPoller
 {
     friend class FairMQChannel;
     friend class FairMQTransportFactorySHM;

--- a/fairmq/shmem/FairMQSocketSHM.cxx
+++ b/fairmq/shmem/FairMQSocketSHM.cxx
@@ -11,6 +11,7 @@
 #include "FairMQMessageSHM.h"
 #include "FairMQUnmanagedRegionSHM.h"
 #include "FairMQLogger.h"
+#include <fairmq/Tools.h>
 
 #include <zmq.h>
 
@@ -18,6 +19,7 @@
 
 using namespace std;
 using namespace fair::mq::shmem;
+using namespace fair::mq;
 
 atomic<bool> FairMQSocketSHM::fInterrupted(false);
 
@@ -475,6 +477,91 @@ void FairMQSocketSHM::GetOption(const string& option, void* value, size_t* value
     {
         LOG(error) << "Failed getting socket option, reason: " << zmq_strerror(errno);
     }
+}
+
+void FairMQSocketSHM::SetLinger(const int value)
+{
+    if (zmq_setsockopt(fSocket, ZMQ_LINGER, &value, sizeof(value)) < 0) {
+        throw SocketError(tools::ToString("failed setting ZMQ_LINGER, reason: ", zmq_strerror(errno)));
+    }
+}
+
+int FairMQSocketSHM::GetLinger() const
+{
+    int value = 0;
+    size_t valueSize;
+    if (zmq_getsockopt(fSocket, ZMQ_LINGER, &value, &valueSize) < 0) {
+        throw SocketError(tools::ToString("failed getting ZMQ_LINGER, reason: ", zmq_strerror(errno)));
+    }
+    return value;
+}
+
+void FairMQSocketSHM::SetSndBufSize(const int value)
+{
+    if (zmq_setsockopt(fSocket, ZMQ_SNDHWM, &value, sizeof(value)) < 0) {
+        throw SocketError(tools::ToString("failed setting ZMQ_SNDHWM, reason: ", zmq_strerror(errno)));
+    }
+}
+
+int FairMQSocketSHM::GetSndBufSize() const
+{
+    int value = 0;
+    size_t valueSize;
+    if (zmq_getsockopt(fSocket, ZMQ_SNDHWM, &value, &valueSize) < 0) {
+        throw SocketError(tools::ToString("failed getting ZMQ_SNDHWM, reason: ", zmq_strerror(errno)));
+    }
+    return value;
+}
+
+void FairMQSocketSHM::SetRcvBufSize(const int value)
+{
+    if (zmq_setsockopt(fSocket, ZMQ_RCVHWM, &value, sizeof(value)) < 0) {
+        throw SocketError(tools::ToString("failed setting ZMQ_RCVHWM, reason: ", zmq_strerror(errno)));
+    }
+}
+
+int FairMQSocketSHM::GetRcvBufSize() const
+{
+    int value = 0;
+    size_t valueSize;
+    if (zmq_getsockopt(fSocket, ZMQ_RCVHWM, &value, &valueSize) < 0) {
+        throw SocketError(tools::ToString("failed getting ZMQ_RCVHWM, reason: ", zmq_strerror(errno)));
+    }
+    return value;
+}
+
+void FairMQSocketSHM::SetSndKernelSize(const int value)
+{
+    if (zmq_setsockopt(fSocket, ZMQ_SNDBUF, &value, sizeof(value)) < 0) {
+        throw SocketError(tools::ToString("failed getting ZMQ_SNDBUF, reason: ", zmq_strerror(errno)));
+    }
+}
+
+int FairMQSocketSHM::GetSndKernelSize() const
+{
+    int value = 0;
+    size_t valueSize;
+    if (zmq_getsockopt(fSocket, ZMQ_SNDBUF, &value, &valueSize) < 0) {
+        throw SocketError(tools::ToString("failed getting ZMQ_SNDBUF, reason: ", zmq_strerror(errno)));
+    }
+    return value;
+}
+
+void FairMQSocketSHM::SetRcvKernelSize(const int value)
+{
+    if (zmq_setsockopt(fSocket, ZMQ_RCVBUF, &value, sizeof(value)) < 0) {
+        throw SocketError(tools::ToString("failed getting ZMQ_RCVBUF, reason: ", zmq_strerror(errno)));
+    }
+}
+
+int FairMQSocketSHM::GetRcvKernelSize() const
+{
+    int value = 0;
+    size_t valueSize;
+    if (zmq_getsockopt(fSocket, ZMQ_RCVBUF, &value, &valueSize) < 0) {
+        throw SocketError(tools::ToString("failed getting ZMQ_RCVBUF, reason: ", zmq_strerror(errno)));
+    }
+    return value;
 }
 
 unsigned long FairMQSocketSHM::GetBytesTx() const

--- a/fairmq/shmem/FairMQSocketSHM.cxx
+++ b/fairmq/shmem/FairMQSocketSHM.cxx
@@ -457,12 +457,6 @@ void* FairMQSocketSHM::GetSocket() const
     return fSocket;
 }
 
-int FairMQSocketSHM::GetSocket(int) const
-{
-    // dummy method to comply with the interface. functionality not possible in zeromq.
-    return -1;
-}
-
 void FairMQSocketSHM::SetOption(const string& option, const void* value, size_t valueSize)
 {
     if (zmq_setsockopt(fSocket, GetConstant(option), value, valueSize) < 0)
@@ -489,7 +483,7 @@ void FairMQSocketSHM::SetLinger(const int value)
 int FairMQSocketSHM::GetLinger() const
 {
     int value = 0;
-    size_t valueSize;
+    size_t valueSize = sizeof(value);
     if (zmq_getsockopt(fSocket, ZMQ_LINGER, &value, &valueSize) < 0) {
         throw SocketError(tools::ToString("failed getting ZMQ_LINGER, reason: ", zmq_strerror(errno)));
     }
@@ -506,7 +500,7 @@ void FairMQSocketSHM::SetSndBufSize(const int value)
 int FairMQSocketSHM::GetSndBufSize() const
 {
     int value = 0;
-    size_t valueSize;
+    size_t valueSize = sizeof(value);
     if (zmq_getsockopt(fSocket, ZMQ_SNDHWM, &value, &valueSize) < 0) {
         throw SocketError(tools::ToString("failed getting ZMQ_SNDHWM, reason: ", zmq_strerror(errno)));
     }
@@ -523,7 +517,7 @@ void FairMQSocketSHM::SetRcvBufSize(const int value)
 int FairMQSocketSHM::GetRcvBufSize() const
 {
     int value = 0;
-    size_t valueSize;
+    size_t valueSize = sizeof(value);
     if (zmq_getsockopt(fSocket, ZMQ_RCVHWM, &value, &valueSize) < 0) {
         throw SocketError(tools::ToString("failed getting ZMQ_RCVHWM, reason: ", zmq_strerror(errno)));
     }
@@ -540,7 +534,7 @@ void FairMQSocketSHM::SetSndKernelSize(const int value)
 int FairMQSocketSHM::GetSndKernelSize() const
 {
     int value = 0;
-    size_t valueSize;
+    size_t valueSize = sizeof(value);
     if (zmq_getsockopt(fSocket, ZMQ_SNDBUF, &value, &valueSize) < 0) {
         throw SocketError(tools::ToString("failed getting ZMQ_SNDBUF, reason: ", zmq_strerror(errno)));
     }
@@ -557,7 +551,7 @@ void FairMQSocketSHM::SetRcvKernelSize(const int value)
 int FairMQSocketSHM::GetRcvKernelSize() const
 {
     int value = 0;
-    size_t valueSize;
+    size_t valueSize = sizeof(value);
     if (zmq_getsockopt(fSocket, ZMQ_RCVBUF, &value, &valueSize) < 0) {
         throw SocketError(tools::ToString("failed getting ZMQ_RCVBUF, reason: ", zmq_strerror(errno)));
     }

--- a/fairmq/shmem/FairMQSocketSHM.h
+++ b/fairmq/shmem/FairMQSocketSHM.h
@@ -38,8 +38,7 @@ class FairMQSocketSHM final : public FairMQSocket
     int64_t TrySend(std::vector<std::unique_ptr<FairMQMessage>>& msgVec) override;
     int64_t TryReceive(std::vector<std::unique_ptr<FairMQMessage>>& msgVec) override;
 
-    void* GetSocket() const override;
-    int GetSocket(int nothing) const override;
+    void* GetSocket() const;
 
     void Close() override;
 

--- a/fairmq/shmem/FairMQSocketSHM.h
+++ b/fairmq/shmem/FairMQSocketSHM.h
@@ -49,6 +49,17 @@ class FairMQSocketSHM final : public FairMQSocket
     void SetOption(const std::string& option, const void* value, size_t valueSize) override;
     void GetOption(const std::string& option, void* value, size_t* valueSize) override;
 
+    void SetLinger(const int value) override;
+    int GetLinger() const override;
+    void SetSndBufSize(const int value) override;
+    int GetSndBufSize() const override;
+    void SetRcvBufSize(const int value) override;
+    int GetRcvBufSize() const override;
+    void SetSndKernelSize(const int value) override;
+    int GetSndKernelSize() const override;
+    void SetRcvKernelSize(const int value) override;
+    int GetRcvKernelSize() const override;
+
     unsigned long GetBytesTx() const override;
     unsigned long GetBytesRx() const override;
     unsigned long GetMessagesTx() const override;

--- a/fairmq/shmem/FairMQSocketSHM.h
+++ b/fairmq/shmem/FairMQSocketSHM.h
@@ -16,7 +16,7 @@
 #include <atomic>
 #include <memory> // unique_ptr
 
-class FairMQSocketSHM : public FairMQSocket
+class FairMQSocketSHM final : public FairMQSocket
 {
   public:
     FairMQSocketSHM(fair::mq::shmem::Manager& manager, const std::string& type, const std::string& name, const std::string& id = "", void* context = nullptr);

--- a/fairmq/shmem/FairMQTransportFactorySHM.cxx
+++ b/fairmq/shmem/FairMQTransportFactorySHM.cxx
@@ -254,11 +254,6 @@ FairMQPollerPtr FairMQTransportFactorySHM::CreatePoller(const unordered_map<stri
     return unique_ptr<FairMQPoller>(new FairMQPollerSHM(channelsMap, channelList));
 }
 
-FairMQPollerPtr FairMQTransportFactorySHM::CreatePoller(const FairMQSocket& cmdSocket, const FairMQSocket& dataSocket) const
-{
-    return unique_ptr<FairMQPoller>(new FairMQPollerSHM(cmdSocket, dataSocket));
-}
-
 FairMQUnmanagedRegionPtr FairMQTransportFactorySHM::CreateUnmanagedRegion(const size_t size, FairMQRegionCallback callback) const
 {
     return unique_ptr<FairMQUnmanagedRegion>(new FairMQUnmanagedRegionSHM(*fManager, size, callback));

--- a/fairmq/shmem/FairMQTransportFactorySHM.h
+++ b/fairmq/shmem/FairMQTransportFactorySHM.h
@@ -51,6 +51,7 @@ class FairMQTransportFactorySHM : public FairMQTransportFactory
 
     void Interrupt() override { FairMQSocketSHM::Interrupt(); }
     void Resume() override { FairMQSocketSHM::Resume(); }
+    void Reset() override {}
 
     ~FairMQTransportFactorySHM() override;
 

--- a/fairmq/shmem/FairMQTransportFactorySHM.h
+++ b/fairmq/shmem/FairMQTransportFactorySHM.h
@@ -43,7 +43,6 @@ class FairMQTransportFactorySHM final : public FairMQTransportFactory
     FairMQPollerPtr CreatePoller(const std::vector<FairMQChannel>& channels) const override;
     FairMQPollerPtr CreatePoller(const std::vector<const FairMQChannel*>& channels) const override;
     FairMQPollerPtr CreatePoller(const std::unordered_map<std::string, std::vector<FairMQChannel>>& channelsMap, const std::vector<std::string>& channelList) const override;
-    FairMQPollerPtr CreatePoller(const FairMQSocket& cmdSocket, const FairMQSocket& dataSocket) const override;
 
     FairMQUnmanagedRegionPtr CreateUnmanagedRegion(const size_t size, FairMQRegionCallback callback = nullptr) const override;
 

--- a/fairmq/shmem/FairMQTransportFactorySHM.h
+++ b/fairmq/shmem/FairMQTransportFactorySHM.h
@@ -26,7 +26,7 @@
 #include <thread>
 #include <atomic>
 
-class FairMQTransportFactorySHM : public FairMQTransportFactory
+class FairMQTransportFactorySHM final : public FairMQTransportFactory
 {
   public:
     FairMQTransportFactorySHM(const std::string& id = "", const FairMQProgOptions* config = nullptr);

--- a/fairmq/shmem/FairMQUnmanagedRegionSHM.h
+++ b/fairmq/shmem/FairMQUnmanagedRegionSHM.h
@@ -19,7 +19,7 @@
 
 #include <cstddef> // size_t
 
-class FairMQUnmanagedRegionSHM : public FairMQUnmanagedRegion
+class FairMQUnmanagedRegionSHM final : public FairMQUnmanagedRegion
 {
     friend class FairMQSocketSHM;
     friend class FairMQMessageSHM;

--- a/fairmq/zeromq/FairMQMessageZMQ.h
+++ b/fairmq/zeromq/FairMQMessageZMQ.h
@@ -26,7 +26,7 @@
 
 class FairMQSocketZMQ;
 
-class FairMQMessageZMQ : public FairMQMessage
+class FairMQMessageZMQ final : public FairMQMessage
 {
     friend class FairMQSocketZMQ;
 

--- a/fairmq/zeromq/FairMQPollerZMQ.h
+++ b/fairmq/zeromq/FairMQPollerZMQ.h
@@ -51,8 +51,6 @@ class FairMQPollerZMQ final : public FairMQPoller
     ~FairMQPollerZMQ() override;
 
   private:
-    FairMQPollerZMQ(const FairMQSocket& cmdSocket, const FairMQSocket& dataSocket);
-
     zmq_pollitem_t* fItems;
     int fNumItems;
 

--- a/fairmq/zeromq/FairMQPollerZMQ.h
+++ b/fairmq/zeromq/FairMQPollerZMQ.h
@@ -27,7 +27,7 @@
 
 class FairMQChannel;
 
-class FairMQPollerZMQ : public FairMQPoller
+class FairMQPollerZMQ final : public FairMQPoller
 {
     friend class FairMQChannel;
     friend class FairMQTransportFactoryZMQ;
@@ -42,13 +42,13 @@ class FairMQPollerZMQ : public FairMQPoller
 
     void SetItemEvents(zmq_pollitem_t& item, const int type);
 
-    virtual void Poll(const int timeout);
-    virtual bool CheckInput(const int index);
-    virtual bool CheckOutput(const int index);
-    virtual bool CheckInput(const std::string& channelKey, const int index);
-    virtual bool CheckOutput(const std::string& channelKey, const int index);
+    void Poll(const int timeout) override;
+    bool CheckInput(const int index) override;
+    bool CheckOutput(const int index) override;
+    bool CheckInput(const std::string& channelKey, const int index) override;
+    bool CheckOutput(const std::string& channelKey, const int index) override;
 
-    virtual ~FairMQPollerZMQ();
+    ~FairMQPollerZMQ() override;
 
   private:
     FairMQPollerZMQ(const FairMQSocket& cmdSocket, const FairMQSocket& dataSocket);

--- a/fairmq/zeromq/FairMQSocketZMQ.cxx
+++ b/fairmq/zeromq/FairMQSocketZMQ.cxx
@@ -164,12 +164,11 @@ int FairMQSocketZMQ::SendImpl(FairMQMessagePtr& msg, const int flags, const int 
 
 int FairMQSocketZMQ::ReceiveImpl(FairMQMessagePtr& msg, const int flags, const int timeout)
 {
-    int nbytes = -1;
     int elapsed = 0;
 
     while (true)
     {
-        nbytes = zmq_msg_recv(static_cast<FairMQMessageZMQ*>(msg.get())->GetMessage(), fSocket, flags);
+        int nbytes = zmq_msg_recv(static_cast<FairMQMessageZMQ*>(msg.get())->GetMessage(), fSocket, flags);
         if (nbytes >= 0)
         {
             fBytesRx += nbytes;

--- a/fairmq/zeromq/FairMQSocketZMQ.cxx
+++ b/fairmq/zeromq/FairMQSocketZMQ.cxx
@@ -9,12 +9,14 @@
 #include "FairMQSocketZMQ.h"
 #include "FairMQMessageZMQ.h"
 #include "FairMQLogger.h"
+#include <fairmq/Tools.h>
 
 #include <zmq.h>
 
 #include <cassert>
 
 using namespace std;
+using namespace fair::mq;
 
 atomic<bool> FairMQSocketZMQ::fInterrupted(false);
 
@@ -400,6 +402,91 @@ void FairMQSocketZMQ::GetOption(const string& option, void* value, size_t* value
     {
         LOG(error) << "Failed getting socket option, reason: " << zmq_strerror(errno);
     }
+}
+
+void FairMQSocketZMQ::SetLinger(const int value)
+{
+    if (zmq_setsockopt(fSocket, ZMQ_LINGER, &value, sizeof(value)) < 0) {
+        throw SocketError(tools::ToString("failed setting ZMQ_LINGER, reason: ", zmq_strerror(errno)));
+    }
+}
+
+int FairMQSocketZMQ::GetLinger() const
+{
+    int value = 0;
+    size_t valueSize;
+    if (zmq_getsockopt(fSocket, ZMQ_LINGER, &value, &valueSize) < 0) {
+        throw SocketError(tools::ToString("failed getting ZMQ_LINGER, reason: ", zmq_strerror(errno)));
+    }
+    return value;
+}
+
+void FairMQSocketZMQ::SetSndBufSize(const int value)
+{
+    if (zmq_setsockopt(fSocket, ZMQ_SNDHWM, &value, sizeof(value)) < 0) {
+        throw SocketError(tools::ToString("failed setting ZMQ_SNDHWM, reason: ", zmq_strerror(errno)));
+    }
+}
+
+int FairMQSocketZMQ::GetSndBufSize() const
+{
+    int value = 0;
+    size_t valueSize;
+    if (zmq_getsockopt(fSocket, ZMQ_SNDHWM, &value, &valueSize) < 0) {
+        throw SocketError(tools::ToString("failed getting ZMQ_SNDHWM, reason: ", zmq_strerror(errno)));
+    }
+    return value;
+}
+
+void FairMQSocketZMQ::SetRcvBufSize(const int value)
+{
+    if (zmq_setsockopt(fSocket, ZMQ_RCVHWM, &value, sizeof(value)) < 0) {
+        throw SocketError(tools::ToString("failed setting ZMQ_RCVHWM, reason: ", zmq_strerror(errno)));
+    }
+}
+
+int FairMQSocketZMQ::GetRcvBufSize() const
+{
+    int value = 0;
+    size_t valueSize;
+    if (zmq_getsockopt(fSocket, ZMQ_RCVHWM, &value, &valueSize) < 0) {
+        throw SocketError(tools::ToString("failed getting ZMQ_RCVHWM, reason: ", zmq_strerror(errno)));
+    }
+    return value;
+}
+
+void FairMQSocketZMQ::SetSndKernelSize(const int value)
+{
+    if (zmq_setsockopt(fSocket, ZMQ_SNDBUF, &value, sizeof(value)) < 0) {
+        throw SocketError(tools::ToString("failed getting ZMQ_SNDBUF, reason: ", zmq_strerror(errno)));
+    }
+}
+
+int FairMQSocketZMQ::GetSndKernelSize() const
+{
+    int value = 0;
+    size_t valueSize;
+    if (zmq_getsockopt(fSocket, ZMQ_SNDBUF, &value, &valueSize) < 0) {
+        throw SocketError(tools::ToString("failed getting ZMQ_SNDBUF, reason: ", zmq_strerror(errno)));
+    }
+    return value;
+}
+
+void FairMQSocketZMQ::SetRcvKernelSize(const int value)
+{
+    if (zmq_setsockopt(fSocket, ZMQ_RCVBUF, &value, sizeof(value)) < 0) {
+        throw SocketError(tools::ToString("failed getting ZMQ_RCVBUF, reason: ", zmq_strerror(errno)));
+    }
+}
+
+int FairMQSocketZMQ::GetRcvKernelSize() const
+{
+    int value = 0;
+    size_t valueSize;
+    if (zmq_getsockopt(fSocket, ZMQ_RCVBUF, &value, &valueSize) < 0) {
+        throw SocketError(tools::ToString("failed getting ZMQ_RCVBUF, reason: ", zmq_strerror(errno)));
+    }
+    return value;
 }
 
 unsigned long FairMQSocketZMQ::GetBytesTx() const

--- a/fairmq/zeromq/FairMQSocketZMQ.cxx
+++ b/fairmq/zeromq/FairMQSocketZMQ.cxx
@@ -382,12 +382,6 @@ void* FairMQSocketZMQ::GetSocket() const
     return fSocket;
 }
 
-int FairMQSocketZMQ::GetSocket(int) const
-{
-    // dummy method to comply with the interface. functionality not possible in zeromq.
-    return -1;
-}
-
 void FairMQSocketZMQ::SetOption(const string& option, const void* value, size_t valueSize)
 {
     if (zmq_setsockopt(fSocket, GetConstant(option), value, valueSize) < 0)
@@ -414,7 +408,7 @@ void FairMQSocketZMQ::SetLinger(const int value)
 int FairMQSocketZMQ::GetLinger() const
 {
     int value = 0;
-    size_t valueSize;
+    size_t valueSize = sizeof(value);
     if (zmq_getsockopt(fSocket, ZMQ_LINGER, &value, &valueSize) < 0) {
         throw SocketError(tools::ToString("failed getting ZMQ_LINGER, reason: ", zmq_strerror(errno)));
     }
@@ -431,7 +425,7 @@ void FairMQSocketZMQ::SetSndBufSize(const int value)
 int FairMQSocketZMQ::GetSndBufSize() const
 {
     int value = 0;
-    size_t valueSize;
+    size_t valueSize = sizeof(value);
     if (zmq_getsockopt(fSocket, ZMQ_SNDHWM, &value, &valueSize) < 0) {
         throw SocketError(tools::ToString("failed getting ZMQ_SNDHWM, reason: ", zmq_strerror(errno)));
     }
@@ -448,7 +442,7 @@ void FairMQSocketZMQ::SetRcvBufSize(const int value)
 int FairMQSocketZMQ::GetRcvBufSize() const
 {
     int value = 0;
-    size_t valueSize;
+    size_t valueSize = sizeof(value);
     if (zmq_getsockopt(fSocket, ZMQ_RCVHWM, &value, &valueSize) < 0) {
         throw SocketError(tools::ToString("failed getting ZMQ_RCVHWM, reason: ", zmq_strerror(errno)));
     }
@@ -465,7 +459,7 @@ void FairMQSocketZMQ::SetSndKernelSize(const int value)
 int FairMQSocketZMQ::GetSndKernelSize() const
 {
     int value = 0;
-    size_t valueSize;
+    size_t valueSize = sizeof(value);
     if (zmq_getsockopt(fSocket, ZMQ_SNDBUF, &value, &valueSize) < 0) {
         throw SocketError(tools::ToString("failed getting ZMQ_SNDBUF, reason: ", zmq_strerror(errno)));
     }
@@ -482,7 +476,7 @@ void FairMQSocketZMQ::SetRcvKernelSize(const int value)
 int FairMQSocketZMQ::GetRcvKernelSize() const
 {
     int value = 0;
-    size_t valueSize;
+    size_t valueSize = sizeof(value);
     if (zmq_getsockopt(fSocket, ZMQ_RCVBUF, &value, &valueSize) < 0) {
         throw SocketError(tools::ToString("failed getting ZMQ_RCVBUF, reason: ", zmq_strerror(errno)));
     }

--- a/fairmq/zeromq/FairMQSocketZMQ.h
+++ b/fairmq/zeromq/FairMQSocketZMQ.h
@@ -49,6 +49,17 @@ class FairMQSocketZMQ final : public FairMQSocket
     void SetOption(const std::string& option, const void* value, size_t valueSize) override;
     void GetOption(const std::string& option, void* value, size_t* valueSize) override;
 
+    void SetLinger(const int value) override;
+    int GetLinger() const override;
+    void SetSndBufSize(const int value) override;
+    int GetSndBufSize() const override;
+    void SetRcvBufSize(const int value) override;
+    int GetRcvBufSize() const override;
+    void SetSndKernelSize(const int value) override;
+    int GetSndKernelSize() const override;
+    void SetRcvKernelSize(const int value) override;
+    int GetRcvKernelSize() const override;
+
     unsigned long GetBytesTx() const override;
     unsigned long GetBytesRx() const override;
     unsigned long GetMessagesTx() const override;

--- a/fairmq/zeromq/FairMQSocketZMQ.h
+++ b/fairmq/zeromq/FairMQSocketZMQ.h
@@ -38,8 +38,7 @@ class FairMQSocketZMQ final : public FairMQSocket
     int64_t TrySend(std::vector<std::unique_ptr<FairMQMessage>>& msgVec) override;
     int64_t TryReceive(std::vector<std::unique_ptr<FairMQMessage>>& msgVec) override;
 
-    void* GetSocket() const override;
-    int GetSocket(int nothing) const override;
+    void* GetSocket() const;
 
     void Close() override;
 

--- a/fairmq/zeromq/FairMQSocketZMQ.h
+++ b/fairmq/zeromq/FairMQSocketZMQ.h
@@ -16,7 +16,7 @@
 #include "FairMQSocket.h"
 #include "FairMQMessage.h"
 
-class FairMQSocketZMQ : public FairMQSocket
+class FairMQSocketZMQ final : public FairMQSocket
 {
   public:
     FairMQSocketZMQ(const std::string& type, const std::string& name, const std::string& id = "", void* context = nullptr);

--- a/fairmq/zeromq/FairMQTransportFactoryZMQ.cxx
+++ b/fairmq/zeromq/FairMQTransportFactoryZMQ.cxx
@@ -90,11 +90,6 @@ FairMQPollerPtr FairMQTransportFactoryZMQ::CreatePoller(const unordered_map<stri
     return unique_ptr<FairMQPoller>(new FairMQPollerZMQ(channelsMap, channelList));
 }
 
-FairMQPollerPtr FairMQTransportFactoryZMQ::CreatePoller(const FairMQSocket& cmdSocket, const FairMQSocket& dataSocket) const
-{
-    return unique_ptr<FairMQPoller>(new FairMQPollerZMQ(cmdSocket, dataSocket));
-}
-
 FairMQUnmanagedRegionPtr FairMQTransportFactoryZMQ::CreateUnmanagedRegion(const size_t size, FairMQRegionCallback callback) const
 {
     return unique_ptr<FairMQUnmanagedRegion>(new FairMQUnmanagedRegionZMQ(size, callback));

--- a/fairmq/zeromq/FairMQTransportFactoryZMQ.h
+++ b/fairmq/zeromq/FairMQTransportFactoryZMQ.h
@@ -52,6 +52,7 @@ class FairMQTransportFactoryZMQ : public FairMQTransportFactory
 
     void Interrupt() override { FairMQSocketZMQ::Interrupt(); }
     void Resume() override { FairMQSocketZMQ::Resume(); }
+    void Reset() override {}
 
   private:
     static fair::mq::Transport fTransportType;

--- a/fairmq/zeromq/FairMQTransportFactoryZMQ.h
+++ b/fairmq/zeromq/FairMQTransportFactoryZMQ.h
@@ -25,7 +25,7 @@
 #include "FairMQUnmanagedRegionZMQ.h"
 #include <options/FairMQProgOptions.h>
 
-class FairMQTransportFactoryZMQ : public FairMQTransportFactory
+class FairMQTransportFactoryZMQ final : public FairMQTransportFactory
 {
   public:
     FairMQTransportFactoryZMQ(const std::string& id = "", const FairMQProgOptions* config = nullptr);

--- a/fairmq/zeromq/FairMQTransportFactoryZMQ.h
+++ b/fairmq/zeromq/FairMQTransportFactoryZMQ.h
@@ -44,7 +44,6 @@ class FairMQTransportFactoryZMQ final : public FairMQTransportFactory
     FairMQPollerPtr CreatePoller(const std::vector<FairMQChannel>& channels) const override;
     FairMQPollerPtr CreatePoller(const std::vector<const FairMQChannel*>& channels) const override;
     FairMQPollerPtr CreatePoller(const std::unordered_map<std::string, std::vector<FairMQChannel>>& channelsMap, const std::vector<std::string>& channelList) const override;
-    FairMQPollerPtr CreatePoller(const FairMQSocket& cmdSocket, const FairMQSocket& dataSocket) const override;
 
     FairMQUnmanagedRegionPtr CreateUnmanagedRegion(const size_t size, FairMQRegionCallback callback) const override;
 

--- a/fairmq/zeromq/FairMQUnmanagedRegionZMQ.h
+++ b/fairmq/zeromq/FairMQUnmanagedRegionZMQ.h
@@ -13,7 +13,7 @@
 
 #include <cstddef> // size_t
 
-class FairMQUnmanagedRegionZMQ : public FairMQUnmanagedRegion
+class FairMQUnmanagedRegionZMQ final : public FairMQUnmanagedRegion
 {
     friend class FairMQSocketZMQ;
     friend class FairMQMessageZMQ;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -202,11 +202,13 @@ add_testsuite(FairMQ.Transport
     SOURCES
     ${CMAKE_CURRENT_BINARY_DIR}/runner.cxx
     transport/_transfer_timeout.cxx
+    transport/_options.cxx
 
     LINKS FairMQ
     INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}
              ${CMAKE_CURRENT_BINARY_DIR}
     TIMEOUT 10
+    ${definitions}
 )
 
 add_testsuite(FairMQ.Poller
@@ -218,4 +220,5 @@ add_testsuite(FairMQ.Poller
     INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}
              ${CMAKE_CURRENT_BINARY_DIR}
     TIMEOUT 10
+    ${definitions}
 )

--- a/test/device/TestReceiver.h
+++ b/test/device/TestReceiver.h
@@ -35,11 +35,6 @@ class Receiver : public FairMQDevice
         std::this_thread::sleep_for(std::chrono::milliseconds(200));
     }
 
-    auto Reset() -> void override
-    {
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
-    }
-
     auto Run() -> void override
     {
         auto msg = FairMQMessagePtr{NewMessage()};

--- a/test/device/TestSender.h
+++ b/test/device/TestSender.h
@@ -35,11 +35,6 @@ class Sender : public FairMQDevice
         std::this_thread::sleep_for(std::chrono::milliseconds(200));
     }
 
-    auto Reset() -> void override
-    {
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
-    }
-
     auto Run() -> void override
     {
         auto msg = FairMQMessagePtr{NewMessage()};

--- a/test/helper/devices/TestPairLeft.cxx
+++ b/test/helper/devices/TestPairLeft.cxx
@@ -26,11 +26,6 @@ class PairLeft : public FairMQDevice
         std::this_thread::sleep_for(std::chrono::milliseconds(200));
     }
 
-    auto Reset() -> void override
-    {
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
-    }
-
     auto Run() -> void override
     {
         int counter{0};

--- a/test/helper/devices/TestPairRight.cxx
+++ b/test/helper/devices/TestPairRight.cxx
@@ -26,11 +26,6 @@ class PairRight : public FairMQDevice
         std::this_thread::sleep_for(std::chrono::milliseconds(200));
     }
 
-    auto Reset() -> void override
-    {
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
-    }
-
     auto Run() -> void override
     {
         int counter{0};
@@ -45,7 +40,7 @@ class PairRight : public FairMQDevice
         auto msg4(NewMessageFor("data", 0));
         if (Send(msg4, "data") >= 0) counter++;
         if (counter == 4) LOG(info) << "Simple empty message ping pong successfull";
-        
+
         // Simple message with short text data
         auto msg5(NewMessageFor("data", 0));
         auto ret = Receive(msg5, "data");

--- a/test/helper/devices/TestPollIn.cxx
+++ b/test/helper/devices/TestPollIn.cxx
@@ -33,11 +33,6 @@ class PollIn : public FairMQDevice
         std::this_thread::sleep_for(std::chrono::milliseconds(200));
     }
 
-    auto Reset() -> void override
-    {
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
-    }
-
     auto InitTask() -> void override
     {
         fPollType = fConfig->GetValue<int>("poll-type");

--- a/test/helper/devices/TestPollOut.cxx
+++ b/test/helper/devices/TestPollOut.cxx
@@ -24,11 +24,6 @@ class PollOut : public FairMQDevice
         std::this_thread::sleep_for(std::chrono::milliseconds(200));
     }
 
-    auto Reset() -> void override
-    {
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
-    }
-
     auto Run() -> void override
     {
         auto msg1 = FairMQMessagePtr{NewMessage()};

--- a/test/helper/devices/TestPub.cxx
+++ b/test/helper/devices/TestPub.cxx
@@ -25,11 +25,6 @@ class Pub : public FairMQDevice
     {
         std::this_thread::sleep_for(std::chrono::milliseconds(200));
     }
-    
-    auto Reset() -> void override
-    {
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
-    }
 
     auto Run() -> void override
     {

--- a/test/helper/devices/TestPull.cxx
+++ b/test/helper/devices/TestPull.cxx
@@ -27,11 +27,6 @@ class Pull : public FairMQDevice
         std::this_thread::sleep_for(std::chrono::milliseconds(200));
     }
 
-    auto Reset() -> void override
-    {
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
-    }
-
     auto Run() -> void override
     {
         auto msg = FairMQMessagePtr{NewMessage()};

--- a/test/helper/devices/TestPush.cxx
+++ b/test/helper/devices/TestPush.cxx
@@ -24,11 +24,6 @@ class Push : public FairMQDevice
         std::this_thread::sleep_for(std::chrono::milliseconds(200));
     }
 
-    auto Reset() -> void override
-    {
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
-    }
-
     auto Run() -> void override
     {
         auto msg = FairMQMessagePtr{NewMessage()};

--- a/test/helper/devices/TestRep.cxx
+++ b/test/helper/devices/TestRep.cxx
@@ -25,11 +25,6 @@ class Rep : public FairMQDevice
         std::this_thread::sleep_for(std::chrono::milliseconds(200));
     }
 
-    auto Reset() -> void override
-    {
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
-    }
-
     auto Run() -> void override
     {
         auto request1 = FairMQMessagePtr{NewMessage()};

--- a/test/helper/devices/TestReq.cxx
+++ b/test/helper/devices/TestReq.cxx
@@ -25,11 +25,6 @@ class Req : public FairMQDevice
         std::this_thread::sleep_for(std::chrono::milliseconds(200));
     }
 
-    auto Reset() -> void override
-    {
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
-    }
-
     auto Run() -> void override
     {
         auto request = FairMQMessagePtr{NewMessage()};

--- a/test/helper/devices/TestSub.cxx
+++ b/test/helper/devices/TestSub.cxx
@@ -25,11 +25,6 @@ class Sub : public FairMQDevice
     {
         std::this_thread::sleep_for(std::chrono::milliseconds(200));
     }
-    
-    auto Reset() -> void override
-    {
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
-    }
 
     auto Run() -> void override
     {

--- a/test/transport/_options.cxx
+++ b/test/transport/_options.cxx
@@ -1,0 +1,98 @@
+/********************************************************************************
+ *    Copyright (C) 2017 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ *                                                                              *
+ *              This software is distributed under the terms of the             *
+ *              GNU Lesser General Public Licence (LGPL) version 3,             *
+ *                  copied verbatim in the file "LICENSE"                       *
+ ********************************************************************************/
+
+#include <gtest/gtest.h>
+#include <FairMQChannel.h>
+#include <FairMQParts.h>
+#include <FairMQLogger.h>
+#include <FairMQTransportFactory.h>
+#include <fairmq/Tools.h>
+#include <options/FairMQProgOptions.h>
+
+#include <algorithm>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <thread>
+
+namespace
+{
+
+using namespace std;
+
+void CheckOldOptionInterface(FairMQChannel& channel, const string& option, const string& transport)
+{
+    int value = 500;
+    channel.GetSocket().SetOption(option, &value, sizeof(value));
+    value = 0;
+    size_t valueSize = sizeof(value);
+    channel.GetSocket().GetOption(option, &value, &valueSize);
+    if (transport == "nanomsg" && (option == "snd-hwm" || option == "rcv-hwm")) {
+        ASSERT_EQ(value, -1);
+    } else {
+        ASSERT_EQ(value, 500);
+    }
+}
+
+void RunOptionsTest(const string& transport)
+{
+    size_t session{fair::mq::tools::UuidHash()};
+
+    FairMQProgOptions config;
+    config.SetValue<string>("session", to_string(session));
+    auto factory = FairMQTransportFactory::CreateTransportFactory(transport, fair::mq::tools::Uuid(), &config);
+    FairMQChannel channel("Push", "push", factory);
+
+    CheckOldOptionInterface(channel, "linger", transport);
+    CheckOldOptionInterface(channel, "snd-hwm", transport);
+    CheckOldOptionInterface(channel, "rcv-hwm", transport);
+    CheckOldOptionInterface(channel, "snd-size", transport);
+    CheckOldOptionInterface(channel, "rcv-size", transport);
+
+    channel.GetSocket().SetLinger(300);
+    ASSERT_EQ(channel.GetSocket().GetLinger(), 300);
+
+    channel.GetSocket().SetSndBufSize(500);
+    if (transport == "nanomsg") { // nanomsg doesn't use this option and the getter always returns -1
+        ASSERT_EQ(channel.GetSocket().GetSndBufSize(), -1);
+    } else {
+        ASSERT_EQ(channel.GetSocket().GetSndBufSize(), 500);
+    }
+
+    channel.GetSocket().SetRcvBufSize(500);
+    if (transport == "nanomsg") { // nanomsg doesn't use this option and the getter always returns -1
+        ASSERT_EQ(channel.GetSocket().GetRcvBufSize(), -1);
+    } else {
+        ASSERT_EQ(channel.GetSocket().GetRcvBufSize(), 500);
+    }
+
+    channel.GetSocket().SetSndKernelSize(8000);
+    ASSERT_EQ(channel.GetSocket().GetSndKernelSize(), 8000);
+
+    channel.GetSocket().SetRcvKernelSize(8000);
+    ASSERT_EQ(channel.GetSocket().GetRcvKernelSize(), 8000);
+}
+
+TEST(Options, ZeroMQ)
+{
+    RunOptionsTest("zeromq");
+}
+
+TEST(Options, shmem)
+{
+    RunOptionsTest("shmem");
+}
+
+#ifdef BUILD_NANOMSG_TRANSPORT
+TEST(Options, nanomsg)
+{
+    RunOptionsTest("nanomsg");
+}
+#endif /* BUILD_NANOMSG_TRANSPORT */
+
+} // namespace


### PR DESCRIPTION
- Implement nanomsg linger by sleeping on Reset.
- Remove support for nanomsg <= 0.6.
- Make factory classes final (optimization potential).
- Remove sleeps from tests that were helping broken linger.
- Add setters/getters for socket options.
- Remove GetSocket interface that exposes transport details.

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
