### PR TITLE
Remove controller input for several tests

### DIFF
--- a/test/device/TestReceiver.h
+++ b/test/device/TestReceiver.h
@@ -38,12 +38,9 @@ class Receiver : public FairMQDevice
     auto Run() -> void override
     {
         auto msg = FairMQMessagePtr{NewMessage()};
-        if (Receive(msg, fChannelName) >= 0)
-        {
+        if (Receive(msg, fChannelName) >= 0) {
             LOG(info) << "received empty message";
-        }
-        else
-        {
+        } else {
             LOG(error) << "fair::mq::test::Receiver::Run(): Receive(msg, fChannelName) < 0";
         }
     };

--- a/test/device/TestSender.h
+++ b/test/device/TestSender.h
@@ -38,12 +38,9 @@ class Sender : public FairMQDevice
     auto Run() -> void override
     {
         auto msg = FairMQMessagePtr{NewMessage()};
-        if (Send(msg, fChannelName) >= 0)
-        {
+        if (Send(msg, fChannelName) >= 0) {
             LOG(info) << "sent empty message";
-        }
-        else
-        {
+        } else {
             LOG(error) << "fair::mq::test::Sender::Run(): Send(msg, fChannelName) < 0";
         }
     };

--- a/test/device/_error_state.cxx
+++ b/test/device/_error_state.cxx
@@ -23,7 +23,7 @@ using namespace std;
 using namespace fair::mq::test;
 using namespace fair::mq::tools;
 
-void RunErrorStateIn(const std::string& state, const std::string& input = "")
+void RunErrorStateIn(const string& state, const string& control, const string& input = "")
 {
     size_t session{fair::mq::tools::UuidHash()};
 
@@ -32,7 +32,7 @@ void RunErrorStateIn(const std::string& state, const std::string& input = "")
         stringstream cmd;
         cmd << runTestDevice
             << " --id error_state_" << state << "_"
-            << " --control " << ((input == "") ? "static" : "interactive")
+            << " --control " << control
             << " --session " << session
             << " --color false";
         result = execute(cmd.str(), "[ErrorFound IN " + state + "]", input);
@@ -40,110 +40,82 @@ void RunErrorStateIn(const std::string& state, const std::string& input = "")
 
     device_thread.join();
 
-    ASSERT_NE(std::string::npos, result.console_out.find("going to change to Error state from " + state + "()"));
+    ASSERT_NE(string::npos, result.console_out.find("going to change to Error state from " + state + "()"));
 
     exit(result.exit_code);
 }
 
 TEST(ErrorState, static_InInit)
 {
-    EXPECT_EXIT(RunErrorStateIn("Init"), ::testing::ExitedWithCode(1), "");
+    EXPECT_EXIT(RunErrorStateIn("Init", "static"), ::testing::ExitedWithCode(1), "");
 }
 TEST(ErrorState, static_InBind)
 {
-    EXPECT_EXIT(RunErrorStateIn("Bind"), ::testing::ExitedWithCode(1), "");
+    EXPECT_EXIT(RunErrorStateIn("Bind", "static"), ::testing::ExitedWithCode(1), "");
 }
 TEST(ErrorState, static_InConnect)
 {
-    EXPECT_EXIT(RunErrorStateIn("Connect"), ::testing::ExitedWithCode(1), "");
+    EXPECT_EXIT(RunErrorStateIn("Connect", "static"), ::testing::ExitedWithCode(1), "");
 }
 TEST(ErrorState, static_InInitTask)
 {
-    EXPECT_EXIT(RunErrorStateIn("InitTask"), ::testing::ExitedWithCode(1), "");
+    EXPECT_EXIT(RunErrorStateIn("InitTask", "static"), ::testing::ExitedWithCode(1), "");
 }
 TEST(ErrorState, static_InPreRun)
 {
-    EXPECT_EXIT(RunErrorStateIn("PreRun"), ::testing::ExitedWithCode(1), "");
+    EXPECT_EXIT(RunErrorStateIn("PreRun", "static"), ::testing::ExitedWithCode(1), "");
 }
 TEST(ErrorState, static_InRun)
 {
-    EXPECT_EXIT(RunErrorStateIn("Run"), ::testing::ExitedWithCode(1), "");
+    EXPECT_EXIT(RunErrorStateIn("Run", "static"), ::testing::ExitedWithCode(1), "");
 }
 TEST(ErrorState, static_InPostRun)
 {
-    EXPECT_EXIT(RunErrorStateIn("PostRun"), ::testing::ExitedWithCode(1), "");
+    EXPECT_EXIT(RunErrorStateIn("PostRun", "static"), ::testing::ExitedWithCode(1), "");
 }
 TEST(ErrorState, static_InResetTask)
 {
-    EXPECT_EXIT(RunErrorStateIn("ResetTask"), ::testing::ExitedWithCode(1), "");
+    EXPECT_EXIT(RunErrorStateIn("ResetTask", "static"), ::testing::ExitedWithCode(1), "");
 }
 TEST(ErrorState, static_InReset)
 {
-    EXPECT_EXIT(RunErrorStateIn("Reset"), ::testing::ExitedWithCode(1), "");
+    EXPECT_EXIT(RunErrorStateIn("Reset", "static"), ::testing::ExitedWithCode(1), "");
 }
 TEST(ErrorState, interactive_InInit)
 {
-    EXPECT_EXIT(RunErrorStateIn("Init", "q"), ::testing::ExitedWithCode(1), "");
+    EXPECT_EXIT(RunErrorStateIn("Init", "interactive"), ::testing::ExitedWithCode(1), "");
 }
 TEST(ErrorState, interactive_InBind)
 {
-    EXPECT_EXIT(RunErrorStateIn("Bind", "q"), ::testing::ExitedWithCode(1), "");
+    EXPECT_EXIT(RunErrorStateIn("Bind", "interactive"), ::testing::ExitedWithCode(1), "");
 }
 TEST(ErrorState, interactive_InConnect)
 {
-    EXPECT_EXIT(RunErrorStateIn("Connect", "q"), ::testing::ExitedWithCode(1), "");
+    EXPECT_EXIT(RunErrorStateIn("Connect", "interactive"), ::testing::ExitedWithCode(1), "");
 }
 TEST(ErrorState, interactive_InInitTask)
 {
-    EXPECT_EXIT(RunErrorStateIn("InitTask", "q"), ::testing::ExitedWithCode(1), "");
+    EXPECT_EXIT(RunErrorStateIn("InitTask", "interactive"), ::testing::ExitedWithCode(1), "");
 }
 TEST(ErrorState, interactive_InPreRun)
 {
-    EXPECT_EXIT(RunErrorStateIn("PreRun", "q"), ::testing::ExitedWithCode(1), "");
+    EXPECT_EXIT(RunErrorStateIn("PreRun", "interactive"), ::testing::ExitedWithCode(1), "");
 }
 TEST(ErrorState, interactive_InRun)
 {
-    EXPECT_EXIT(RunErrorStateIn("Run", "q"), ::testing::ExitedWithCode(1), "");
+    EXPECT_EXIT(RunErrorStateIn("Run", "interactive"), ::testing::ExitedWithCode(1), "");
 }
 TEST(ErrorState, interactive_InPostRun)
 {
-    EXPECT_EXIT(RunErrorStateIn("PostRun", "q"), ::testing::ExitedWithCode(1), "");
+    EXPECT_EXIT(RunErrorStateIn("PostRun", "interactive"), ::testing::ExitedWithCode(1), "");
 }
 TEST(ErrorState, interactive_InResetTask)
 {
-    EXPECT_EXIT(RunErrorStateIn("ResetTask", "q"), ::testing::ExitedWithCode(1), "");
+    EXPECT_EXIT(RunErrorStateIn("ResetTask", "interactive", "q"), ::testing::ExitedWithCode(1), "");
 }
 TEST(ErrorState, interactive_InReset)
 {
-    EXPECT_EXIT(RunErrorStateIn("Reset", "q"), ::testing::ExitedWithCode(1), "");
-}
-TEST(ErrorState, interactive_invalid_InInit)
-{
-    EXPECT_EXIT(RunErrorStateIn("Init", "_"), ::testing::ExitedWithCode(1), "");
-}
-TEST(ErrorState, interactive_invalid_InBind)
-{
-    EXPECT_EXIT(RunErrorStateIn("Bind", "_"), ::testing::ExitedWithCode(1), "");
-}
-TEST(ErrorState, interactive_invalid_InConnect)
-{
-    EXPECT_EXIT(RunErrorStateIn("Connect", "_"), ::testing::ExitedWithCode(1), "");
-}
-TEST(ErrorState, interactive_invalid_InInitTask)
-{
-    EXPECT_EXIT(RunErrorStateIn("InitTask", "_"), ::testing::ExitedWithCode(1), "");
-}
-TEST(ErrorState, interactive_invalid_InPreRun)
-{
-    EXPECT_EXIT(RunErrorStateIn("PreRun", "_"), ::testing::ExitedWithCode(1), "");
-}
-TEST(ErrorState, interactive_invalid_InRun)
-{
-    EXPECT_EXIT(RunErrorStateIn("Run", "_"), ::testing::ExitedWithCode(1), "");
-}
-TEST(ErrorState, interactive_invalid_InPostRun)
-{
-    EXPECT_EXIT(RunErrorStateIn("PostRun", "_"), ::testing::ExitedWithCode(1), "");
+    EXPECT_EXIT(RunErrorStateIn("Reset", "interactive", "q"), ::testing::ExitedWithCode(1), "");
 }
 
 } // namespace

--- a/test/device/_exceptions.cxx
+++ b/test/device/_exceptions.cxx
@@ -23,7 +23,7 @@ using namespace std;
 using namespace fair::mq::test;
 using namespace fair::mq::tools;
 
-void RunExceptionIn(const std::string& state, const std::string& input = "")
+void RunExceptionIn(const string& state, const string& control, const string& input = "")
 {
     size_t session{fair::mq::tools::UuidHash()};
 
@@ -32,7 +32,7 @@ void RunExceptionIn(const std::string& state, const std::string& input = "")
         stringstream cmd;
         cmd << runTestDevice
             << " --id exceptions_" << state << "_"
-            << " --control " << ((input == "") ? "static" : "interactive")
+            << " --control " << control
             << " --session " << session
             << " --color false";
         result = execute(cmd.str(), "[EXCEPTION IN " + state + "]", input);
@@ -40,110 +40,82 @@ void RunExceptionIn(const std::string& state, const std::string& input = "")
 
     device_thread.join();
 
-    ASSERT_NE(std::string::npos, result.console_out.find("exception in " + state + "()"));
+    ASSERT_NE(string::npos, result.console_out.find("exception in " + state + "()"));
 
     exit(result.exit_code);
 }
 
 TEST(Exceptions, static_InInit)
 {
-    EXPECT_EXIT(RunExceptionIn("Init"), ::testing::ExitedWithCode(1), "");
+    EXPECT_EXIT(RunExceptionIn("Init", "static"), ::testing::ExitedWithCode(1), "");
 }
 TEST(Exceptions, static_InBind)
 {
-    EXPECT_EXIT(RunExceptionIn("Bind"), ::testing::ExitedWithCode(1), "");
+    EXPECT_EXIT(RunExceptionIn("Bind", "static"), ::testing::ExitedWithCode(1), "");
 }
 TEST(Exceptions, static_InConnect)
 {
-    EXPECT_EXIT(RunExceptionIn("Connect"), ::testing::ExitedWithCode(1), "");
+    EXPECT_EXIT(RunExceptionIn("Connect", "static"), ::testing::ExitedWithCode(1), "");
 }
 TEST(Exceptions, static_InInitTask)
 {
-    EXPECT_EXIT(RunExceptionIn("InitTask"), ::testing::ExitedWithCode(1), "");
+    EXPECT_EXIT(RunExceptionIn("InitTask", "static"), ::testing::ExitedWithCode(1), "");
 }
 TEST(Exceptions, static_InPreRun)
 {
-    EXPECT_EXIT(RunExceptionIn("PreRun"), ::testing::ExitedWithCode(1), "");
+    EXPECT_EXIT(RunExceptionIn("PreRun", "static"), ::testing::ExitedWithCode(1), "");
 }
 TEST(Exceptions, static_InRun)
 {
-    EXPECT_EXIT(RunExceptionIn("Run"), ::testing::ExitedWithCode(1), "");
+    EXPECT_EXIT(RunExceptionIn("Run", "static"), ::testing::ExitedWithCode(1), "");
 }
 TEST(Exceptions, static_InPostRun)
 {
-    EXPECT_EXIT(RunExceptionIn("PostRun"), ::testing::ExitedWithCode(1), "");
+    EXPECT_EXIT(RunExceptionIn("PostRun", "static"), ::testing::ExitedWithCode(1), "");
 }
 TEST(Exceptions, static_InResetTask)
 {
-    EXPECT_EXIT(RunExceptionIn("ResetTask"), ::testing::ExitedWithCode(1), "");
+    EXPECT_EXIT(RunExceptionIn("ResetTask", "static"), ::testing::ExitedWithCode(1), "");
 }
 TEST(Exceptions, static_InReset)
 {
-    EXPECT_EXIT(RunExceptionIn("Reset"), ::testing::ExitedWithCode(1), "");
+    EXPECT_EXIT(RunExceptionIn("Reset", "static"), ::testing::ExitedWithCode(1), "");
 }
 TEST(Exceptions, interactive_InInit)
 {
-    EXPECT_EXIT(RunExceptionIn("Init", "q"), ::testing::ExitedWithCode(1), "");
+    EXPECT_EXIT(RunExceptionIn("Init", "interactive"), ::testing::ExitedWithCode(1), "");
 }
 TEST(Exceptions, interactive_InBind)
 {
-    EXPECT_EXIT(RunExceptionIn("Bind", "q"), ::testing::ExitedWithCode(1), "");
+    EXPECT_EXIT(RunExceptionIn("Bind", "interactive"), ::testing::ExitedWithCode(1), "");
 }
 TEST(Exceptions, interactive_InConnect)
 {
-    EXPECT_EXIT(RunExceptionIn("Connect", "q"), ::testing::ExitedWithCode(1), "");
+    EXPECT_EXIT(RunExceptionIn("Connect", "interactive"), ::testing::ExitedWithCode(1), "");
 }
 TEST(Exceptions, interactive_InInitTask)
 {
-    EXPECT_EXIT(RunExceptionIn("InitTask", "q"), ::testing::ExitedWithCode(1), "");
+    EXPECT_EXIT(RunExceptionIn("InitTask", "interactive"), ::testing::ExitedWithCode(1), "");
 }
 TEST(Exceptions, interactive_InPreRun)
 {
-    EXPECT_EXIT(RunExceptionIn("PreRun", "q"), ::testing::ExitedWithCode(1), "");
+    EXPECT_EXIT(RunExceptionIn("PreRun", "interactive"), ::testing::ExitedWithCode(1), "");
 }
 TEST(Exceptions, interactive_InRun)
 {
-    EXPECT_EXIT(RunExceptionIn("Run", "q"), ::testing::ExitedWithCode(1), "");
+    EXPECT_EXIT(RunExceptionIn("Run", "interactive"), ::testing::ExitedWithCode(1), "");
 }
 TEST(Exceptions, interactive_InPostRun)
 {
-    EXPECT_EXIT(RunExceptionIn("PostRun", "q"), ::testing::ExitedWithCode(1), "");
+    EXPECT_EXIT(RunExceptionIn("PostRun", "interactive"), ::testing::ExitedWithCode(1), "");
 }
 TEST(Exceptions, interactive_InResetTask)
 {
-    EXPECT_EXIT(RunExceptionIn("ResetTask", "q"), ::testing::ExitedWithCode(1), "");
+    EXPECT_EXIT(RunExceptionIn("ResetTask", "interactive", "q"), ::testing::ExitedWithCode(1), "");
 }
 TEST(Exceptions, interactive_InReset)
 {
-    EXPECT_EXIT(RunExceptionIn("Reset", "q"), ::testing::ExitedWithCode(1), "");
-}
-TEST(Exceptions, interactive_invalid_InInit)
-{
-    EXPECT_EXIT(RunExceptionIn("Init", "_"), ::testing::ExitedWithCode(1), "");
-}
-TEST(Exceptions, interactive_invalid_InBind)
-{
-    EXPECT_EXIT(RunExceptionIn("Bind", "_"), ::testing::ExitedWithCode(1), "");
-}
-TEST(Exceptions, interactive_invalid_InConnect)
-{
-    EXPECT_EXIT(RunExceptionIn("Connect", "_"), ::testing::ExitedWithCode(1), "");
-}
-TEST(Exceptions, interactive_invalid_InInitTask)
-{
-    EXPECT_EXIT(RunExceptionIn("InitTask", "_"), ::testing::ExitedWithCode(1), "");
-}
-TEST(Exceptions, interactive_invalid_InPreRun)
-{
-    EXPECT_EXIT(RunExceptionIn("PreRun", "_"), ::testing::ExitedWithCode(1), "");
-}
-TEST(Exceptions, interactive_invalid_InRun)
-{
-    EXPECT_EXIT(RunExceptionIn("Run", "_"), ::testing::ExitedWithCode(1), "");
-}
-TEST(Exceptions, interactive_invalid_InPostRun)
-{
-    EXPECT_EXIT(RunExceptionIn("PostRun", "_"), ::testing::ExitedWithCode(1), "");
+    EXPECT_EXIT(RunExceptionIn("Reset", "interactive", "q"), ::testing::ExitedWithCode(1), "");
 }
 
 } // namespace

--- a/test/device/_signals.cxx
+++ b/test/device/_signals.cxx
@@ -23,7 +23,7 @@ using namespace std;
 using namespace fair::mq::test;
 using namespace fair::mq::tools;
 
-void RunSignalIn(const std::string& state, const std::string& input = "")
+void RunSignalIn(const string& state, const string& control, const string& input = "")
 {
     size_t session{fair::mq::tools::UuidHash()};
 
@@ -32,7 +32,7 @@ void RunSignalIn(const std::string& state, const std::string& input = "")
         stringstream cmd;
         cmd << runTestDevice
             << " --id signals_" << state << "_"
-            << " --control " << ((input == "") ? "static" : "interactive")
+            << " --control " << control
             << " --session " << session
             << " --color false";
         result = execute(cmd.str(), "[SIGINT IN " + state + "]", input);
@@ -40,110 +40,82 @@ void RunSignalIn(const std::string& state, const std::string& input = "")
 
     device_thread.join();
 
-    ASSERT_NE(std::string::npos, result.console_out.find("raising SIGINT from " + state + "()"));
+    ASSERT_NE(string::npos, result.console_out.find("raising SIGINT from " + state + "()"));
 
     exit(result.exit_code);
 }
 
 TEST(Signal_SIGINT, static_InInit)
 {
-    EXPECT_EXIT(RunSignalIn("Init"), ::testing::ExitedWithCode(0), "");
+    EXPECT_EXIT(RunSignalIn("Init", "static"), ::testing::ExitedWithCode(0), "");
 }
 TEST(Signal_SIGINT, static_InBind)
 {
-    EXPECT_EXIT(RunSignalIn("Bind"), ::testing::ExitedWithCode(0), "");
+    EXPECT_EXIT(RunSignalIn("Bind", "static"), ::testing::ExitedWithCode(0), "");
 }
 TEST(Signal_SIGINT, static_InConnect)
 {
-    EXPECT_EXIT(RunSignalIn("Connect"), ::testing::ExitedWithCode(0), "");
+    EXPECT_EXIT(RunSignalIn("Connect", "static"), ::testing::ExitedWithCode(0), "");
 }
 TEST(Signal_SIGINT, static_InInitTask)
 {
-    EXPECT_EXIT(RunSignalIn("InitTask"), ::testing::ExitedWithCode(0), "");
+    EXPECT_EXIT(RunSignalIn("InitTask", "static"), ::testing::ExitedWithCode(0), "");
 }
 TEST(Signal_SIGINT, static_InPreRun)
 {
-    EXPECT_EXIT(RunSignalIn("PreRun"), ::testing::ExitedWithCode(0), "");
+    EXPECT_EXIT(RunSignalIn("PreRun", "static"), ::testing::ExitedWithCode(0), "");
 }
 TEST(Signal_SIGINT, static_InRun)
 {
-    EXPECT_EXIT(RunSignalIn("Run"), ::testing::ExitedWithCode(0), "");
+    EXPECT_EXIT(RunSignalIn("Run", "static"), ::testing::ExitedWithCode(0), "");
 }
 TEST(Signal_SIGINT, static_InPostRun)
 {
-    EXPECT_EXIT(RunSignalIn("PostRun"), ::testing::ExitedWithCode(0), "");
+    EXPECT_EXIT(RunSignalIn("PostRun", "static"), ::testing::ExitedWithCode(0), "");
 }
 TEST(Signal_SIGINT, static_InResetTask)
 {
-    EXPECT_EXIT(RunSignalIn("ResetTask"), ::testing::ExitedWithCode(0), "");
+    EXPECT_EXIT(RunSignalIn("ResetTask", "static"), ::testing::ExitedWithCode(0), "");
 }
 TEST(Signal_SIGINT, static_InReset)
 {
-    EXPECT_EXIT(RunSignalIn("Reset"), ::testing::ExitedWithCode(0), "");
+    EXPECT_EXIT(RunSignalIn("Reset", "static"), ::testing::ExitedWithCode(0), "");
 }
 TEST(Signal_SIGINT, interactive_InInit)
 {
-    EXPECT_EXIT(RunSignalIn("Init", "q"), ::testing::ExitedWithCode(0), "");
+    EXPECT_EXIT(RunSignalIn("Init", "interactive"), ::testing::ExitedWithCode(0), "");
 }
 TEST(Signal_SIGINT, interactive_InBind)
 {
-    EXPECT_EXIT(RunSignalIn("Bind", "q"), ::testing::ExitedWithCode(0), "");
+    EXPECT_EXIT(RunSignalIn("Bind", "interactive"), ::testing::ExitedWithCode(0), "");
 }
 TEST(Signal_SIGINT, interactive_InConnect)
 {
-    EXPECT_EXIT(RunSignalIn("Connect", "q"), ::testing::ExitedWithCode(0), "");
+    EXPECT_EXIT(RunSignalIn("Connect", "interactive"), ::testing::ExitedWithCode(0), "");
 }
 TEST(Signal_SIGINT, interactive_InInitTask)
 {
-    EXPECT_EXIT(RunSignalIn("InitTask", "q"), ::testing::ExitedWithCode(0), "");
+    EXPECT_EXIT(RunSignalIn("InitTask", "interactive"), ::testing::ExitedWithCode(0), "");
 }
 TEST(Signal_SIGINT, interactive_InPreRun)
 {
-    EXPECT_EXIT(RunSignalIn("PreRun", "q"), ::testing::ExitedWithCode(0), "");
+    EXPECT_EXIT(RunSignalIn("PreRun", "interactive"), ::testing::ExitedWithCode(0), "");
 }
 TEST(Signal_SIGINT, interactive_InRun)
 {
-    EXPECT_EXIT(RunSignalIn("Run", "q"), ::testing::ExitedWithCode(0), "");
+    EXPECT_EXIT(RunSignalIn("Run", "interactive"), ::testing::ExitedWithCode(0), "");
 }
 TEST(Signal_SIGINT, interactive_InPostRun)
 {
-    EXPECT_EXIT(RunSignalIn("PostRun", "q"), ::testing::ExitedWithCode(0), "");
+    EXPECT_EXIT(RunSignalIn("PostRun", "interactive"), ::testing::ExitedWithCode(0), "");
 }
 TEST(Signal_SIGINT, interactive_InResetTask)
 {
-    EXPECT_EXIT(RunSignalIn("ResetTask", "q"), ::testing::ExitedWithCode(0), "");
+    EXPECT_EXIT(RunSignalIn("ResetTask", "interactive", "q"), ::testing::ExitedWithCode(0), "");
 }
 TEST(Signal_SIGINT, interactive_InReset)
 {
-    EXPECT_EXIT(RunSignalIn("Reset", "q"), ::testing::ExitedWithCode(0), "");
-}
-TEST(Signal_SIGINT, interactive_invalid_InInit)
-{
-    EXPECT_EXIT(RunSignalIn("Init", "_"), ::testing::ExitedWithCode(0), "");
-}
-TEST(Signal_SIGINT, interactive_invalid_InBind)
-{
-    EXPECT_EXIT(RunSignalIn("Bind", "_"), ::testing::ExitedWithCode(0), "");
-}
-TEST(Signal_SIGINT, interactive_invalid_InConnect)
-{
-    EXPECT_EXIT(RunSignalIn("Connect", "_"), ::testing::ExitedWithCode(0), "");
-}
-TEST(Signal_SIGINT, interactive_invalid_InInitTask)
-{
-    EXPECT_EXIT(RunSignalIn("InitTask", "_"), ::testing::ExitedWithCode(0), "");
-}
-TEST(Signal_SIGINT, interactive_invalid_InPreRun)
-{
-    EXPECT_EXIT(RunSignalIn("PreRun", "_"), ::testing::ExitedWithCode(0), "");
-}
-TEST(Signal_SIGINT, interactive_invalid_InRun)
-{
-    EXPECT_EXIT(RunSignalIn("Run", "_"), ::testing::ExitedWithCode(0), "");
-}
-TEST(Signal_SIGINT, interactive_invalid_InPostRun)
-{
-    EXPECT_EXIT(RunSignalIn("PostRun", "_"), ::testing::ExitedWithCode(0), "");
+    EXPECT_EXIT(RunSignalIn("Reset", "interactive", "q"), ::testing::ExitedWithCode(0), "");
 }
 
 } // namespace


### PR DESCRIPTION
The affected tests have independent shutdown conditions that race with the controller inputs.

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
