### PR TITLE
Allow plugins to create channels

### DIFF
--- a/fairmq/FairMQDevice.h
+++ b/fairmq/FairMQDevice.h
@@ -397,7 +397,11 @@ class FairMQDevice : public FairMQStateMachine
     void SetRawCmdLineArgs(const std::vector<std::string>& args) { fRawCmdLineArgs = args; }
     std::vector<std::string> GetRawCmdLineArgs() const { return fRawCmdLineArgs; }
 
-    void RunStateMachine() { ProcessWork(); };
+    void RunStateMachine()
+    {
+      CallStateChangeCallbacks(FairMQStateMachine::IDLE);
+      ProcessWork();
+    };
 
     /// Wait for the supplied amount of time or for interruption.
     /// If interrupted, returns false, otherwise true.

--- a/fairmq/FairMQStateMachine.cxx
+++ b/fairmq/FairMQStateMachine.cxx
@@ -175,12 +175,13 @@ struct Machine_ : public state_machine_def<Machine_>
     using initial_state = boost::mpl::vector<IDLE_FSM_STATE, OK_FSM_STATE>;
 
     template<typename Event, typename FSM>
-    void on_entry(Event const&, FSM& fsm)
+    void on_entry(Event const&, FSM& /*fsm*/)
     {
         LOG(state) << "Starting FairMQ state machine";
         fState = FairMQStateMachine::IDLE;
         LOG(state) << "Entering IDLE state";
-        fsm.CallStateChangeCallbacks(FairMQStateMachine::IDLE);
+        // fsm.CallStateChangeCallbacks(FairMQStateMachine::IDLE);
+        // we call this for now in FairMQDevice::RunStateMachine()
     }
 
     template<typename Event, typename FSM>

--- a/fairmq/PluginServices.h
+++ b/fairmq/PluginServices.h
@@ -186,13 +186,16 @@ class PluginServices
     auto SetProperty(const std::string& key, T val) -> void
     {
         auto currentState = GetCurrentDeviceState();
-        if (currentState == DeviceState::InitializingDevice)
+        if (   (currentState == DeviceState::InitializingDevice)
+            || ((currentState == DeviceState::Idle) && (key == "channel-config")))
         {
             fConfig.SetValue(key, val);
         }
         else
         {
-            throw InvalidStateError{tools::ToString("PluginServices::SetProperty is not supported in device state ", currentState, ". Supported state is ", DeviceState::InitializingDevice, ".")};
+            throw InvalidStateError{
+                tools::ToString("PluginServices::SetProperty is not supported in device state ", currentState, ". ",
+                                "Supported state is ", DeviceState::InitializingDevice, ".")};
         }
     }
     struct InvalidStateError : std::runtime_error { using std::runtime_error::runtime_error; };

--- a/fairmq/options/FairMQProgOptions.cxx
+++ b/fairmq/options/FairMQProgOptions.cxx
@@ -162,7 +162,7 @@ int FairMQProgOptions::ParseAll(const int argc, char const* const* argv, bool al
         else if (fVarMap.count("channel-config"))
         {
             LOG(debug) << "channel-config: Parsing channel configuration";
-            UpdateChannelMap(parser::SUBOPT().UserParser(fVarMap.at("channel-config").as<vector<string>>(), idForParser));
+            ParseChannelsFromCmdLine();
         }
         else
         {
@@ -183,6 +183,23 @@ int FairMQProgOptions::ParseAll(const int argc, char const* const* argv, bool al
     PrintOptions();
 
     return 0;
+}
+
+void FairMQProgOptions::ParseChannelsFromCmdLine()
+{
+    string idForParser;
+
+    // check if config-key for config parser is provided
+    if (fVarMap.count("config-key"))
+    {
+        idForParser = fVarMap["config-key"].as<string>();
+    }
+    else if (fVarMap.count("id"))
+    {
+        idForParser = fVarMap["id"].as<string>();
+    }
+
+    UpdateChannelMap(parser::SUBOPT().UserParser(fVarMap.at("channel-config").as<vector<string>>(), idForParser));
 }
 
 void FairMQProgOptions::ParseCmdLine(const int argc, char const* const* argv, bool allowUnregistered)

--- a/fairmq/options/FairMQProgOptions.h
+++ b/fairmq/options/FairMQProgOptions.h
@@ -59,13 +59,13 @@ class FairMQProgOptions
         // update variable map
         UpdateVarMap<typename std::decay<T>::type>(key, val);
 
-        // update FairMQChannel map if the key is a channel key
-        if (std::is_same<T, int>::value || std::is_same<T, std::string>::value)
+        if (key == "channel-config")
         {
-            if (fChannelKeyMap.count(key))
-            {
-                UpdateChannelValue(fChannelKeyMap.at(key).channel, fChannelKeyMap.at(key).index, fChannelKeyMap.at(key).member, val);
-            }
+            ParseChannelsFromCmdLine();
+        }
+        else if (fChannelKeyMap.count(key))
+        {
+            UpdateChannelValue(fChannelKeyMap.at(key).channel, fChannelKeyMap.at(key).index, fChannelKeyMap.at(key).member, val);
         }
 
         lock.unlock();
@@ -210,6 +210,12 @@ class FairMQProgOptions
     }
 
     int UpdateChannelMap(const FairMQChannelMap& map);
+    template<typename T>
+    int UpdateChannelValue(const std::string&, int, const std::string&, T)
+    {
+        LOG(error)  << "update of FairMQChannel map failed, because value type not supported";
+        return 1;
+    }
     int UpdateChannelValue(const std::string& channelName, int index, const std::string& member, const std::string& val);
     int UpdateChannelValue(const std::string& channelName, int index, const std::string& member, int val);
 
@@ -223,6 +229,7 @@ class FairMQProgOptions
         vm[key].value() = boost::any(val);
     }
 
+    void ParseChannelsFromCmdLine();
 };
 
 #endif /* FAIRMQPROGOPTIONS_H */


### PR DESCRIPTION
This also fixes a bug, that prevented the usage of custom types with the
plugin config API.

Example:

```cpp
// in DeviceState::Idle
vector<string> channels;
channels.push_back("name=asdf,method=bind,type=pull");
SetProperty("channel-config", channels);
```

This is a workaround for channel creation from plugins only. One should still configure the channels as usual in `DeviceState::InitializingDevice` via `SetProperty("chans.asdf.0.address", "tcp://...");` (In FairMQ 1.4 channels will be implicitely created, if a plugin sets properties on it).

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
