### PR TITLE
Avoid boost::uuids::entropy_error on some systems

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -4,6 +4,7 @@ Eulisse, Giulio
 Karabowicz, Radoslaw
 Kretz, Matthias <kretz@kde.org>
 Krzewicki, Mikolaj 
+Mrnjavac, Teo <teo.m@cern.ch>
 Neskovic, Gvozden
 Richter, Matthias
 Uhlig, Florian

--- a/fairmq/options/FairMQProgOptions.cxx
+++ b/fairmq/options/FairMQProgOptions.cxx
@@ -19,10 +19,9 @@
 #include "FairMQParser.h"
 #include "FairMQSuboptParser.h"
 
+#include "tools/Unique.h"
+
 #include <boost/algorithm/string.hpp> // join/split
-#include <boost/uuid/uuid.hpp>
-#include <boost/uuid/uuid_generators.hpp>
-#include <boost/uuid/uuid_io.hpp>
 
 #include <algorithm>
 #include <iomanip>
@@ -227,7 +226,7 @@ void FairMQProgOptions::ParseCmdLine(const int argc, char const* const* argv, bo
 
 void FairMQProgOptions::ParseDefaults()
 {
-    vector<string> emptyArgs = {"dummy", "--id", boost::uuids::to_string(boost::uuids::random_generator()())};
+    vector<string> emptyArgs = {"dummy", "--id", tools::Uuid()};
 
     vector<const char*> argv(emptyArgs.size());
 

--- a/fairmq/tools/Unique.cxx
+++ b/fairmq/tools/Unique.cxx
@@ -8,6 +8,10 @@
 
 #include <fairmq/tools/Unique.h>
 
+// We have to force boost::uuids to rely on /dev/*random instead of getrandom(2) or getentropy(3)
+// otherwise on some systems we'd get boost::uuids::entropy_error
+#define BOOST_UUID_RANDOM_PROVIDER_FORCE_POSIX
+
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>


### PR DESCRIPTION
This fixes an issue with `boost::uuids::random_generator` which only seems to happen on some systems. I've managed to reproduce it in a VM, with CC7.3 (which ships Linux 3.10). As it turns out, the kernel in question does not have `getrandom`, but `boost::uuids::random_generator` tries to use it anyway and fails miserably, throwing a `boost::uuids::entropy_error`.
Ultimately, this results in `[ERROR] Uncaught exception reached the top of main: getrandom` and it happens immediately on startup (tested with the fairmq-ex-1-n-1 example).

The safe and compatible option is to `#define BOOST_UUID_RANDOM_PROVIDER_FORCE_POSIX` so Boost uses plain `/dev/*random`.