### PR TITLE
Allow implicit conversion factory->resource

### DIFF
--- a/fairmq/FairMQTransportFactory.h
+++ b/fairmq/FairMQTransportFactory.h
@@ -43,6 +43,7 @@ class FairMQTransportFactory
 
     /// Get a pointer to the associated polymorphic memory resource
     fair::mq::ChannelResource* GetMemoryResource() { return &fMemoryResource; }
+    operator fair::mq::ChannelResource*() { return &fMemoryResource; }
 
     /// @brief Create empty FairMQMessage
     /// @return pointer to FairMQMessage

--- a/test/memory_resources/_memory_resources.cxx
+++ b/test/memory_resources/_memory_resources.cxx
@@ -127,10 +127,11 @@ TEST(MemoryResources, getMessage_test)
         v.emplace_back(5);
         v.emplace_back(6);
         void* vectorBeginPtr = &v[0];
-        message = getMessage(std::move(v), allocSHM);
+        message = getMessage(std::move(v), *factorySHM);
         EXPECT_TRUE(message != nullptr);
         EXPECT_TRUE(message->GetData() != vectorBeginPtr);
     }
+
     EXPECT_TRUE(message->GetSize() == 3 * sizeof(testData));
     messageArray = static_cast<int*>(message->GetData());
     EXPECT_TRUE(messageArray[0] == 4 && messageArray[1] == 5 && messageArray[2] == 6);


### PR DESCRIPTION
reduces boilerplate in many places, logic is clear: factory can be treated like a memory resource where appropriate.