### PR TITLE
Remove obsolete dependency to boost signals v1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,7 @@ find_package(Threads REQUIRED)
 
 if(BUILD_FAIRMQ)
   find_package2(PUBLIC Boost VERSION 1.64 REQUIRED
-    COMPONENTS container program_options thread system filesystem regex date_time signals
+    COMPONENTS container program_options thread system filesystem regex date_time
   )
   find_package2(PUBLIC FairLogger VERSION 1.2.0 REQUIRED)
   find_package2(PRIVATE ZeroMQ VERSION 4.1.5 REQUIRED)

--- a/fairmq/CMakeLists.txt
+++ b/fairmq/CMakeLists.txt
@@ -248,7 +248,6 @@ target_link_libraries(${_target}
   Boost::filesystem
   Boost::regex
   Boost::date_time
-  Boost::signals
   FairLogger::FairLogger
 
   PRIVATE # only libFairMQ links against private dependencies


### PR DESCRIPTION
Needed to support Boost 1.69, which dropped the signals v1 library. Anyways, we are not using it any more, so we can just remove the dependency.