### PR TITLE
Add test for FairMQMessage::Rebuild

### DIFF
--- a/fairmq/FairMQMessage.h
+++ b/fairmq/FairMQMessage.h
@@ -35,7 +35,6 @@ class FairMQMessage
     FairMQTransportFactory* GetTransport() { return fTransport; }
     //void SetTransport(FairMQTransportFactory* transport) { fTransport = transport; }
 
-    virtual void Copy(const std::unique_ptr<FairMQMessage>& msg) __attribute__((deprecated("Use 'Copy(const FairMQMessage& msg)'"))) = 0;
     virtual void Copy(const FairMQMessage& msg) = 0;
 
     virtual ~FairMQMessage() {};

--- a/fairmq/nanomsg/FairMQMessageNN.cxx
+++ b/fairmq/nanomsg/FairMQMessageNN.cxx
@@ -205,30 +205,6 @@ void FairMQMessageNN::Copy(const FairMQMessage& msg)
     }
 }
 
-void FairMQMessageNN::Copy(const FairMQMessagePtr& msg)
-{
-    if (fMessage)
-    {
-        if (nn_freemsg(fMessage) < 0)
-        {
-            LOG(error) << "failed freeing message, reason: " << nn_strerror(errno);
-        }
-    }
-
-    size_t size = msg->GetSize();
-
-    fMessage = nn_allocmsg(size, 0);
-    if (!fMessage)
-    {
-        LOG(error) << "failed allocating message, reason: " << nn_strerror(errno);
-    }
-    else
-    {
-        memcpy(fMessage, static_cast<FairMQMessageNN*>(msg.get())->GetMessage(), size);
-        fSize = size;
-    }
-}
-
 void FairMQMessageNN::CloseMessage()
 {
     if (nn_freemsg(fMessage) < 0)

--- a/fairmq/nanomsg/FairMQMessageNN.h
+++ b/fairmq/nanomsg/FairMQMessageNN.h
@@ -49,7 +49,6 @@ class FairMQMessageNN final : public FairMQMessage
     fair::mq::Transport GetType() const override;
 
     void Copy(const FairMQMessage& msg) override;
-    void Copy(const FairMQMessagePtr& msg) override;
 
     ~FairMQMessageNN() override;
 

--- a/fairmq/nanomsg/FairMQSocketNN.cxx
+++ b/fairmq/nanomsg/FairMQSocketNN.cxx
@@ -88,7 +88,7 @@ FairMQSocketNN::FairMQSocketNN(const string& type, const string& name, const str
     }
 #endif
 
-    // LOG(info) << "created socket " << fId;
+    LOG(debug) << "Created socket " << GetId();
 }
 
 string FairMQSocketNN::GetId()

--- a/fairmq/ofi/Message.cxx
+++ b/fairmq/ofi/Message.cxx
@@ -138,11 +138,6 @@ auto Message::Copy(const fair::mq::Message& /*msg*/) -> void
     throw MessageError{"Not yet implemented."};
 }
 
-auto Message::Copy(const fair::mq::MessagePtr& /*msg*/) -> void
-{
-    throw MessageError{"Not yet implemented."};
-}
-
 Message::~Message()
 {
     if (fFreeFunction) {

--- a/fairmq/ofi/Message.h
+++ b/fairmq/ofi/Message.h
@@ -53,7 +53,6 @@ class Message final : public fair::mq::Message
     auto GetType() const -> fair::mq::Transport override { return fair::mq::Transport::OFI; }
 
     auto Copy(const fair::mq::Message& msg) -> void override;
-    auto Copy(const fair::mq::MessagePtr& msg) -> void override;
 
     ~Message() override;
 

--- a/fairmq/shmem/FairMQMessageSHM.cxx
+++ b/fairmq/shmem/FairMQMessageSHM.cxx
@@ -346,7 +346,7 @@ void FairMQMessageSHM::CloseMessage()
         if (fRegionId == 0)
         {
             fManager.Segment().deallocate(fManager.Segment().get_address_from_handle(fHandle));
-            fHandle = 0;
+            fHandle = -1;
         }
         else
         {
@@ -402,6 +402,7 @@ void FairMQMessageSHM::CloseMessage()
         {
             LOG(error) << "failed closing message, reason: " << zmq_strerror(errno);
         }
+        fMetaCreated = false;
     }
 }
 

--- a/fairmq/shmem/FairMQMessageSHM.cxx
+++ b/fairmq/shmem/FairMQMessageSHM.cxx
@@ -316,29 +316,6 @@ void FairMQMessageSHM::Copy(const FairMQMessage& msg)
     }
 }
 
-void FairMQMessageSHM::Copy(const FairMQMessagePtr& msg)
-{
-    if (fHandle < 0)
-    {
-        bipc::managed_shared_memory::handle_t otherHandle = static_cast<FairMQMessageSHM*>(msg.get())->fHandle;
-        if (otherHandle)
-        {
-            if (InitializeChunk(msg->GetSize()))
-            {
-                memcpy(GetData(), msg->GetData(), msg->GetSize());
-            }
-        }
-        else
-        {
-            LOG(error) << "copy fail: source message not initialized!";
-        }
-    }
-    else
-    {
-        LOG(error) << "copy fail: target message already initialized!";
-    }
-}
-
 void FairMQMessageSHM::CloseMessage()
 {
     if (fHandle >= 0 && !fQueued)

--- a/fairmq/shmem/FairMQMessageSHM.h
+++ b/fairmq/shmem/FairMQMessageSHM.h
@@ -47,7 +47,6 @@ class FairMQMessageSHM final : public FairMQMessage
     fair::mq::Transport GetType() const override;
 
     void Copy(const FairMQMessage& msg) override;
-    void Copy(const FairMQMessagePtr& msg) override;
 
     ~FairMQMessageSHM() override;
 

--- a/fairmq/shmem/FairMQSocketSHM.cxx
+++ b/fairmq/shmem/FairMQSocketSHM.cxx
@@ -81,7 +81,7 @@ FairMQSocketSHM::FairMQSocketSHM(Manager& manager, const string& type, const str
         throw fair::mq::SocketError("PUB/SUB socket type is not supported for shared memory transport");
     }
 
-    // LOG(info) << "created socket " << fId;
+    LOG(debug) << "Created socket " << GetId();
 }
 
 bool FairMQSocketSHM::Bind(const string& address)

--- a/fairmq/zeromq/FairMQMessageZMQ.cxx
+++ b/fairmq/zeromq/FairMQMessageZMQ.cxx
@@ -220,24 +220,6 @@ void FairMQMessageZMQ::Copy(const FairMQMessage& msg)
     }
 }
 
-void FairMQMessageZMQ::Copy(const FairMQMessagePtr& msg)
-{
-    FairMQMessageZMQ* msgPtr = static_cast<FairMQMessageZMQ*>(msg.get());
-    // Shares the message buffer between msg and this fMsg.
-    if (zmq_msg_copy(fMsg.get(), msgPtr->GetMessage()) != 0)
-    {
-        LOG(error) << "failed copying message, reason: " << zmq_strerror(errno);
-        return;
-    }
-
-    // if the target message has been resized, apply same to this message also
-    if (msgPtr->fUsedSizeModified)
-    {
-        fUsedSizeModified = true;
-        fUsedSize = msgPtr->fUsedSize;
-    }
-}
-
 void FairMQMessageZMQ::CloseMessage()
 {
     if (!fViewMsg)

--- a/fairmq/zeromq/FairMQMessageZMQ.h
+++ b/fairmq/zeromq/FairMQMessageZMQ.h
@@ -49,7 +49,6 @@ class FairMQMessageZMQ final : public FairMQMessage
 
     fair::mq::Transport GetType() const override;
 
-    void Copy(const FairMQMessagePtr& msg) override;
     void Copy(const FairMQMessage& msg) override;
 
     ~FairMQMessageZMQ() override;

--- a/fairmq/zeromq/FairMQSocketZMQ.cxx
+++ b/fairmq/zeromq/FairMQSocketZMQ.cxx
@@ -71,7 +71,7 @@ FairMQSocketZMQ::FairMQSocketZMQ(const string& type, const string& name, const s
         }
     }
 
-    // LOG(info) << "created socket " << fId;
+    LOG(debug) << "Created socket " << GetId();
 }
 
 string FairMQSocketZMQ::GetId()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -74,14 +74,14 @@ add_testsuite(FairMQ.Parts
     TIMEOUT 5
 )
 
-add_testsuite(FairMQ.MessageResize
+add_testsuite(FairMQ.Message
     SOURCES
     ${CMAKE_CURRENT_BINARY_DIR}/runner.cxx
-    message_resize/_message_resize.cxx
+    message/_message.cxx
 
     LINKS FairMQ
     INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}
-             ${CMAKE_CURRENT_SOURCE_DIR}/message_resize
+             ${CMAKE_CURRENT_SOURCE_DIR}/message
              ${CMAKE_CURRENT_BINARY_DIR}
     TIMEOUT 5
     ${definitions}


### PR DESCRIPTION
- Fix bug in shmem CloseMessage (occurs when Rebuild is used).
- Add test for FairMQMessage::Rebuild.
- Remove previously deprecated Copy method (since 1 year).

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
