### PR TITLE
Move Bind/Connect from FairMQDevice to FairMQChannel

### DIFF
--- a/fairmq/FairMQChannel.cxx
+++ b/fairmq/FairMQChannel.cxx
@@ -18,90 +18,65 @@
 #include <boost/algorithm/string.hpp> // join/split
 
 #include <set>
-#include <utility> // std::move
+#include <random>
 
 using namespace std;
 
 mutex FairMQChannel::fChannelMutex;
 
 FairMQChannel::FairMQChannel()
-    : fSocket(nullptr)
-    , fType("unspecified")
-    , fMethod("unspecified")
-    , fAddress("unspecified")
-    , fTransportType(fair::mq::Transport::DEFAULT)
-    , fSndBufSize(1000)
-    , fRcvBufSize(1000)
-    , fSndKernelSize(0)
-    , fRcvKernelSize(0)
-    , fLinger(500)
-    , fRateLogging(1)
-    , fName("")
-    , fIsValid(false)
-    , fTransportFactory(nullptr)
-    , fMultipart(false)
-    , fModified(true)
-    , fReset(false)
-{
-}
+    : FairMQChannel("", "unspecified", "unspecified", "unspecified", nullptr)
+{}
 
 FairMQChannel::FairMQChannel(const string& type, const string& method, const string& address)
-    : fSocket(nullptr)
+    : FairMQChannel("", type, method, address, nullptr)
+{}
+
+FairMQChannel::FairMQChannel(const string& name, const string& type, shared_ptr<FairMQTransportFactory> factory)
+    : FairMQChannel(name, type, "unspecified", "unspecified", factory)
+{}
+
+FairMQChannel::FairMQChannel(const string& name, const string& type, const string& method, const string& address, shared_ptr<FairMQTransportFactory> factory)
+    : fTransportFactory(factory)
+    , fTransportType(factory ? factory->GetType() : fair::mq::Transport::DEFAULT)
+    , fSocket(factory ? factory->CreateSocket(type, name) : nullptr)
     , fType(type)
     , fMethod(method)
     , fAddress(address)
-    , fTransportType(fair::mq::Transport::DEFAULT)
     , fSndBufSize(1000)
     , fRcvBufSize(1000)
     , fSndKernelSize(0)
     , fRcvKernelSize(0)
     , fLinger(500)
     , fRateLogging(1)
-    , fName("")
-    , fIsValid(false)
-    , fTransportFactory(nullptr)
-    , fMultipart(false)
-    , fModified(true)
-    , fReset(false)
-{
-}
-
-FairMQChannel::FairMQChannel(const string& name, const string& type, shared_ptr<FairMQTransportFactory> factory)
-    : fSocket(factory->CreateSocket(type, name))
-    , fType(type)
-    , fMethod("unspecified")
-    , fAddress("unspecified")
-    , fTransportType(factory->GetType())
-    , fSndBufSize(1000)
-    , fRcvBufSize(1000)
-    , fSndKernelSize(0)
-    , fRcvKernelSize(0)
-    , fLinger(500)
-    , fRateLogging(1)
+    , fPortRangeMin(22000)
+    , fPortRangeMax(23000)
+    , fAutoBind(true)
     , fName(name)
     , fIsValid(false)
-    , fTransportFactory(factory)
     , fMultipart(false)
     , fModified(true)
     , fReset(false)
-{
-}
+{}
 
 FairMQChannel::FairMQChannel(const FairMQChannel& chan)
-    : fSocket(nullptr)
+    : fTransportFactory(nullptr)
+    , fTransportType(chan.fTransportType)
+    , fSocket(nullptr)
     , fType(chan.fType)
     , fMethod(chan.fMethod)
     , fAddress(chan.fAddress)
-    , fTransportType(chan.fTransportType)
     , fSndBufSize(chan.fSndBufSize)
     , fRcvBufSize(chan.fRcvBufSize)
     , fSndKernelSize(chan.fSndKernelSize)
     , fRcvKernelSize(chan.fRcvKernelSize)
     , fLinger(chan.fLinger)
     , fRateLogging(chan.fRateLogging)
+    , fPortRangeMin(chan.fPortRangeMin)
+    , fPortRangeMax(chan.fPortRangeMax)
+    , fAutoBind(chan.fAutoBind)
     , fName(chan.fName)
     , fIsValid(false)
-    , fTransportFactory(nullptr)
     , fMultipart(chan.fMultipart)
     , fModified(chan.fModified)
     , fReset(false)
@@ -109,20 +84,23 @@ FairMQChannel::FairMQChannel(const FairMQChannel& chan)
 
 FairMQChannel& FairMQChannel::operator=(const FairMQChannel& chan)
 {
+    fTransportFactory = nullptr;
+    fTransportType = chan.fTransportType;
     fSocket = nullptr;
     fType = chan.fType;
     fMethod = chan.fMethod;
     fAddress = chan.fAddress;
-    fTransportType = chan.fTransportType;
     fSndBufSize = chan.fSndBufSize;
     fRcvBufSize = chan.fRcvBufSize;
     fSndKernelSize = chan.fSndKernelSize;
     fRcvKernelSize = chan.fRcvKernelSize;
     fLinger = chan.fLinger;
     fRateLogging = chan.fRateLogging;
+    fPortRangeMin = chan.fPortRangeMin;
+    fPortRangeMax = chan.fPortRangeMax;
+    fAutoBind = chan.fAutoBind;
     fName = chan.fName;
     fIsValid = false;
-    fTransportFactory = nullptr;
     fMultipart = chan.fMultipart;
     fModified = chan.fModified;
     fReset = false;
@@ -136,20 +114,23 @@ FairMQSocket & FairMQChannel::GetSocket() const
     return *fSocket;
 }
 
-string FairMQChannel::GetChannelName() const
+string FairMQChannel::GetName() const
 {
+    lock_guard<mutex> lock(fChannelMutex);
     return fName;
 }
 
-string FairMQChannel::GetChannelPrefix() const
+string FairMQChannel::GetPrefix() const
 {
+    lock_guard<mutex> lock(fChannelMutex);
     string prefix = fName;
     prefix = prefix.erase(fName.rfind('['));
     return prefix;
 }
 
-string FairMQChannel::GetChannelIndex() const
+string FairMQChannel::GetIndex() const
 {
+    lock_guard<mutex> lock(fChannelMutex);
     string indexStr = fName;
     indexStr.erase(indexStr.rfind(']'));
     indexStr.erase(0, indexStr.rfind('[') + 1);
@@ -243,6 +224,33 @@ try {
     return fRateLogging;
 } catch (exception& e) {
     LOG(error) << "Exception caught in FairMQChannel::GetRateLogging: " << e.what();
+    throw ChannelConfigurationError(fair::mq::tools::ToString("failed to acquire lock: ", e.what()));
+}
+
+int FairMQChannel::GetPortRangeMin() const
+try {
+    lock_guard<mutex> lock(fChannelMutex);
+    return fPortRangeMin;
+} catch (exception& e) {
+    LOG(error) << "Exception caught in FairMQChannel::GetPortRangeMin: " << e.what();
+    throw ChannelConfigurationError(fair::mq::tools::ToString("failed to acquire lock: ", e.what()));
+}
+
+int FairMQChannel::GetPortRangeMax() const
+try {
+    lock_guard<mutex> lock(fChannelMutex);
+    return fPortRangeMax;
+} catch (exception& e) {
+    LOG(error) << "Exception caught in FairMQChannel::GetPortRangeMax: " << e.what();
+    throw ChannelConfigurationError(fair::mq::tools::ToString("failed to acquire lock: ", e.what()));
+}
+
+bool FairMQChannel::GetAutoBind() const
+try {
+    lock_guard<mutex> lock(fChannelMutex);
+    return fAutoBind;
+} catch (exception& e) {
+    LOG(error) << "Exception caught in FairMQChannel::GetAutoBind: " << e.what();
     throw ChannelConfigurationError(fair::mq::tools::ToString("failed to acquire lock: ", e.what()));
 }
 
@@ -356,6 +364,39 @@ try {
     throw ChannelConfigurationError(fair::mq::tools::ToString("failed to acquire lock: ", e.what()));
 }
 
+void FairMQChannel::UpdatePortRangeMin(const int minPort)
+try {
+    lock_guard<mutex> lock(fChannelMutex);
+    fIsValid = false;
+    fPortRangeMin = minPort;
+    fModified = true;
+} catch (exception& e) {
+    LOG(error) << "Exception caught in FairMQChannel::UpdatePortRangeMin: " << e.what();
+    throw ChannelConfigurationError(fair::mq::tools::ToString("failed to acquire lock: ", e.what()));
+}
+
+void FairMQChannel::UpdatePortRangeMax(const int maxPort)
+try {
+    lock_guard<mutex> lock(fChannelMutex);
+    fIsValid = false;
+    fPortRangeMax = maxPort;
+    fModified = true;
+} catch (exception& e) {
+    LOG(error) << "Exception caught in FairMQChannel::UpdatePortRangeMax: " << e.what();
+    throw ChannelConfigurationError(fair::mq::tools::ToString("failed to acquire lock: ", e.what()));
+}
+
+void FairMQChannel::UpdateAutoBind(const bool autobind)
+try {
+    lock_guard<mutex> lock(fChannelMutex);
+    fIsValid = false;
+    fAutoBind = autobind;
+    fModified = true;
+} catch (exception& e) {
+    LOG(error) << "Exception caught in FairMQChannel::UpdateAutoBind: " << e.what();
+    throw ChannelConfigurationError(fair::mq::tools::ToString("failed to acquire lock: ", e.what()));
+}
+
 auto FairMQChannel::SetModified(const bool modified) -> void
 try {
     lock_guard<mutex> lock(fChannelMutex);
@@ -365,14 +406,14 @@ try {
     throw ChannelConfigurationError(fair::mq::tools::ToString("failed to acquire lock: ", e.what()));
 }
 
-void FairMQChannel::UpdateChannelName(const string& name)
+void FairMQChannel::UpdateName(const string& name)
 try {
     lock_guard<mutex> lock(fChannelMutex);
     fIsValid = false;
     fName = name;
     fModified = true;
 } catch (exception& e) {
-    LOG(error) << "Exception caught in FairMQChannel::UpdateChannelName: " << e.what();
+    LOG(error) << "Exception caught in FairMQChannel::UpdateName: " << e.what();
     throw ChannelConfigurationError(fair::mq::tools::ToString("failed to acquire lock: ", e.what()));
 }
 
@@ -385,14 +426,13 @@ try {
     throw ChannelConfigurationError(fair::mq::tools::ToString("failed to acquire lock: ", e.what()));
 }
 
-bool FairMQChannel::ValidateChannel()
+bool FairMQChannel::Validate()
 try {
     lock_guard<mutex> lock(fChannelMutex);
     stringstream ss;
     ss << "Validating channel '" << fName << "'... ";
 
-    if (fIsValid)
-    {
+    if (fIsValid) {
         ss << "ALREADY VALID";
         LOG(debug) << ss.str();
         return true;
@@ -400,8 +440,7 @@ try {
 
     // validate socket type
     const set<string> socketTypes{ "sub", "pub", "pull", "push", "req", "rep", "xsub", "xpub", "dealer", "router", "pair" };
-    if (socketTypes.find(fType) == socketTypes.end())
-    {
+    if (socketTypes.find(fType) == socketTypes.end()) {
         ss << "INVALID";
         LOG(debug) << ss.str();
         LOG(error) << "Invalid channel type: '" << fType << "'";
@@ -409,30 +448,22 @@ try {
     }
 
     // validate socket address
-    if (fAddress == "unspecified" || fAddress == "")
-    {
+    if (fAddress == "unspecified" || fAddress == "") {
         ss << "INVALID";
         LOG(debug) << ss.str();
         LOG(debug) << "invalid channel address: '" << fAddress << "'";
         return false;
-    }
-    else
-    {
+    } else {
         vector<string> endpoints;
         boost::algorithm::split(endpoints, fAddress, boost::algorithm::is_any_of(";"));
-        for (const auto endpoint : endpoints)
-        {
+        for (const auto endpoint : endpoints) {
             string address;
-            if (endpoint[0] == '@' || endpoint[0] == '+' || endpoint[0] == '>')
-            {
+            if (endpoint[0] == '@' || endpoint[0] == '+' || endpoint[0] == '>') {
                 address = endpoint.substr(1);
-            }
-            else
-            {
+            } else {
                 // we don't have a method modifier, check if the default method is set
                 const set<string> socketMethods{ "bind", "connect" };
-                if (socketMethods.find(fMethod) == socketMethods.end())
-                {
+                if (socketMethods.find(fMethod) == socketMethods.end()) {
                     ss << "INVALID";
                     LOG(debug) << ss.str();
                     LOG(error) << "Invalid endpoint connection method: '" << fMethod << "' for " << endpoint;
@@ -441,56 +472,43 @@ try {
                 address = endpoint;
             }
             // check if address is a tcp or ipc address
-            if (address.compare(0, 6, "tcp://") == 0)
-            {
+            if (address.compare(0, 6, "tcp://") == 0) {
                 // check if TCP address contains port delimiter
                 string addressString = address.substr(6);
-                if (addressString.find(':') == string::npos)
-                {
+                if (addressString.find(':') == string::npos) {
                     ss << "INVALID";
                     LOG(debug) << ss.str();
                     LOG(error) << "invalid channel address: '" << address << "' (missing port?)";
                     return false;
                 }
-            }
-            else if (address.compare(0, 6, "ipc://") == 0)
-            {
+            } else if (address.compare(0, 6, "ipc://") == 0) {
                 // check if IPC address is not empty
                 string addressString = address.substr(6);
-                if (addressString == "")
-                {
+                if (addressString == "") {
                     ss << "INVALID";
                     LOG(debug) << ss.str();
                     LOG(error) << "invalid channel address: '" << address << "' (empty IPC address?)";
                     return false;
                 }
-            }
-            else if (address.compare(0, 9, "inproc://") == 0)
-            {
+            } else if (address.compare(0, 9, "inproc://") == 0) {
                 // check if IPC address is not empty
                 string addressString = address.substr(9);
-                if (addressString == "")
-                {
+                if (addressString == "") {
                     ss << "INVALID";
                     LOG(debug) << ss.str();
                     LOG(error) << "invalid channel address: '" << address << "' (empty inproc address?)";
                     return false;
                 }
-            }
-            else if (address.compare(0, 8, "verbs://") == 0)
-            {
+            } else if (address.compare(0, 8, "verbs://") == 0) {
                 // check if IPC address is not empty
                 string addressString = address.substr(8);
-                if (addressString == "")
-                {
+                if (addressString == "") {
                     ss << "INVALID";
                     LOG(debug) << ss.str();
                     LOG(error) << "invalid channel address: '" << address << "' (empty verbs address?)";
                     return false;
                 }
-            }
-            else
-            {
+            } else {
                 // if neither TCP or IPC is specified, return invalid
                 ss << "INVALID";
                 LOG(debug) << ss.str();
@@ -501,8 +519,7 @@ try {
     }
 
     // validate socket buffer size for sending
-    if (fSndBufSize < 0)
-    {
+    if (fSndBufSize < 0) {
         ss << "INVALID";
         LOG(debug) << ss.str();
         LOG(error) << "invalid channel send buffer size (cannot be negative): '" << fSndBufSize << "'";
@@ -510,8 +527,7 @@ try {
     }
 
     // validate socket buffer size for receiving
-    if (fRcvBufSize < 0)
-    {
+    if (fRcvBufSize < 0) {
         ss << "INVALID";
         LOG(debug) << ss.str();
         LOG(error) << "invalid channel receive buffer size (cannot be negative): '" << fRcvBufSize << "'";
@@ -519,8 +535,7 @@ try {
     }
 
     // validate socket kernel transmit size for sending
-    if (fSndKernelSize < 0)
-    {
+    if (fSndKernelSize < 0) {
         ss << "INVALID";
         LOG(debug) << ss.str();
         LOG(error) << "invalid channel send kernel transmit size (cannot be negative): '" << fSndKernelSize << "'";
@@ -528,8 +543,7 @@ try {
     }
 
     // validate socket kernel transmit size for receiving
-    if (fRcvKernelSize < 0)
-    {
+    if (fRcvKernelSize < 0) {
         ss << "INVALID";
         LOG(debug) << ss.str();
         LOG(error) << "invalid channel receive kernel transmit size (cannot be negative): '" << fRcvKernelSize << "'";
@@ -537,8 +551,7 @@ try {
     }
 
     // validate socket rate logging interval
-    if (fRateLogging < 0)
-    {
+    if (fRateLogging < 0) {
         ss << "INVALID";
         LOG(debug) << ss.str();
         LOG(error) << "invalid socket rate logging interval (cannot be negative): '" << fRateLogging << "'";
@@ -554,10 +567,71 @@ try {
     throw ChannelConfigurationError(fair::mq::tools::ToString(e.what()));
 }
 
-void FairMQChannel::InitTransport(shared_ptr<FairMQTransportFactory> factory)
+void FairMQChannel::Init()
 {
-    fTransportFactory = factory;
-    fTransportType = factory->GetType();
+    lock_guard<mutex> lock(fChannelMutex);
+
+    fSocket = fTransportFactory->CreateSocket(fType, fName);
+
+    // set linger duration (how long socket should wait for outstanding transfers before shutdown)
+    fSocket->SetLinger(fLinger);
+
+    // set high water marks
+    fSocket->SetSndBufSize(fSndBufSize);
+    fSocket->SetRcvBufSize(fRcvBufSize);
+
+    // set kernel transmit size (set it only if value is not the default value)
+    if (fSndKernelSize != 0) {
+        fSocket->SetSndKernelSize(fSndKernelSize);
+    }
+    if (fRcvKernelSize != 0) {
+        fSocket->SetRcvKernelSize(fRcvKernelSize);
+    }
+}
+
+bool FairMQChannel::ConnectEndpoint(const string& endpoint)
+{
+    lock_guard<mutex> lock(fChannelMutex);
+
+    return fSocket->Connect(endpoint);
+}
+
+bool FairMQChannel::BindEndpoint(string& endpoint)
+{
+    lock_guard<mutex> lock(fChannelMutex);
+
+    // try to bind to the configured port. If it fails, try random one (if AutoBind is on).
+    if (fSocket->Bind(endpoint)) {
+        return true;
+    } else {
+        if (fAutoBind) {
+            // number of attempts when choosing a random port
+            int numAttempts = 0;
+            int maxAttempts = 1000;
+
+            // initialize random generator
+            default_random_engine generator(chrono::system_clock::now().time_since_epoch().count());
+            uniform_int_distribution<int> randomPort(fPortRangeMin, fPortRangeMax);
+
+            do {
+                LOG(debug) << "Could not bind to configured (TCP) port, trying random port in range " << fPortRangeMin << "-" << fPortRangeMax;
+                ++numAttempts;
+
+                if (numAttempts > maxAttempts) {
+                    LOG(error) << "could not bind to any (TCP) port in the given range after " << maxAttempts << " attempts";
+                    return false;
+                }
+
+                size_t pos = endpoint.rfind(':');
+                endpoint = endpoint.substr(0, pos + 1) + fair::mq::tools::ToString(static_cast<int>(randomPort(generator)));
+            } while (fSocket->Bind(endpoint));
+
+            return true;
+        } else {
+            return false;
+        }
+    }
+
 }
 
 void FairMQChannel::ResetChannel()
@@ -565,132 +639,4 @@ void FairMQChannel::ResetChannel()
     lock_guard<mutex> lock(fChannelMutex);
     fIsValid = false;
     // TODO: implement channel resetting
-}
-
-int FairMQChannel::Send(unique_ptr<FairMQMessage>& msg, int sndTimeoutInMs)
-{
-    CheckSendCompatibility(msg);
-    return fSocket->Send(msg, sndTimeoutInMs);
-}
-
-int FairMQChannel::Receive(unique_ptr<FairMQMessage>& msg, int rcvTimeoutInMs)
-{
-    CheckReceiveCompatibility(msg);
-    return fSocket->Receive(msg, rcvTimeoutInMs);
-}
-
-int FairMQChannel::SendAsync(unique_ptr<FairMQMessage>& msg)
-{
-    CheckSendCompatibility(msg);
-    return fSocket->Send(msg, 0);
-}
-
-int FairMQChannel::ReceiveAsync(unique_ptr<FairMQMessage>& msg)
-{
-    CheckReceiveCompatibility(msg);
-    return fSocket->Receive(msg, 0);
-}
-
-int64_t FairMQChannel::Send(vector<unique_ptr<FairMQMessage>>& msgVec, int sndTimeoutInMs)
-{
-    CheckSendCompatibility(msgVec);
-    return fSocket->Send(msgVec, sndTimeoutInMs);
-}
-
-int64_t FairMQChannel::Receive(vector<unique_ptr<FairMQMessage>>& msgVec, int rcvTimeoutInMs)
-{
-    CheckReceiveCompatibility(msgVec);
-    return fSocket->Receive(msgVec, rcvTimeoutInMs);
-}
-
-int64_t FairMQChannel::SendAsync(vector<unique_ptr<FairMQMessage>>& msgVec)
-{
-    CheckSendCompatibility(msgVec);
-    return fSocket->Send(msgVec, 0);
-}
-
-int64_t FairMQChannel::ReceiveAsync(vector<unique_ptr<FairMQMessage>>& msgVec)
-{
-    CheckReceiveCompatibility(msgVec);
-    return fSocket->Receive(msgVec, 0);
-}
-
-FairMQChannel::~FairMQChannel()
-{
-}
-
-unsigned long FairMQChannel::GetBytesTx() const
-{
-    return fSocket->GetBytesTx();
-}
-
-unsigned long FairMQChannel::GetBytesRx() const
-{
-    return fSocket->GetBytesRx();
-}
-
-unsigned long FairMQChannel::GetMessagesTx() const
-{
-    return fSocket->GetMessagesTx();
-}
-
-unsigned long FairMQChannel::GetMessagesRx() const
-{
-    return fSocket->GetMessagesRx();
-}
-
-void FairMQChannel::CheckSendCompatibility(FairMQMessagePtr& msg)
-{
-    if (fTransportType != msg->GetType())
-    {
-        // LOG(debug) << "Channel type does not match message type. Creating wrapper";
-        FairMQMessagePtr msgWrapper(NewMessage(msg->GetData(),
-                                               msg->GetSize(),
-                                               [](void* /*data*/, void* _msg) { delete static_cast<FairMQMessage*>(_msg); },
-                                               msg.get()
-                                               ));
-        msg.release();
-        msg = move(msgWrapper);
-    }
-}
-
-void FairMQChannel::CheckSendCompatibility(vector<FairMQMessagePtr>& msgVec)
-{
-    for (auto& msg : msgVec)
-    {
-        if (fTransportType != msg->GetType())
-        {
-            // LOG(debug) << "Channel type does not match message type. Creating wrapper";
-            FairMQMessagePtr msgWrapper(NewMessage(msg->GetData(),
-                                                   msg->GetSize(),
-                                                   [](void* /*data*/, void* _msg) { delete static_cast<FairMQMessage*>(_msg); },
-                                                   msg.get()
-                                                   ));
-            msg.release();
-            msg = move(msgWrapper);
-        }
-    }
-}
-
-void FairMQChannel::CheckReceiveCompatibility(FairMQMessagePtr& msg)
-{
-    if (fTransportType != msg->GetType())
-    {
-        // LOG(debug) << "Channel type does not match message type. Creating wrapper";
-        FairMQMessagePtr newMsg(NewMessage());
-        msg = move(newMsg);
-    }
-}
-
-void FairMQChannel::CheckReceiveCompatibility(vector<FairMQMessagePtr>& msgVec)
-{
-    for (auto& msg : msgVec)
-    {
-        if (fTransportType != msg->GetType())
-        {
-            // LOG(debug) << "Channel type does not match message type. Creating wrapper";
-            FairMQMessagePtr newMsg(NewMessage());
-            msg = move(newMsg);
-        }
-    }
 }

--- a/fairmq/FairMQDevice.h
+++ b/fairmq/FairMQDevice.h
@@ -81,10 +81,6 @@ class FairMQDevice : public FairMQStateMachine
     /// @param reindex Should reindexing be done
     void SortChannel(const std::string& name, const bool reindex = true);
 
-    /// Prints channel configuration
-    /// @param name Name of the channel
-    void PrintChannel(const std::string& name);
-
     template<typename Serializer, typename DataType, typename... Args>
     void Serialize(FairMQMessage& msg, DataType&& data, Args&&... args) const
     {
@@ -373,12 +369,6 @@ class FairMQDevice : public FairMQStateMachine
     void SetNumIoThreads(int numIoThreads) { fConfig->SetValue<int>("io-threads", numIoThreads);}
     int GetNumIoThreads() const { return fConfig->GetValue<int>("io-threads"); }
 
-    void SetPortRangeMin(int portRangeMin) { fConfig->SetValue<int>("port-range-min", portRangeMin); }
-    int GetPortRangeMin() const { return fConfig->GetValue<int>("port-range-min"); }
-
-    void SetPortRangeMax(int portRangeMax) { fConfig->SetValue<int>("port-range-max", portRangeMax); }
-    int GetPortRangeMax() const { return fConfig->GetValue<int>("port-range-max"); }
-
     void SetNetworkInterface(const std::string& networkInterface) { fConfig->SetValue<std::string>("network-interface", networkInterface); }
     std::string GetNetworkInterface() const { return fConfig->GetValue<std::string>("network-interface"); }
 
@@ -458,9 +448,6 @@ class FairMQDevice : public FairMQStateMachine
     virtual void Reset();
 
   private:
-    int fPortRangeMin; ///< Minimum value for the port range (if dynamic)
-    int fPortRangeMax; ///< Maximum value for the port range (if dynamic)
-
     fair::mq::Transport fDefaultTransportType; ///< Default transport for the device
 
     /// Handles the initialization and the Init() method
@@ -484,15 +471,6 @@ class FairMQDevice : public FairMQStateMachine
 
     /// Attach (bind/connect) channels in the list
     void AttachChannels(std::vector<FairMQChannel*>& chans);
-
-    /// Sets up and connects/binds a socket to an endpoint
-    /// return a string with the actual endpoint if it happens
-    /// to stray from default.
-    bool ConnectEndpoint(FairMQSocket& socket, std::string& endpoint);
-    bool BindEndpoint(FairMQSocket& socket, std::string& endpoint);
-    /// Attaches the channel to all listed endpoints
-    /// the list is comma separated; the default method (bind/connect) is used.
-    /// to override default: prepend "@" to bind, "+" or ">" to connect endpoint.
     bool AttachChannel(FairMQChannel& ch);
 
     void HandleSingleChannelInput();

--- a/fairmq/FairMQSocket.h
+++ b/fairmq/FairMQSocket.h
@@ -23,7 +23,7 @@ class FairMQSocket
     virtual std::string GetId() = 0;
 
     virtual bool Bind(const std::string& address) = 0;
-    virtual void Connect(const std::string& address) = 0;
+    virtual bool Connect(const std::string& address) = 0;
 
     virtual int Send(FairMQMessagePtr& msg, int timeout = -1) = 0;
     virtual int Receive(FairMQMessagePtr& msg, int timeout = -1) = 0;

--- a/fairmq/nanomsg/FairMQSocketNN.cxx
+++ b/fairmq/nanomsg/FairMQSocketNN.cxx
@@ -99,24 +99,26 @@ bool FairMQSocketNN::Bind(const string& address)
 {
     // LOG(info) << "bind socket " << fId << " on " << address;
 
-    int eid = nn_bind(fSocket, address.c_str());
-    if (eid < 0)
+    if (nn_bind(fSocket, address.c_str()) < 0)
     {
         LOG(error) << "failed binding socket " << fId << ", reason: " << nn_strerror(errno);
         return false;
     }
+
     return true;
 }
 
-void FairMQSocketNN::Connect(const string& address)
+bool FairMQSocketNN::Connect(const string& address)
 {
     // LOG(info) << "connect socket " << fId << " to " << address;
 
-    int eid = nn_connect(fSocket, address.c_str());
-    if (eid < 0)
+    if (nn_connect(fSocket, address.c_str()) < 0)
     {
         LOG(error) << "failed connecting socket " << fId << ", reason: " << nn_strerror(errno);
+        return false;
     }
+
+    return true;
 }
 
 int FairMQSocketNN::Send(FairMQMessagePtr& msg, const int timeout)

--- a/fairmq/nanomsg/FairMQSocketNN.h
+++ b/fairmq/nanomsg/FairMQSocketNN.h
@@ -25,7 +25,7 @@ class FairMQSocketNN final : public FairMQSocket
     std::string GetId() override;
 
     bool Bind(const std::string& address) override;
-    void Connect(const std::string& address) override;
+    bool Connect(const std::string& address) override;
 
     int Send(FairMQMessagePtr& msg, const int timeout = -1) override;
     int Receive(FairMQMessagePtr& msg, const int timeout = -1) override;

--- a/fairmq/ofi/Socket.cxx
+++ b/fairmq/ofi/Socket.cxx
@@ -107,13 +107,14 @@ catch (const SocketError& e)
     return false;
 }
 
-auto Socket::Connect(const string& address) -> void
+auto Socket::Connect(const string& address) -> bool
 {
     auto addr = Context::VerifyAddress(address);
     ConnectControlSocket(addr);
     fContext.InitOfi(ConnectionType::Connect, addr);
     InitDataEndpoint();
     fWaitingForControlPeer = true;
+    return true;
 }
 
 auto Socket::BindControlSocket(Context::Address address) -> void

--- a/fairmq/ofi/Socket.h
+++ b/fairmq/ofi/Socket.h
@@ -42,7 +42,7 @@ class Socket final : public fair::mq::Socket
     auto GetId() -> std::string { return fId; }
 
     auto Bind(const std::string& address) -> bool override;
-    auto Connect(const std::string& address) -> void override;
+    auto Connect(const std::string& address) -> bool override;
 
     auto Send(MessagePtr& msg, int timeout = 0) -> int override;
     auto Receive(MessagePtr& msg, int timeout = 0) -> int override;

--- a/fairmq/options/FairMQParser.cxx
+++ b/fairmq/options/FairMQParser.cxx
@@ -32,8 +32,7 @@ namespace parser
 // function that convert property tree (given the json structure) to FairMQChannelMap
 FairMQChannelMap ptreeToMQMap(const boost::property_tree::ptree& pt, const string& id, const string& rootNode)
 {
-    if (id == "")
-    {
+    if (id == "") {
         throw ParserError("no device ID provided. Provide with `--id` cmd option");
     }
 
@@ -44,8 +43,7 @@ FairMQChannelMap ptreeToMQMap(const boost::property_tree::ptree& pt, const strin
     // Extract value from boost::property_tree
     Helper::DeviceParser(pt.get_child(rootNode), channelMap, id);
 
-    if (channelMap.empty())
-    {
+    if (channelMap.empty()) {
         LOG(warn) << "---- No channel keys found for " << id;
         LOG(warn) << "---- Check the JSON inputs and/or command line inputs";
     }
@@ -68,20 +66,14 @@ void PrintDeviceList(const boost::property_tree::ptree& tree)
     string deviceIdKey;
 
     // do a first loop just to print the device-id in json input
-    for (const auto& p : tree)
-    {
-        if (p.first == "devices")
-        {
-            for (const auto& q : p.second.get_child(""))
-            {
+    for (const auto& p : tree) {
+        if (p.first == "devices") {
+            for (const auto& q : p.second.get_child("")) {
                 string key = q.second.get<string>("key", "");
-                if (key != "")
-                {
+                if (key != "") {
                     deviceIdKey = key;
                     LOG(debug) << "Found config for device key '" << deviceIdKey << "' in JSON input";
-                }
-                else
-                {
+                } else {
                     deviceIdKey = q.second.get<string>("id");
                     LOG(debug) << "Found config for device id '" << deviceIdKey << "' in JSON input";
                 }
@@ -95,33 +87,26 @@ void DeviceParser(const boost::property_tree::ptree& tree, FairMQChannelMap& cha
     string deviceIdKey;
 
     // For each node in fairMQOptions
-    for (const auto& p : tree)
-    {
-        if (p.first == "devices")
-        {
-            for (const auto& q : p.second)
-            {
+    for (const auto& p : tree) {
+        if (p.first == "devices") {
+            for (const auto& q : p.second) {
                 // check if key is provided, otherwise use id
                 string key = q.second.get<string>("key", "");
 
-                if (key != "")
-                {
+                if (key != "") {
                     deviceIdKey = key;
-                    // LOG(debug) << "Found config for device key '" << deviceIdKey << "' in JSON input";
-                }
-                else
-                {
+                    // LOG(trace) << "Found config for device key '" << deviceIdKey << "' in JSON input";
+                } else {
                     deviceIdKey = q.second.get<string>("id");
-                    // LOG(debug) << "Found config for device id '" << deviceIdKey << "' in JSON input";
+                    // LOG(trace) << "Found config for device id '" << deviceIdKey << "' in JSON input";
                 }
 
                 // if not correct device id, do not fill MQMap
-                if (deviceId != deviceIdKey)
-                {
+                if (deviceId != deviceIdKey) {
                     continue;
                 }
 
-                LOG(debug) << "Found following channels for device ID '" << deviceId << "' :";
+                LOG(trace) << "Found following channels for device ID '" << deviceId << "' :";
 
                 ChannelParser(q.second, channelMap);
             }
@@ -133,12 +118,9 @@ void ChannelParser(const boost::property_tree::ptree& tree, FairMQChannelMap& ch
 {
     string channelKey;
 
-    for (const auto& p : tree)
-    {
-        if (p.first == "channels")
-        {
-            for (const auto& q : p.second)
-            {
+    for (const auto& p : tree) {
+        if (p.first == "channels") {
+            for (const auto& q : p.second) {
                 channelKey = q.second.get<string>("name");
 
                 int numSockets = q.second.get<int>("numSockets", 0);
@@ -154,36 +136,37 @@ void ChannelParser(const boost::property_tree::ptree& tree, FairMQChannelMap& ch
                 commonChannel.UpdateSndKernelSize(q.second.get<int>("sndKernelSize", commonChannel.GetSndKernelSize()));
                 commonChannel.UpdateRcvKernelSize(q.second.get<int>("rcvKernelSize", commonChannel.GetRcvKernelSize()));
                 commonChannel.UpdateLinger(q.second.get<int>("linger", commonChannel.GetLinger()));
-                commonChannel.UpdateRateLogging(q.second.get<int>("rateLogging", commonChannel.GetRateLogging()));
+                commonChannel.UpdatePortRangeMin(q.second.get<int>("portRangeMin", commonChannel.GetPortRangeMin()));
+                commonChannel.UpdatePortRangeMax(q.second.get<int>("portRangeMax", commonChannel.GetPortRangeMax()));
+                commonChannel.UpdateAutoBind(q.second.get<bool>("autoBind", commonChannel.GetAutoBind()));
 
                 // temporary FairMQChannel container
                 vector<FairMQChannel> channelList;
 
-                if (numSockets > 0)
-                {
-                    LOG(debug) << "" << channelKey << ":";
-                    LOG(debug) << "\tnumSockets of " << numSockets << " specified,";
-                    LOG(debug) << "\tapplying common settings to each:";
+                if (numSockets > 0) {
+                    LOG(trace) << "" << channelKey << ":";
+                    LOG(trace) << "\tnumSockets of " << numSockets << " specified,";
+                    LOG(trace) << "\tapplying common settings to each:";
 
-                    LOG(debug) << "\ttype          = " << commonChannel.GetType();
-                    LOG(debug) << "\tmethod        = " << commonChannel.GetMethod();
-                    LOG(debug) << "\taddress       = " << commonChannel.GetAddress();
-                    LOG(debug) << "\ttransport     = " << commonChannel.GetTransportName();
-                    LOG(debug) << "\tsndBufSize    = " << commonChannel.GetSndBufSize();
-                    LOG(debug) << "\trcvBufSize    = " << commonChannel.GetRcvBufSize();
-                    LOG(debug) << "\tsndKernelSize = " << commonChannel.GetSndKernelSize();
-                    LOG(debug) << "\trcvKernelSize = " << commonChannel.GetRcvKernelSize();
-                    LOG(debug) << "\tlinger        = " << commonChannel.GetLinger();
-                    LOG(debug) << "\trateLogging   = " << commonChannel.GetRateLogging();
+                    LOG(trace) << "\ttype          = " << commonChannel.GetType();
+                    LOG(trace) << "\tmethod        = " << commonChannel.GetMethod();
+                    LOG(trace) << "\taddress       = " << commonChannel.GetAddress();
+                    LOG(trace) << "\ttransport     = " << commonChannel.GetTransportName();
+                    LOG(trace) << "\tsndBufSize    = " << commonChannel.GetSndBufSize();
+                    LOG(trace) << "\trcvBufSize    = " << commonChannel.GetRcvBufSize();
+                    LOG(trace) << "\tsndKernelSize = " << commonChannel.GetSndKernelSize();
+                    LOG(trace) << "\trcvKernelSize = " << commonChannel.GetRcvKernelSize();
+                    LOG(trace) << "\tlinger        = " << commonChannel.GetLinger();
+                    LOG(trace) << "\trateLogging   = " << commonChannel.GetRateLogging();
+                    LOG(trace) << "\tportRangeMin  = " << commonChannel.GetPortRangeMin();
+                    LOG(trace) << "\tportRangeMax  = " << commonChannel.GetPortRangeMax();
+                    LOG(trace) << "\tautoBind      = " << commonChannel.GetAutoBind();
 
-                    for (int i = 0; i < numSockets; ++i)
-                    {
+                    for (int i = 0; i < numSockets; ++i) {
                         FairMQChannel channel(commonChannel);
                         channelList.push_back(channel);
                     }
-                }
-                else
-                {
+                } else {
                     SocketParser(q.second.get_child(""), channelList, channelKey, commonChannel);
                 }
 
@@ -198,12 +181,9 @@ void SocketParser(const boost::property_tree::ptree& tree, vector<FairMQChannel>
     // for each socket in channel
     int socketCounter = 0;
 
-    for (const auto& p : tree)
-    {
-        if (p.first == "sockets")
-        {
-            for (const auto& q : p.second)
-            {
+    for (const auto& p : tree) {
+        if (p.first == "sockets") {
+            for (const auto& q : p.second) {
                 // create new channel and apply setting from the common channel
                 FairMQChannel channel(commonChannel);
 
@@ -218,18 +198,24 @@ void SocketParser(const boost::property_tree::ptree& tree, vector<FairMQChannel>
                 channel.UpdateRcvKernelSize(q.second.get<int>("rcvKernelSize", channel.GetRcvKernelSize()));
                 channel.UpdateLinger(q.second.get<int>("linger", channel.GetLinger()));
                 channel.UpdateRateLogging(q.second.get<int>("rateLogging", channel.GetRateLogging()));
+                channel.UpdatePortRangeMin(q.second.get<int>("portRangeMin", channel.GetPortRangeMin()));
+                channel.UpdatePortRangeMax(q.second.get<int>("portRangeMax", channel.GetPortRangeMax()));
+                channel.UpdateAutoBind(q.second.get<bool>("autoBind", channel.GetAutoBind()));
 
-                LOG(debug) << "" << channelName << "[" << socketCounter << "]:";
-                LOG(debug) << "\ttype          = " << channel.GetType();
-                LOG(debug) << "\tmethod        = " << channel.GetMethod();
-                LOG(debug) << "\taddress       = " << channel.GetAddress();
-                LOG(debug) << "\ttransport     = " << channel.GetTransportName();
-                LOG(debug) << "\tsndBufSize    = " << channel.GetSndBufSize();
-                LOG(debug) << "\trcvBufSize    = " << channel.GetRcvBufSize();
-                LOG(debug) << "\tsndKernelSize = " << channel.GetSndKernelSize();
-                LOG(debug) << "\trcvKernelSize = " << channel.GetRcvKernelSize();
-                LOG(debug) << "\tlinger        = " << channel.GetLinger();
-                LOG(debug) << "\trateLogging   = " << channel.GetRateLogging();
+                LOG(trace) << "" << channelName << "[" << socketCounter << "]:";
+                LOG(trace) << "\ttype          = " << channel.GetType();
+                LOG(trace) << "\tmethod        = " << channel.GetMethod();
+                LOG(trace) << "\taddress       = " << channel.GetAddress();
+                LOG(trace) << "\ttransport     = " << channel.GetTransportName();
+                LOG(trace) << "\tsndBufSize    = " << channel.GetSndBufSize();
+                LOG(trace) << "\trcvBufSize    = " << channel.GetRcvBufSize();
+                LOG(trace) << "\tsndKernelSize = " << channel.GetSndKernelSize();
+                LOG(trace) << "\trcvKernelSize = " << channel.GetRcvKernelSize();
+                LOG(trace) << "\tlinger        = " << channel.GetLinger();
+                LOG(trace) << "\trateLogging   = " << channel.GetRateLogging();
+                LOG(trace) << "\tportRangeMin  = " << channel.GetPortRangeMin();
+                LOG(trace) << "\tportRangeMax  = " << channel.GetPortRangeMax();
+                LOG(trace) << "\tautoBind      = " << channel.GetAutoBind();
 
                 channelList.push_back(channel);
                 ++socketCounter;
@@ -237,28 +223,28 @@ void SocketParser(const boost::property_tree::ptree& tree, vector<FairMQChannel>
         }
     } // end socket loop
 
-    if (socketCounter)
-    {
-        LOG(debug) << "Found " << socketCounter << " socket(s) in channel.";
-    }
-    else
-    {
-        LOG(debug) << "" << channelName << ":";
-        LOG(debug) << "\tNo sockets specified,";
-        LOG(debug) << "\tapplying common settings to the channel:";
+    if (socketCounter) {
+        LOG(trace) << "Found " << socketCounter << " socket(s) in channel.";
+    } else {
+        LOG(trace) << "" << channelName << ":";
+        LOG(trace) << "\tNo sockets specified,";
+        LOG(trace) << "\tapplying common settings to the channel:";
 
         FairMQChannel channel(commonChannel);
 
-        LOG(debug) << "\ttype          = " << channel.GetType();
-        LOG(debug) << "\tmethod        = " << channel.GetMethod();
-        LOG(debug) << "\taddress       = " << channel.GetAddress();
-        LOG(debug) << "\ttransport     = " << channel.GetTransportName();
-        LOG(debug) << "\tsndBufSize    = " << channel.GetSndBufSize();
-        LOG(debug) << "\trcvBufSize    = " << channel.GetRcvBufSize();
-        LOG(debug) << "\tsndKernelSize = " << channel.GetSndKernelSize();
-        LOG(debug) << "\trcvKernelSize = " << channel.GetRcvKernelSize();
-        LOG(debug) << "\tlinger        = " << channel.GetLinger();
-        LOG(debug) << "\trateLogging   = " << channel.GetRateLogging();
+        LOG(trace) << "\ttype          = " << channel.GetType();
+        LOG(trace) << "\tmethod        = " << channel.GetMethod();
+        LOG(trace) << "\taddress       = " << channel.GetAddress();
+        LOG(trace) << "\ttransport     = " << channel.GetTransportName();
+        LOG(trace) << "\tsndBufSize    = " << channel.GetSndBufSize();
+        LOG(trace) << "\trcvBufSize    = " << channel.GetRcvBufSize();
+        LOG(trace) << "\tsndKernelSize = " << channel.GetSndKernelSize();
+        LOG(trace) << "\trcvKernelSize = " << channel.GetRcvKernelSize();
+        LOG(trace) << "\tlinger        = " << channel.GetLinger();
+        LOG(trace) << "\trateLogging   = " << channel.GetRateLogging();
+        LOG(trace) << "\tportRangeMin  = " << channel.GetPortRangeMin();
+        LOG(trace) << "\tportRangeMax  = " << channel.GetPortRangeMax();
+        LOG(trace) << "\tautoBind      = " << channel.GetAutoBind();
 
         channelList.push_back(channel);
     }

--- a/fairmq/options/FairMQProgOptions.h
+++ b/fairmq/options/FairMQProgOptions.h
@@ -218,6 +218,7 @@ class FairMQProgOptions
     }
     int UpdateChannelValue(const std::string& channelName, int index, const std::string& member, const std::string& val);
     int UpdateChannelValue(const std::string& channelName, int index, const std::string& member, int val);
+    int UpdateChannelValue(const std::string& channelName, int index, const std::string& member, bool val);
 
     void UpdateChannelInfo();
 

--- a/fairmq/options/FairMQSuboptParser.h
+++ b/fairmq/options/FairMQSuboptParser.h
@@ -58,6 +58,9 @@ struct SUBOPT
         RCVKERNELSIZE,
         LINGER,
         RATELOGGING,    // logging rate
+        PORTRANGEMIN,
+        PORTRANGEMAX,
+        AUTOBIND,
         NUMSOCKETS,
         lastsocketkey
     };
@@ -74,6 +77,9 @@ struct SUBOPT
         /*[RCVKERNELSIZE] = */ "rcvKernelSize",
         /*[LINGER]        = */ "linger",
         /*[RATELOGGING]   = */ "rateLogging",
+        /*[PORTRANGEMIN]  = */ "portRangeMin",
+        /*[PORTRANGEMAX]  = */ "portRangeMax",
+        /*[AUTOBIND]      = */ "autoBind",
         /*[NUMSOCKETS]    = */ "numSockets",
         nullptr
     };

--- a/fairmq/shmem/FairMQSocketSHM.cxx
+++ b/fairmq/shmem/FairMQSocketSHM.cxx
@@ -99,16 +99,17 @@ bool FairMQSocketSHM::Bind(const string& address)
     return true;
 }
 
-void FairMQSocketSHM::Connect(const string& address)
+bool FairMQSocketSHM::Connect(const string& address)
 {
     // LOG(info) << "connect socket " << fId << " on " << address;
 
     if (zmq_connect(fSocket, address.c_str()) != 0)
     {
         LOG(error) << "Failed connecting socket " << fId << ", reason: " << zmq_strerror(errno);
-        // error here means incorrect configuration. exit if it happens.
-        exit(EXIT_FAILURE);
+        return false;
     }
+
+    return true;
 }
 
 int FairMQSocketSHM::Send(FairMQMessagePtr& msg, const int timeout)

--- a/fairmq/shmem/FairMQSocketSHM.h
+++ b/fairmq/shmem/FairMQSocketSHM.h
@@ -26,7 +26,7 @@ class FairMQSocketSHM final : public FairMQSocket
     std::string GetId() override { return fId; }
 
     bool Bind(const std::string& address) override;
-    void Connect(const std::string& address) override;
+    bool Connect(const std::string& address) override;
 
     int Send(FairMQMessagePtr& msg, const int timeout = -1) override;
     int Receive(FairMQMessagePtr& msg, const int timeout = -1) override;

--- a/fairmq/tools/Process.cxx
+++ b/fairmq/tools/Process.cxx
@@ -13,6 +13,7 @@
 #include <iostream>
 #include <sstream>
 #include <thread>
+#include <stdexcept>
 
 using namespace std;
 namespace bp = boost::process;

--- a/fairmq/zeromq/FairMQSocketZMQ.cxx
+++ b/fairmq/zeromq/FairMQSocketZMQ.cxx
@@ -91,19 +91,21 @@ bool FairMQSocketZMQ::Bind(const string& address)
         LOG(error) << "Failed binding socket " << fId << ", reason: " << zmq_strerror(errno);
         return false;
     }
+
     return true;
 }
 
-void FairMQSocketZMQ::Connect(const string& address)
+bool FairMQSocketZMQ::Connect(const string& address)
 {
     // LOG(info) << "connect socket " << fId << " on " << address;
 
     if (zmq_connect(fSocket, address.c_str()) != 0)
     {
         LOG(error) << "Failed connecting socket " << fId << ", reason: " << zmq_strerror(errno);
-        // error here means incorrect configuration. exit if it happens.
-        exit(EXIT_FAILURE);
+        return false;
     }
+
+    return true;
 }
 
 int FairMQSocketZMQ::Send(FairMQMessagePtr& msg, const int timeout)

--- a/fairmq/zeromq/FairMQSocketZMQ.h
+++ b/fairmq/zeromq/FairMQSocketZMQ.h
@@ -26,7 +26,7 @@ class FairMQSocketZMQ final : public FairMQSocket
     std::string GetId() override;
 
     bool Bind(const std::string& address) override;
-    void Connect(const std::string& address) override;
+    bool Connect(const std::string& address) override;
 
     int Send(FairMQMessagePtr& msg, const int timeout = -1) override;
     int Receive(FairMQMessagePtr& msg, const int timeout = -1) override;

--- a/test/channel/_channel.cxx
+++ b/test/channel/_channel.cxx
@@ -21,76 +21,76 @@ using namespace fair::mq;
 TEST(Channel, Validation)
 {
     FairMQChannel channel;
-    ASSERT_THROW(channel.ValidateChannel(), FairMQChannel::ChannelConfigurationError);
+    ASSERT_THROW(channel.Validate(), FairMQChannel::ChannelConfigurationError);
 
     channel.UpdateType("pair");
-    ASSERT_EQ(channel.ValidateChannel(), false);
+    ASSERT_EQ(channel.Validate(), false);
     ASSERT_EQ(channel.IsValid(), false);
 
     channel.UpdateAddress("bla");
-    ASSERT_THROW(channel.ValidateChannel(), FairMQChannel::ChannelConfigurationError);
+    ASSERT_THROW(channel.Validate(), FairMQChannel::ChannelConfigurationError);
 
     channel.UpdateMethod("connect");
-    ASSERT_EQ(channel.ValidateChannel(), false);
+    ASSERT_EQ(channel.Validate(), false);
     ASSERT_EQ(channel.IsValid(), false);
 
     channel.UpdateAddress("ipc://");
-    ASSERT_EQ(channel.ValidateChannel(), false);
+    ASSERT_EQ(channel.Validate(), false);
     ASSERT_EQ(channel.IsValid(), false);
 
     channel.UpdateAddress("verbs://");
-    ASSERT_EQ(channel.ValidateChannel(), false);
+    ASSERT_EQ(channel.Validate(), false);
     ASSERT_EQ(channel.IsValid(), false);
 
     channel.UpdateAddress("inproc://");
-    ASSERT_EQ(channel.ValidateChannel(), false);
+    ASSERT_EQ(channel.Validate(), false);
     ASSERT_EQ(channel.IsValid(), false);
 
     channel.UpdateAddress("tcp://");
-    ASSERT_EQ(channel.ValidateChannel(), false);
+    ASSERT_EQ(channel.Validate(), false);
     ASSERT_EQ(channel.IsValid(), false);
 
     channel.UpdateAddress("tcp://localhost:5555");
-    ASSERT_EQ(channel.ValidateChannel(), true);
+    ASSERT_EQ(channel.Validate(), true);
     ASSERT_EQ(channel.IsValid(), true);
 
     channel.UpdateSndBufSize(-1);
-    ASSERT_THROW(channel.ValidateChannel(), FairMQChannel::ChannelConfigurationError);
+    ASSERT_THROW(channel.Validate(), FairMQChannel::ChannelConfigurationError);
     channel.UpdateSndBufSize(1000);
-    ASSERT_NO_THROW(channel.ValidateChannel());
+    ASSERT_NO_THROW(channel.Validate());
 
     channel.UpdateRcvBufSize(-1);
-    ASSERT_THROW(channel.ValidateChannel(), FairMQChannel::ChannelConfigurationError);
+    ASSERT_THROW(channel.Validate(), FairMQChannel::ChannelConfigurationError);
     channel.UpdateRcvBufSize(1000);
-    ASSERT_NO_THROW(channel.ValidateChannel());
+    ASSERT_NO_THROW(channel.Validate());
 
     channel.UpdateSndKernelSize(-1);
-    ASSERT_THROW(channel.ValidateChannel(), FairMQChannel::ChannelConfigurationError);
+    ASSERT_THROW(channel.Validate(), FairMQChannel::ChannelConfigurationError);
     channel.UpdateSndKernelSize(1000);
-    ASSERT_NO_THROW(channel.ValidateChannel());
+    ASSERT_NO_THROW(channel.Validate());
 
     channel.UpdateRcvKernelSize(-1);
-    ASSERT_THROW(channel.ValidateChannel(), FairMQChannel::ChannelConfigurationError);
+    ASSERT_THROW(channel.Validate(), FairMQChannel::ChannelConfigurationError);
     channel.UpdateRcvKernelSize(1000);
-    ASSERT_NO_THROW(channel.ValidateChannel());
+    ASSERT_NO_THROW(channel.Validate());
 
     channel.UpdateRateLogging(-1);
-    ASSERT_THROW(channel.ValidateChannel(), FairMQChannel::ChannelConfigurationError);
+    ASSERT_THROW(channel.Validate(), FairMQChannel::ChannelConfigurationError);
     channel.UpdateRateLogging(1);
-    ASSERT_NO_THROW(channel.ValidateChannel());
+    ASSERT_NO_THROW(channel.Validate());
 
     FairMQChannel channel2 = channel;
-    ASSERT_NO_THROW(channel2.ValidateChannel());
-    ASSERT_EQ(channel2.ValidateChannel(), true);
+    ASSERT_NO_THROW(channel2.Validate());
+    ASSERT_EQ(channel2.Validate(), true);
     ASSERT_EQ(channel2.IsValid(), true);
-    ASSERT_EQ(channel2.ValidateChannel(), true);
+    ASSERT_EQ(channel2.Validate(), true);
 
     channel2.UpdateChannelName("Kanal");
     ASSERT_EQ(channel2.GetChannelName(), "Kanal");
 
     channel2.ResetChannel();
     ASSERT_EQ(channel2.IsValid(), false);
-    ASSERT_EQ(channel2.ValidateChannel(), true);
+    ASSERT_EQ(channel2.Validate(), true);
 }
 
 } /* namespace */

--- a/test/protocols/_push_pull_multipart.cxx
+++ b/test/protocols/_push_pull_multipart.cxx
@@ -39,8 +39,8 @@ auto RunSingleThreadedMultipart(string transport, string address) -> void {
 
     // TODO validate that fTransportFactory is not nullptr
     // TODO validate that fSocket is not nullptr
-    ASSERT_TRUE(push.ValidateChannel());
-    ASSERT_TRUE(pull.ValidateChannel());
+    ASSERT_TRUE(push.Validate());
+    ASSERT_TRUE(pull.Validate());
 
     {
         auto sentMsg = FairMQParts{};
@@ -76,7 +76,7 @@ auto RunMultiThreadedMultipart(string transport, string address) -> void
     pull.Connect(address);
 
     auto pusher = thread{[&push](){
-        ASSERT_TRUE(push.ValidateChannel());
+        ASSERT_TRUE(push.Validate());
 
         auto sentMsg = FairMQParts{};
         sentMsg.AddPart(push.NewSimpleMessage("1"));
@@ -87,7 +87,7 @@ auto RunMultiThreadedMultipart(string transport, string address) -> void
     }};
 
     auto puller = thread{[&pull](){
-        ASSERT_TRUE(pull.ValidateChannel());
+        ASSERT_TRUE(pull.Validate());
 
         auto receivedMsg = FairMQParts{};
         ASSERT_GE(pull.Receive(receivedMsg), 0);


### PR DESCRIPTION
- Move BindEndpoint/ConnectEndpoint to FairMQChannel (#101).
- Use delegating constructors in FairMQChannel.
- Allow setting port range for dynamic binding per-channel, instead of per-device.
- Make dynamic binding optional (on by default).
- Formatting.
- Move short methods from source file to header file.
- Remove `PrintChannel()` from FairMQDevice, it is unused and outdated, if needed it can become a method of FairMQChannel.
- Change return type of `Connect()` in the transport interface - from void to bool.

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
