### PR TITLE
fix a forward declaration

### DIFF
--- a/fairmq/tools/Network.h
+++ b/fairmq/tools/Network.h
@@ -18,8 +18,7 @@ namespace boost
 namespace asio
 {
 
-class io_context;
-typedef class io_context io_service;
+class io_service;
 
 } // namespace asio
 } // namespace boost


### PR DESCRIPTION
compile error:

```
 from fairmq/fairmq/tools/Network.cxx:24:
/opt/fairsoft/oct17p1/include/boost/asio/io_service.hpp:39:7: error: using typedef-name ‘boost::asio::io_service’ after ‘class’
 class io_service;
       ^~~~~~~~~~
In file included from fairmq/fairmq/tools/Network.cxx:9:0:
fairmq/fairmq/tools/Network.h:22:26: note: ‘boost::asio::io_service’ has a previous declaration here
 typedef class io_context io_service;
                          ^~~~~~~~~~
```


boost version 1.64

Signed-off-by: Gvozden Neskovic <neskovic@compeng.uni-frankfurt.de>

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
