### PR TITLE
Deprecate Send-/ReceiveAsync, use timeout variant instead

### DIFF
--- a/fairmq/FairMQChannel.cxx
+++ b/fairmq/FairMQChannel.cxx
@@ -689,77 +689,52 @@ void FairMQChannel::ResetChannel()
     // TODO: implement channel resetting
 }
 
-int FairMQChannel::Send(unique_ptr<FairMQMessage>& msg) const
-{
-    CheckSendCompatibility(msg);
-    return fSocket->Send(msg);
-}
-
-int FairMQChannel::Receive(unique_ptr<FairMQMessage>& msg) const
-{
-    CheckReceiveCompatibility(msg);
-    return fSocket->Receive(msg);
-}
-
 int FairMQChannel::Send(unique_ptr<FairMQMessage>& msg, int sndTimeoutInMs) const
 {
+    CheckSendCompatibility(msg);
     return fSocket->Send(msg, sndTimeoutInMs);
 }
 
 int FairMQChannel::Receive(unique_ptr<FairMQMessage>& msg, int rcvTimeoutInMs) const
 {
+    CheckReceiveCompatibility(msg);
     return fSocket->Receive(msg, rcvTimeoutInMs);
 }
 
 int FairMQChannel::SendAsync(unique_ptr<FairMQMessage>& msg) const
 {
     CheckSendCompatibility(msg);
-    return fSocket->TrySend(msg);
+    return fSocket->Send(msg, 0);
 }
 
 int FairMQChannel::ReceiveAsync(unique_ptr<FairMQMessage>& msg) const
 {
     CheckReceiveCompatibility(msg);
-    return fSocket->TryReceive(msg);
-}
-
-int64_t FairMQChannel::Send(vector<unique_ptr<FairMQMessage>>& msgVec) const
-{
-    CheckSendCompatibility(msgVec);
-    return fSocket->Send(msgVec);
-}
-
-int64_t FairMQChannel::Receive(vector<unique_ptr<FairMQMessage>>& msgVec) const
-{
-    CheckReceiveCompatibility(msgVec);
-    return fSocket->Receive(msgVec);
+    return fSocket->Receive(msg, 0);
 }
 
 int64_t FairMQChannel::Send(vector<unique_ptr<FairMQMessage>>& msgVec, int sndTimeoutInMs) const
 {
+    CheckSendCompatibility(msgVec);
     return fSocket->Send(msgVec, sndTimeoutInMs);
 }
 
 int64_t FairMQChannel::Receive(vector<unique_ptr<FairMQMessage>>& msgVec, int rcvTimeoutInMs) const
 {
+    CheckReceiveCompatibility(msgVec);
     return fSocket->Receive(msgVec, rcvTimeoutInMs);
 }
 
 int64_t FairMQChannel::SendAsync(vector<unique_ptr<FairMQMessage>>& msgVec) const
 {
     CheckSendCompatibility(msgVec);
-    return fSocket->TrySend(msgVec);
+    return fSocket->Send(msgVec, 0);
 }
 
-/// Receives a vector of messages in non-blocking mode.
-///
-/// @param msgVec message vector reference
-/// @return Number of bytes that have been received. If queue is empty, returns -2.
-/// In case of errors, returns -1.
 int64_t FairMQChannel::ReceiveAsync(vector<unique_ptr<FairMQMessage>>& msgVec) const
 {
     CheckReceiveCompatibility(msgVec);
-    return fSocket->TryReceive(msgVec);
+    return fSocket->Receive(msgVec, 0);
 }
 
 FairMQChannel::~FairMQChannel()

--- a/fairmq/FairMQChannel.h
+++ b/fairmq/FairMQChannel.h
@@ -174,106 +174,62 @@ class FairMQChannel
     /// Resets the channel (requires validation to be used again).
     void ResetChannel();
 
-    int Send(FairMQMessagePtr& msg) const;
-    int Receive(FairMQMessagePtr& msg) const;
-
     /// Sends a message to the socket queue.
-    /// @details Send method attempts to send a message by
-    /// putting it in the output queue. If the queue is full or queueing is not possible
-    /// for some other reason (e.g. no peers connected for a binding socket), the method blocks.
-    ///
     /// @param msg Constant reference of unique_ptr to a FairMQMessage
-    /// @return Number of bytes that have been queued. -2 If queueing was not possible or timed out.
-    /// In case of errors, returns -1.
-    int Send(FairMQMessagePtr& msg, int sndTimeoutInMs) const;
+    /// @param sndTimeoutInMs send timeout in ms. -1 will wait forever (or until interrupt (e.g. via state change)), 0 will not wait (return immediately if cannot send)
+    /// @return Number of bytes that have been queued. -2 If queueing was not possible or timed out. -1 if there was an error.
+    int Send(FairMQMessagePtr& msg, int sndTimeoutInMs = -1) const;
 
     /// Receives a message from the socket queue.
-    /// @details Receive method attempts to receive a message from the input queue.
-    /// If the queue is empty the method blocks.
-    ///
     /// @param msg Constant reference of unique_ptr to a FairMQMessage
-    /// @return Number of bytes that have been received. -2 If reading from the queue was not possible or timed out.
-    /// In case of errors, returns -1.
-    int Receive(FairMQMessagePtr& msg, int rcvTimeoutInMs) const;
+    /// @param rcvTimeoutInMs receive timeout in ms. -1 will wait forever (or until interrupt (e.g. via state change)), 0 will not wait (return immediately if cannot receive)
+    /// @return Number of bytes that have been received. -2 if reading from the queue was not possible or timed out. -1 if there was an error.
+    int Receive(FairMQMessagePtr& msg, int rcvTimeoutInMs = -1) const;
 
-    /// Sends a message in non-blocking mode.
-    /// @details SendAsync method attempts to send a message without blocking by
-    /// putting it in the queue.
-    ///
-    /// @param msg Constant reference of unique_ptr to a FairMQMessage
-    /// @return Number of bytes that have been queued. If queueing failed due to
-    /// full queue or no connected peers (when binding), returns -2.
-    /// In case of errors, returns -1.
-    int SendAsync(FairMQMessagePtr& msg) const;
-
-    /// Receives a message in non-blocking mode.
-    ///
-    /// @param msg Constant reference of unique_ptr to a FairMQMessage
-    /// @return Number of bytes that have been received. If queue is empty, returns -2.
-    /// In case of errors, returns -1.
-    int ReceiveAsync(FairMQMessagePtr& msg) const;
-
-    int64_t Send(std::vector<FairMQMessagePtr>& msgVec) const;
-    int64_t Receive(std::vector<FairMQMessagePtr>& msgVec) const;
+    int SendAsync(FairMQMessagePtr& msg) const __attribute__((deprecated("For non-blocking Send, use timeout version with timeout of 0: Send(msg, timeout);")));
+    int ReceiveAsync(FairMQMessagePtr& msg) const __attribute__((deprecated("For non-blocking Receive, use timeout version with timeout of 0: Receive(msg, timeout);")));
 
     /// Send a vector of messages
-    ///
     /// @param msgVec message vector reference
-    /// @return Number of bytes that have been queued. -2 If queueing was not possible or timed out.
-    /// In case of errors, returns -1.
-    int64_t Send(std::vector<FairMQMessagePtr>& msgVec, int sndTimeoutInMs) const;
+    /// @param sndTimeoutInMs send timeout in ms. -1 will wait forever (or until interrupt (e.g. via state change)), 0 will not wait (return immediately if cannot send)
+    /// @return Number of bytes that have been queued. -2 If queueing was not possible or timed out. -1 if there was an error.
+    int64_t Send(std::vector<FairMQMessagePtr>& msgVec, int sndTimeoutInMs = -1) const;
 
     /// Receive a vector of messages
-    ///
     /// @param msgVec message vector reference
-    /// @return Number of bytes that have been received. -2 If reading from the queue was not possible or timed out.
-    /// In case of errors, returns -1.
-    int64_t Receive(std::vector<FairMQMessagePtr>& msgVec, int rcvTimeoutInMs) const;
+    /// @param rcvTimeoutInMs receive timeout in ms. -1 will wait forever (or until interrupt (e.g. via state change)), 0 will not wait (return immediately if cannot receive)
+    /// @return Number of bytes that have been received. -2 if reading from the queue was not possible or timed out. -1 if there was an error.
+    int64_t Receive(std::vector<FairMQMessagePtr>& msgVec, int rcvTimeoutInMs = -1) const;
 
-    /// Sends a vector of message in non-blocking mode.
-    /// @details SendAsync method attempts to send a vector of messages without blocking by
-    /// putting it them the queue.
-    ///
-    /// @param msgVec message vector reference
-    /// @return Number of bytes that have been queued. If queueing failed due to
-    /// full queue or no connected peers (when binding), returns -2. In case of errors, returns -1.
-    int64_t SendAsync(std::vector<FairMQMessagePtr>& msgVec) const;
+    int64_t SendAsync(std::vector<FairMQMessagePtr>& msgVec) const __attribute__((deprecated("For non-blocking Send, use timeout version with timeout of 0: Send(msgVec, timeout);")));
+    int64_t ReceiveAsync(std::vector<FairMQMessagePtr>& msgVec) const __attribute__((deprecated("For non-blocking Receive, use timeout version with timeout of 0: Receive(msgVec, timeout);")));
 
-    /// Receives a vector of messages in non-blocking mode.
-    ///
-    /// @param msgVec message vector reference
-    /// @return Number of bytes that have been received. If queue is empty, returns -2.
-    /// In case of errors, returns -1.
-    int64_t ReceiveAsync(std::vector<FairMQMessagePtr>& msgVec) const;
-
-    int64_t Send(FairMQParts& parts) const
-    {
-        return Send(parts.fParts);
-    }
-
-    int64_t Receive(FairMQParts& parts) const
-    {
-        return Receive(parts.fParts);
-    }
-
-    int64_t Send(FairMQParts& parts, int sndTimeoutInMs) const
+    /// Send FairMQParts
+    /// @param parts FairMQParts reference
+    /// @param sndTimeoutInMs send timeout in ms. -1 will wait forever (or until interrupt (e.g. via state change)), 0 will not wait (return immediately if cannot send)
+    /// @return Number of bytes that have been queued. -2 If queueing was not possible or timed out. -1 if there was an error.
+    int64_t Send(FairMQParts& parts, int sndTimeoutInMs = -1) const
     {
         return Send(parts.fParts, sndTimeoutInMs);
     }
 
-    int64_t Receive(FairMQParts& parts, int rcvTimeoutInMs) const
+    /// Receive FairMQParts
+    /// @param parts FairMQParts reference
+    /// @param rcvTimeoutInMs receive timeout in ms. -1 will wait forever (or until interrupt (e.g. via state change)), 0 will not wait (return immediately if cannot receive)
+    /// @return Number of bytes that have been received. -2 if reading from the queue was not possible or timed out. -1 if there was an error.
+    int64_t Receive(FairMQParts& parts, int rcvTimeoutInMs = -1) const
     {
         return Receive(parts.fParts, rcvTimeoutInMs);
     }
 
-    int64_t SendAsync(FairMQParts& parts) const
+    int64_t SendAsync(FairMQParts& parts) const __attribute__((deprecated("For non-blocking Send, use timeout version with timeout of 0: Send(parts, timeout);")))
     {
-        return SendAsync(parts.fParts);
+        return Send(parts.fParts, 0);
     }
 
-    int64_t ReceiveAsync(FairMQParts& parts) const
+    int64_t ReceiveAsync(FairMQParts& parts) const __attribute__((deprecated("For non-blocking Receive, use timeout version with timeout of 0: Receive(parts, timeout);")))
     {
-        return ReceiveAsync(parts.fParts);
+        return Receive(parts.fParts, 0);
     }
 
     unsigned long GetBytesTx() const;

--- a/fairmq/FairMQDevice.h
+++ b/fairmq/FairMQDevice.h
@@ -96,23 +96,13 @@ class FairMQDevice : public FairMQStateMachine
         Deserializer().Deserialize(msg, std::forward<DataType>(data), std::forward<Args>(args)...);
     }
 
-    int Send(FairMQMessagePtr& msg, const std::string& chan, const int i = 0) const
-    {
-        return fChannels.at(chan).at(i).Send(msg);
-    }
-
-    int Receive(FairMQMessagePtr& msg, const std::string& chan, const int i = 0) const
-    {
-        return fChannels.at(chan).at(i).Receive(msg);
-    }
-
     /// Shorthand method to send `msg` on `chan` at index `i`
     /// @param msg message reference
     /// @param chan channel name
     /// @param i channel index
-    /// @return Number of bytes that have been queued. -2 If queueing was not possible or timed out.
-    /// In case of errors, returns -1.
-    int Send(FairMQMessagePtr& msg, const std::string& chan, const int i, int sndTimeoutInMs) const
+    /// @param sndTimeoutInMs send timeout in ms, -1 will wait forever (or until interrupt (e.g. via state change)), 0 will not wait (return immediately if cannot send)
+    /// @return Number of bytes that have been queued. -2 If queueing was not possible or timed out. -1 if there was an error.
+    int Send(FairMQMessagePtr& msg, const std::string& chan, const int i = 0, int sndTimeoutInMs = -1) const
     {
         return fChannels.at(chan).at(i).Send(msg, sndTimeoutInMs);
     }
@@ -121,52 +111,29 @@ class FairMQDevice : public FairMQStateMachine
     /// @param msg message reference
     /// @param chan channel name
     /// @param i channel index
-    /// @return Number of bytes that have been received. -2 If reading from the queue was not possible or timed out.
-    /// In case of errors, returns -1.
-    int Receive(FairMQMessagePtr& msg, const std::string& chan, const int i, int rcvTimeoutInMs) const
+    /// @param rcvTimeoutInMs receive timeout in ms, -1 will wait forever (or until interrupt (e.g. via state change)), 0 will not wait (return immediately if cannot receive)
+    /// @return Number of bytes that have been received. -2 if reading from the queue was not possible or timed out. -1 if there was an error.
+    int Receive(FairMQMessagePtr& msg, const std::string& chan, const int i = 0, int rcvTimeoutInMs = -1) const
     {
         return fChannels.at(chan).at(i).Receive(msg, rcvTimeoutInMs);
     }
 
-    /// Shorthand method to send `msg` on `chan` at index `i` without blocking
-    /// @param msg message reference
-    /// @param chan channel name
-    /// @param i channel index
-    /// @return Number of bytes that have been queued. -2 If queueing was not possible or timed out.
-    /// In case of errors, returns -1.
-    int SendAsync(FairMQMessagePtr& msg, const std::string& chan, const int i = 0) const
+    int SendAsync(FairMQMessagePtr& msg, const std::string& chan, const int i = 0) const __attribute__((deprecated("For non-blocking Send, use timeout version with timeout of 0: Send(msg, \"channelA\", subchannelIndex, timeout);")))
     {
-        return fChannels.at(chan).at(i).SendAsync(msg);
+        return fChannels.at(chan).at(i).Send(msg, 0);
     }
-
-    /// Shorthand method to receive `msg` on `chan` at index `i` without blocking
-    /// @param msg message reference
-    /// @param chan channel name
-    /// @param i channel index
-    /// @return Number of bytes that have been received. -2 If reading from the queue was not possible or timed out.
-    /// In case of errors, returns -1.
-    int ReceiveAsync(FairMQMessagePtr& msg, const std::string& chan, const int i = 0) const
+    int ReceiveAsync(FairMQMessagePtr& msg, const std::string& chan, const int i = 0) const __attribute__((deprecated("For non-blocking Receive, use timeout version with timeout of 0: Receive(msg, \"channelA\", subchannelIndex, timeout);")))
     {
-        return fChannels.at(chan).at(i).ReceiveAsync(msg);
-    }
-
-    int64_t Send(FairMQParts& parts, const std::string& chan, const int i = 0) const
-    {
-        return fChannels.at(chan).at(i).Send(parts.fParts);
-    }
-
-    int64_t Receive(FairMQParts& parts, const std::string& chan, const int i = 0) const
-    {
-        return fChannels.at(chan).at(i).Receive(parts.fParts);
+        return fChannels.at(chan).at(i).Receive(msg, 0);
     }
 
     /// Shorthand method to send FairMQParts on `chan` at index `i`
     /// @param parts parts reference
     /// @param chan channel name
     /// @param i channel index
-    /// @return Number of bytes that have been queued. -2 If queueing was not possible or timed out.
-    /// In case of errors, returns -1.
-    int64_t Send(FairMQParts& parts, const std::string& chan, const int i, int sndTimeoutInMs) const
+    /// @param sndTimeoutInMs send timeout in ms, -1 will wait forever (or until interrupt (e.g. via state change)), 0 will not wait (return immediately if cannot send)
+    /// @return Number of bytes that have been queued. -2 If queueing was not possible or timed out. -1 if there was an error.
+    int64_t Send(FairMQParts& parts, const std::string& chan, const int i = 0, int sndTimeoutInMs = -1) const
     {
         return fChannels.at(chan).at(i).Send(parts.fParts, sndTimeoutInMs);
     }
@@ -175,33 +142,20 @@ class FairMQDevice : public FairMQStateMachine
     /// @param parts parts reference
     /// @param chan channel name
     /// @param i channel index
-    /// @return Number of bytes that have been received. -2 If reading from the queue was not possible or timed out.
-    /// In case of errors, returns -1.
-    int64_t Receive(FairMQParts& parts, const std::string& chan, const int i, int rcvTimeoutInMs) const
+    /// @param rcvTimeoutInMs receive timeout in ms, -1 will wait forever (or until interrupt (e.g. via state change)), 0 will not wait (return immediately if cannot receive)
+    /// @return Number of bytes that have been received. -2 if reading from the queue was not possible or timed out. -1 if there was an error.
+    int64_t Receive(FairMQParts& parts, const std::string& chan, const int i = 0, int rcvTimeoutInMs = -1) const
     {
         return fChannels.at(chan).at(i).Receive(parts.fParts, rcvTimeoutInMs);
     }
 
-    /// Shorthand method to send FairMQParts on `chan` at index `i` without blocking
-    /// @param parts parts reference
-    /// @param chan channel name
-    /// @param i channel index
-    /// @return Number of bytes that have been queued. -2 If queueing was not possible or timed out.
-    /// In case of errors, returns -1.
-    int64_t SendAsync(FairMQParts& parts, const std::string& chan, const int i = 0) const
+    int64_t SendAsync(FairMQParts& parts, const std::string& chan, const int i = 0) const __attribute__((deprecated("For non-blocking Send, use timeout version with timeout of 0: Send(parts, \"channelA\", subchannelIndex, timeout);")))
     {
-        return fChannels.at(chan).at(i).SendAsync(parts.fParts);
+        return fChannels.at(chan).at(i).Send(parts.fParts, 0);
     }
-
-    /// Shorthand method to receive FairMQParts on `chan` at index `i` without blocking
-    /// @param parts parts reference
-    /// @param chan channel name
-    /// @param i channel index
-    /// @return Number of bytes that have been received. -2 If reading from the queue was not possible or timed out.
-    /// In case of errors, returns -1.
-    int64_t ReceiveAsync(FairMQParts& parts, const std::string& chan, const int i = 0) const
+    int64_t ReceiveAsync(FairMQParts& parts, const std::string& chan, const int i = 0) const __attribute__((deprecated("For non-blocking Receive, use timeout version with timeout of 0: Receive(parts, \"channelA\", subchannelIndex, timeout);")))
     {
-        return fChannels.at(chan).at(i).ReceiveAsync(parts.fParts);
+        return fChannels.at(chan).at(i).Receive(parts.fParts, 0);
     }
 
     /// @brief Getter for default transport factory

--- a/fairmq/FairMQSocket.h
+++ b/fairmq/FairMQSocket.h
@@ -25,15 +25,10 @@ class FairMQSocket
     virtual bool Bind(const std::string& address) = 0;
     virtual void Connect(const std::string& address) = 0;
 
-    virtual int Send(FairMQMessagePtr& msg, int timeout = 0) = 0;
-    virtual int Receive(FairMQMessagePtr& msg, int timeout = 0) = 0;
-    virtual int64_t Send(std::vector<std::unique_ptr<FairMQMessage>>& msgVec, int timeout = 0) = 0;
-    virtual int64_t Receive(std::vector<std::unique_ptr<FairMQMessage>>& msgVec, int timeout = 0) = 0;
-
-    virtual int TrySend(FairMQMessagePtr& msg) = 0;
-    virtual int TryReceive(FairMQMessagePtr& msg) = 0;
-    virtual int64_t TrySend(std::vector<std::unique_ptr<FairMQMessage>>& msgVec) = 0;
-    virtual int64_t TryReceive(std::vector<std::unique_ptr<FairMQMessage>>& msgVec) = 0;
+    virtual int Send(FairMQMessagePtr& msg, int timeout = -1) = 0;
+    virtual int Receive(FairMQMessagePtr& msg, int timeout = -1) = 0;
+    virtual int64_t Send(std::vector<std::unique_ptr<FairMQMessage>>& msgVec, int timeout = -1) = 0;
+    virtual int64_t Receive(std::vector<std::unique_ptr<FairMQMessage>>& msgVec, int timeout = -1) = 0;
 
     virtual void Close() = 0;
 

--- a/fairmq/nanomsg/FairMQSocketNN.cxx
+++ b/fairmq/nanomsg/FairMQSocketNN.cxx
@@ -119,18 +119,13 @@ void FairMQSocketNN::Connect(const string& address)
     }
 }
 
-int FairMQSocketNN::Send(FairMQMessagePtr& msg, const int timeout) { return SendImpl(msg, 0, timeout); }
-int FairMQSocketNN::Receive(FairMQMessagePtr& msg, const int timeout) { return ReceiveImpl(msg, 0, timeout); }
-int64_t FairMQSocketNN::Send(vector<unique_ptr<FairMQMessage>>& msgVec, const int timeout) { return SendImpl(msgVec, 0, timeout); }
-int64_t FairMQSocketNN::Receive(vector<unique_ptr<FairMQMessage>>& msgVec, const int timeout) { return ReceiveImpl(msgVec, 0, timeout); }
-
-int FairMQSocketNN::TrySend(FairMQMessagePtr& msg) { return SendImpl(msg, NN_DONTWAIT, 0); }
-int FairMQSocketNN::TryReceive(FairMQMessagePtr& msg) { return ReceiveImpl(msg, NN_DONTWAIT, 0); }
-int64_t FairMQSocketNN::TrySend(vector<unique_ptr<FairMQMessage>>& msgVec) { return SendImpl(msgVec, NN_DONTWAIT, 0); }
-int64_t FairMQSocketNN::TryReceive(vector<unique_ptr<FairMQMessage>>& msgVec) { return ReceiveImpl(msgVec, NN_DONTWAIT, 0); }
-
-int FairMQSocketNN::SendImpl(FairMQMessagePtr& msg, const int flags, const int timeout)
+int FairMQSocketNN::Send(FairMQMessagePtr& msg, const int timeout)
 {
+    int flags = 0;
+    if (timeout == 0)
+    {
+        flags = NN_DONTWAIT;
+    }
     int nbytes = -1;
     int elapsed = 0;
 
@@ -162,7 +157,7 @@ int FairMQSocketNN::SendImpl(FairMQMessagePtr& msg, const int flags, const int t
         {
             if (!fInterrupted && ((flags & NN_DONTWAIT) == 0))
             {
-                if (timeout)
+                if (timeout > 0)
                 {
                     elapsed += fSndTimeout;
                     if (elapsed >= timeout)
@@ -194,8 +189,13 @@ int FairMQSocketNN::SendImpl(FairMQMessagePtr& msg, const int flags, const int t
     }
 }
 
-int FairMQSocketNN::ReceiveImpl(FairMQMessagePtr& msg, const int flags, const int timeout)
+int FairMQSocketNN::Receive(FairMQMessagePtr& msg, const int timeout)
 {
+    int flags = 0;
+    if (timeout == 0)
+    {
+        flags = NN_DONTWAIT;
+    }
     int elapsed = 0;
 
     FairMQMessageNN* msgPtr = static_cast<FairMQMessageNN*>(msg.get());
@@ -216,7 +216,7 @@ int FairMQSocketNN::ReceiveImpl(FairMQMessagePtr& msg, const int flags, const in
         {
             if (!fInterrupted && ((flags & NN_DONTWAIT) == 0))
             {
-                if (timeout)
+                if (timeout > 0)
                 {
                     elapsed += fRcvTimeout;
                     if (elapsed >= timeout)
@@ -248,8 +248,13 @@ int FairMQSocketNN::ReceiveImpl(FairMQMessagePtr& msg, const int flags, const in
     }
 }
 
-int64_t FairMQSocketNN::SendImpl(vector<FairMQMessagePtr>& msgVec, const int flags, const int timeout)
+int64_t FairMQSocketNN::Send(vector<FairMQMessagePtr>& msgVec, const int timeout)
 {
+    int flags = 0;
+    if (timeout == 0)
+    {
+        flags = NN_DONTWAIT;
+    }
     const unsigned int vecSize = msgVec.size();
     int elapsed = 0;
 
@@ -286,7 +291,7 @@ int64_t FairMQSocketNN::SendImpl(vector<FairMQMessagePtr>& msgVec, const int fla
         {
             if (!fInterrupted && ((flags & NN_DONTWAIT) == 0))
             {
-                if (timeout)
+                if (timeout > 0)
                 {
                     elapsed += fSndTimeout;
                     if (elapsed >= timeout)
@@ -318,8 +323,13 @@ int64_t FairMQSocketNN::SendImpl(vector<FairMQMessagePtr>& msgVec, const int fla
     }
 }
 
-int64_t FairMQSocketNN::ReceiveImpl(vector<FairMQMessagePtr>& msgVec, const int flags, const int timeout)
+int64_t FairMQSocketNN::Receive(vector<FairMQMessagePtr>& msgVec, const int timeout)
 {
+    int flags = 0;
+    if (timeout == 0)
+    {
+        flags = NN_DONTWAIT;
+    }
     // Warn if the vector is filled before Receive() and empty it.
     // if (msgVec.size() > 0)
     // {
@@ -369,7 +379,7 @@ int64_t FairMQSocketNN::ReceiveImpl(vector<FairMQMessagePtr>& msgVec, const int 
         {
             if (!fInterrupted && ((flags & NN_DONTWAIT) == 0))
             {
-                if (timeout)
+                if (timeout > 0)
                 {
                     elapsed += fRcvTimeout;
                     if (elapsed >= timeout)

--- a/fairmq/nanomsg/FairMQSocketNN.h
+++ b/fairmq/nanomsg/FairMQSocketNN.h
@@ -27,15 +27,10 @@ class FairMQSocketNN final : public FairMQSocket
     bool Bind(const std::string& address) override;
     void Connect(const std::string& address) override;
 
-    int Send(FairMQMessagePtr& msg, const int timeout = 0) override;
-    int Receive(FairMQMessagePtr& msg, const int timeout = 0) override;
-    int64_t Send(std::vector<std::unique_ptr<FairMQMessage>>& msgVec, const int timeout = 0) override;
-    int64_t Receive(std::vector<std::unique_ptr<FairMQMessage>>& msgVec, const int timeout = 0) override;
-
-    int TrySend(FairMQMessagePtr& msg) override;
-    int TryReceive(FairMQMessagePtr& msg) override;
-    int64_t TrySend(std::vector<std::unique_ptr<FairMQMessage>>& msgVec) override;
-    int64_t TryReceive(std::vector<std::unique_ptr<FairMQMessage>>& msgVec) override;
+    int Send(FairMQMessagePtr& msg, const int timeout = -1) override;
+    int Receive(FairMQMessagePtr& msg, const int timeout = -1) override;
+    int64_t Send(std::vector<std::unique_ptr<FairMQMessage>>& msgVec, const int timeout = -1) override;
+    int64_t Receive(std::vector<std::unique_ptr<FairMQMessage>>& msgVec, const int timeout = -1) override;
 
     int GetSocket() const;
 
@@ -80,11 +75,6 @@ class FairMQSocketNN final : public FairMQSocket
     int fSndTimeout;
     int fRcvTimeout;
     int fLinger;
-
-    int SendImpl(FairMQMessagePtr& msg, const int flags, const int timeout);
-    int ReceiveImpl(FairMQMessagePtr& msg, const int flags, const int timeout);
-    int64_t SendImpl(std::vector<std::unique_ptr<FairMQMessage>>& msgVec, const int flags, const int timeout);
-    int64_t ReceiveImpl(std::vector<std::unique_ptr<FairMQMessage>>& msgVec, const int flags, const int timeout);
 };
 
 #endif /* FAIRMQSOCKETNN_H_ */

--- a/fairmq/shmem/FairMQSocketSHM.cxx
+++ b/fairmq/shmem/FairMQSocketSHM.cxx
@@ -111,18 +111,13 @@ void FairMQSocketSHM::Connect(const string& address)
     }
 }
 
-int FairMQSocketSHM::Send(FairMQMessagePtr& msg, const int timeout) { return SendImpl(msg, 0, timeout); }
-int FairMQSocketSHM::Receive(FairMQMessagePtr& msg, const int timeout) { return ReceiveImpl(msg, 0, timeout); }
-int64_t FairMQSocketSHM::Send(vector<unique_ptr<FairMQMessage>>& msgVec, const int timeout) { return SendImpl(msgVec, 0, timeout); }
-int64_t FairMQSocketSHM::Receive(vector<unique_ptr<FairMQMessage>>& msgVec, const int timeout) { return ReceiveImpl(msgVec, 0, timeout); }
-
-int FairMQSocketSHM::TrySend(FairMQMessagePtr& msg) { return SendImpl(msg, ZMQ_DONTWAIT, 0); }
-int FairMQSocketSHM::TryReceive(FairMQMessagePtr& msg) { return ReceiveImpl(msg, ZMQ_DONTWAIT, 0); }
-int64_t FairMQSocketSHM::TrySend(vector<unique_ptr<FairMQMessage>>& msgVec) { return SendImpl(msgVec, ZMQ_DONTWAIT, 0); }
-int64_t FairMQSocketSHM::TryReceive(vector<unique_ptr<FairMQMessage>>& msgVec) { return ReceiveImpl(msgVec, ZMQ_DONTWAIT, 0); }
-
-int FairMQSocketSHM::SendImpl(FairMQMessagePtr& msg, const int flags, const int timeout)
+int FairMQSocketSHM::Send(FairMQMessagePtr& msg, const int timeout)
 {
+    int flags = 0;
+    if (timeout == 0)
+    {
+        flags = ZMQ_DONTWAIT;
+    }
     int elapsed = 0;
 
     while (true && !fInterrupted)
@@ -146,7 +141,7 @@ int FairMQSocketSHM::SendImpl(FairMQMessagePtr& msg, const int flags, const int 
         {
             if (!fInterrupted && ((flags & ZMQ_DONTWAIT) == 0))
             {
-                if (timeout)
+                if (timeout > 0)
                 {
                     elapsed += fSndTimeout;
                     if (elapsed >= timeout)
@@ -176,8 +171,13 @@ int FairMQSocketSHM::SendImpl(FairMQMessagePtr& msg, const int flags, const int 
     return -1;
 }
 
-int FairMQSocketSHM::ReceiveImpl(FairMQMessagePtr& msg, const int flags, const int timeout)
+int FairMQSocketSHM::Receive(FairMQMessagePtr& msg, const int timeout)
 {
+    int flags = 0;
+    if (timeout == 0)
+    {
+        flags = ZMQ_DONTWAIT;
+    }
     int elapsed = 0;
 
     zmq_msg_t* msgPtr = static_cast<FairMQMessageSHM*>(msg.get())->GetMessage();
@@ -218,7 +218,7 @@ int FairMQSocketSHM::ReceiveImpl(FairMQMessagePtr& msg, const int flags, const i
         {
             if (!fInterrupted && ((flags & ZMQ_DONTWAIT) == 0))
             {
-                if (timeout)
+                if (timeout > 0)
                 {
                     elapsed += fRcvTimeout;
                     if (elapsed >= timeout)
@@ -246,13 +246,18 @@ int FairMQSocketSHM::ReceiveImpl(FairMQMessagePtr& msg, const int flags, const i
     }
 }
 
-int64_t FairMQSocketSHM::SendImpl(vector<FairMQMessagePtr>& msgVec, const int flags, const int timeout)
+int64_t FairMQSocketSHM::Send(vector<FairMQMessagePtr>& msgVec, const int timeout)
 {
+    int flags = 0;
+    if (timeout == 0)
+    {
+        flags = ZMQ_DONTWAIT;
+    }
     const unsigned int vecSize = msgVec.size();
     int elapsed = 0;
 
     if (vecSize == 1) {
-        return SendImpl(msgVec.back(), flags, timeout);
+        return Send(msgVec.back(), timeout);
     }
 
     // put it into zmq message
@@ -299,7 +304,7 @@ int64_t FairMQSocketSHM::SendImpl(vector<FairMQMessagePtr>& msgVec, const int fl
         {
             if (!fInterrupted && ((flags & ZMQ_DONTWAIT) == 0))
             {
-                if (timeout)
+                if (timeout > 0)
                 {
                     elapsed += fSndTimeout;
                     if (elapsed >= timeout)
@@ -334,8 +339,13 @@ int64_t FairMQSocketSHM::SendImpl(vector<FairMQMessagePtr>& msgVec, const int fl
     return -1;
 }
 
-int64_t FairMQSocketSHM::ReceiveImpl(vector<FairMQMessagePtr>& msgVec, const int flags, const int timeout)
+int64_t FairMQSocketSHM::Receive(vector<FairMQMessagePtr>& msgVec, const int timeout)
 {
+    int flags = 0;
+    if (timeout == 0)
+    {
+        flags = ZMQ_DONTWAIT;
+    }
     int elapsed = 0;
 
     zmq_msg_t zmqMsg;
@@ -392,7 +402,7 @@ int64_t FairMQSocketSHM::ReceiveImpl(vector<FairMQMessagePtr>& msgVec, const int
         {
             if (!fInterrupted && ((flags & ZMQ_DONTWAIT) == 0))
             {
-                if (timeout)
+                if (timeout > 0)
                 {
                     elapsed += fRcvTimeout;
                     if (elapsed >= timeout)

--- a/fairmq/shmem/FairMQSocketSHM.h
+++ b/fairmq/shmem/FairMQSocketSHM.h
@@ -28,15 +28,10 @@ class FairMQSocketSHM final : public FairMQSocket
     bool Bind(const std::string& address) override;
     void Connect(const std::string& address) override;
 
-    int Send(FairMQMessagePtr& msg, const int timeout = 0) override;
-    int Receive(FairMQMessagePtr& msg, const int timeout = 0) override;
-    int64_t Send(std::vector<std::unique_ptr<FairMQMessage>>& msgVec, const int timeout = 0) override;
-    int64_t Receive(std::vector<std::unique_ptr<FairMQMessage>>& msgVec, const int timeout = 0) override;
-
-    int TrySend(FairMQMessagePtr& msg) override;
-    int TryReceive(FairMQMessagePtr& msg) override;
-    int64_t TrySend(std::vector<std::unique_ptr<FairMQMessage>>& msgVec) override;
-    int64_t TryReceive(std::vector<std::unique_ptr<FairMQMessage>>& msgVec) override;
+    int Send(FairMQMessagePtr& msg, const int timeout = -1) override;
+    int Receive(FairMQMessagePtr& msg, const int timeout = -1) override;
+    int64_t Send(std::vector<std::unique_ptr<FairMQMessage>>& msgVec, const int timeout = -1) override;
+    int64_t Receive(std::vector<std::unique_ptr<FairMQMessage>>& msgVec, const int timeout = -1) override;
 
     void* GetSocket() const;
 
@@ -81,12 +76,6 @@ class FairMQSocketSHM final : public FairMQSocket
 
     int fSndTimeout;
     int fRcvTimeout;
-
-    int SendImpl(FairMQMessagePtr& msg, const int flags, const int timeout);
-    int ReceiveImpl(FairMQMessagePtr& msg, const int flags, const int timeout);
-
-    int64_t SendImpl(std::vector<std::unique_ptr<FairMQMessage>>& msgVec, const int flags, const int timeout);
-    int64_t ReceiveImpl(std::vector<std::unique_ptr<FairMQMessage>>& msgVec, const int flags, const int timeout);
 };
 
 #endif /* FAIRMQSOCKETSHM_H_ */

--- a/fairmq/zeromq/FairMQSocketZMQ.h
+++ b/fairmq/zeromq/FairMQSocketZMQ.h
@@ -28,15 +28,10 @@ class FairMQSocketZMQ final : public FairMQSocket
     bool Bind(const std::string& address) override;
     void Connect(const std::string& address) override;
 
-    int Send(FairMQMessagePtr& msg, const int timeout = 0) override;
-    int Receive(FairMQMessagePtr& msg, const int timeout = 0) override;
-    int64_t Send(std::vector<std::unique_ptr<FairMQMessage>>& msgVec, const int timeout = 0) override;
-    int64_t Receive(std::vector<std::unique_ptr<FairMQMessage>>& msgVec, const int timeout = 0) override;
-
-    int TrySend(FairMQMessagePtr& msg) override;
-    int TryReceive(FairMQMessagePtr& msg) override;
-    int64_t TrySend(std::vector<std::unique_ptr<FairMQMessage>>& msgVec) override;
-    int64_t TryReceive(std::vector<std::unique_ptr<FairMQMessage>>& msgVec) override;
+    int Send(FairMQMessagePtr& msg, const int timeout = -1) override;
+    int Receive(FairMQMessagePtr& msg, const int timeout = -1) override;
+    int64_t Send(std::vector<std::unique_ptr<FairMQMessage>>& msgVec, const int timeout = -1) override;
+    int64_t Receive(std::vector<std::unique_ptr<FairMQMessage>>& msgVec, const int timeout = -1) override;
 
     void* GetSocket() const;
 
@@ -80,12 +75,6 @@ class FairMQSocketZMQ final : public FairMQSocket
 
     int fSndTimeout;
     int fRcvTimeout;
-
-    int SendImpl(FairMQMessagePtr& msg, const int flags, const int timeout);
-    int ReceiveImpl(FairMQMessagePtr& msg, const int flags, const int timeout);
-
-    int64_t SendImpl(std::vector<std::unique_ptr<FairMQMessage>>& msgVec, const int flags, const int timeout);
-    int64_t ReceiveImpl(std::vector<std::unique_ptr<FairMQMessage>>& msgVec, const int flags, const int timeout);
 };
 
 #endif /* FAIRMQSOCKETZMQ_H_ */

--- a/test/helper/devices/TestTransferTimeout.h
+++ b/test/helper/devices/TestTransferTimeout.h
@@ -24,88 +24,132 @@ class TransferTimeout : public FairMQDevice
   protected:
     auto Run() -> void override
     {
-        bool sendMsgCanceling = false;
-        bool receiveMsgCanceling = false;
+        bool sendMsgCancelingAfter100ms = false;
+        bool receiveMsgCancelingAfter100ms = false;
+
+        bool sendMsgCancelingAfter0ms = false;
+        bool receiveMsgCancelingAfter0ms = false;
+
+        bool send1PartCancelingAfter100ms = false;
+        bool receive1PartCancelingAfter100ms = false;
+
+        bool send1PartCancelingAfter0ms = false;
+        bool receive1PartCancelingAfter0ms = false;
+
+        bool send2PartsCancelingAfter100ms = false;
+        bool receive2PartsCancelingAfter100ms = false;
+
+        bool send2PartsCancelingAfter0ms = false;
+        bool receive2PartsCancelingAfter0ms = false;
 
         FairMQMessagePtr msg1(NewMessage());
         FairMQMessagePtr msg2(NewMessage());
 
-        if (Send(msg1, "data-out", 0, 100) == -2)
-        {
-            LOG(info) << "send msg canceled";
-            sendMsgCanceling = true;
-        }
-        else
-        {
-            LOG(error) << "send msg did not cancel";
+        if (Send(msg1, "data-out", 0, 100) == -2) {
+            LOG(info) << "send msg canceled (100ms)";
+            sendMsgCancelingAfter100ms = true;
+        } else {
+            LOG(error) << "send msg did not cancel (100ms)";
         }
 
-        if (Receive(msg2, "data-in", 0, 100) == -2)
-        {
-            LOG(info) << "receive msg canceled";
-            receiveMsgCanceling = true;
-        }
-        else
-        {
-            LOG(error) << "receive msg did not cancel";
+        if (Receive(msg2, "data-in", 0, 100) == -2) {
+            LOG(info) << "receive msg canceled (100ms)";
+            receiveMsgCancelingAfter100ms = true;
+        } else {
+            LOG(error) << "receive msg did not cancel (100ms)";
         }
 
-        bool send1PartCanceling = false;
-        bool receive1PartCanceling = false;
+        if (Send(msg1, "data-out", 0, 0) == -2) {
+            LOG(info) << "send msg canceled (0ms)";
+            sendMsgCancelingAfter0ms = true;
+        } else {
+            LOG(error) << "send msg did not cancel (0ms)";
+        }
+
+        if (Receive(msg2, "data-in", 0, 0) == -2) {
+            LOG(info) << "receive msg canceled (0ms)";
+            receiveMsgCancelingAfter0ms = true;
+        } else {
+            LOG(error) << "receive msg did not cancel (0ms)";
+        }
 
         FairMQParts parts1;
         parts1.AddPart(NewMessage(10));
         FairMQParts parts2;
 
-        if (Send(parts1, "data-out", 0, 100) == -2)
-        {
-            LOG(info) << "send 1 part canceled";
-            send1PartCanceling = true;
-        }
-        else
-        {
-            LOG(error) << "send 1 part did not cancel";
+        if (Send(parts1, "data-out", 0, 100) == -2) {
+            LOG(info) << "send 1 part canceled (100ms)";
+            send1PartCancelingAfter100ms = true;
+        } else {
+            LOG(error) << "send 1 part did not cancel (100ms)";
         }
 
-        if (Receive(parts2, "data-in", 0, 100) == -2)
-        {
-            LOG(info) << "receive 1 part canceled";
-            receive1PartCanceling = true;
-        }
-        else
-        {
-            LOG(error) << "receive 1 part did not cancel";
+        if (Receive(parts2, "data-in", 0, 100) == -2) {
+            LOG(info) << "receive 1 part canceled (100ms)";
+            receive1PartCancelingAfter100ms = true;
+        } else {
+            LOG(error) << "receive 1 part did not cancel (100ms)";
         }
 
-        bool send2PartsCanceling = false;
-        bool receive2PartsCanceling = false;
+        if (Send(parts1, "data-out", 0, 0) == -2) {
+            LOG(info) << "send 1 part canceled (0ms)";
+            send1PartCancelingAfter0ms = true;
+        } else {
+            LOG(error) << "send 1 part did not cancel (0ms)";
+        }
+
+        if (Receive(parts2, "data-in", 0, 0) == -2) {
+            LOG(info) << "receive 1 part canceled (0ms)";
+            receive1PartCancelingAfter0ms = true;
+        } else {
+            LOG(error) << "receive 1 part did not cancel (0ms)";
+        }
 
         FairMQParts parts3;
         parts3.AddPart(NewMessage(10));
         parts3.AddPart(NewMessage(10));
         FairMQParts parts4;
 
-        if (Send(parts3, "data-out", 0, 100) == -2)
-        {
-            LOG(info) << "send 2 parts canceled";
-            send2PartsCanceling = true;
-        }
-        else
-        {
-            LOG(error) << "send 2 parts did not cancel";
+        if (Send(parts3, "data-out", 0, 100) == -2) {
+            LOG(info) << "send 2 parts canceled (100ms)";
+            send2PartsCancelingAfter100ms = true;
+        } else {
+            LOG(error) << "send 2 parts did not cancel (100ms)";
         }
 
-        if (Receive(parts4, "data-in", 0, 100) == -2)
-        {
-            LOG(info) << "receive 2 parts canceled";
-            receive2PartsCanceling = true;
-        }
-        else
-        {
-            LOG(error) << "receive 2 parts did not cancel";
+        if (Receive(parts4, "data-in", 0, 100) == -2) {
+            LOG(info) << "receive 2 parts canceled (100ms)";
+            receive2PartsCancelingAfter100ms = true;
+        } else {
+            LOG(error) << "receive 2 parts did not cancel (100ms)";
         }
 
-        if (sendMsgCanceling && receiveMsgCanceling && send1PartCanceling && receive1PartCanceling && send2PartsCanceling && receive2PartsCanceling)
+        if (Send(parts3, "data-out", 0, 0) == -2) {
+            LOG(info) << "send 2 parts canceled (0ms)";
+            send2PartsCancelingAfter0ms = true;
+        } else {
+            LOG(error) << "send 2 parts did not cancel (0ms)";
+        }
+
+        if (Receive(parts4, "data-in", 0, 0) == -2) {
+            LOG(info) << "receive 2 parts canceled (0ms)";
+            receive2PartsCancelingAfter0ms = true;
+        } else {
+            LOG(error) << "receive 2 parts did not cancel (0ms)";
+        }
+
+        if (sendMsgCancelingAfter100ms &&
+            receiveMsgCancelingAfter100ms &&
+            sendMsgCancelingAfter0ms &&
+            receiveMsgCancelingAfter0ms &&
+            send1PartCancelingAfter100ms &&
+            receive1PartCancelingAfter100ms &&
+            send1PartCancelingAfter0ms &&
+            receive1PartCancelingAfter0ms &&
+            send2PartsCancelingAfter100ms &&
+            receive2PartsCancelingAfter100ms &&
+            send2PartsCancelingAfter0ms &&
+            receive2PartsCancelingAfter0ms)
         {
             LOG(info) << "Transfer timeout test successfull";
         }


### PR DESCRIPTION
Deprecate Send-/ReceiveAsync, use timeout variant instead.

The naming of these methods is confusing and the logic can be expressed via the timeout value of 0.

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
