### PR TITLE
Extend process tools

### DIFF
--- a/fairmq/FairMQDevice.h
+++ b/fairmq/FairMQDevice.h
@@ -430,7 +430,7 @@ class FairMQDevice
     template<class Rep, class Period>
     bool WaitFor(std::chrono::duration<Rep, Period> const& duration)
     {
-        return fStateMachine.WaitForPendingStateFor(std::chrono::duration_cast<std::chrono::milliseconds>(duration).count());
+        return !fStateMachine.WaitForPendingStateFor(std::chrono::duration_cast<std::chrono::milliseconds>(duration).count());
     }
 
   protected:

--- a/fairmq/plugins/Control.cxx
+++ b/fairmq/plugins/Control.cxx
@@ -189,7 +189,7 @@ try {
     bool keepRunning = true;
 
     while (keepRunning) {
-        if (poll(cinfd, 1, 500)) {
+        if (poll(cinfd, 1, 100)) {
             if (fDeviceShutdownRequested) {
                 break;
             }

--- a/fairmq/tools/Process.h
+++ b/fairmq/tools/Process.h
@@ -38,7 +38,8 @@ struct execute_result
  */
 execute_result execute(const std::string& cmd,
                        const std::string& prefix = "",
-                       const std::string& input = "");
+                       const std::string& input = "",
+                       int sig = -1);
 
 } /* namespace tools */
 } /* namespace mq */

--- a/test/helper/devices/TestErrorState.h
+++ b/test/helper/devices/TestErrorState.h
@@ -32,6 +32,7 @@ class ErrorState : public FairMQDevice
             ChangeState(fair::mq::Transition::ErrorFound);
         }
     }
+
     void Bind() override
     {
         std::string state("Bind");
@@ -40,6 +41,7 @@ class ErrorState : public FairMQDevice
             ChangeState(fair::mq::Transition::ErrorFound);
         }
     }
+
     void Connect() override
     {
         std::string state("Connect");

--- a/test/helper/devices/TestExceptions.h
+++ b/test/helper/devices/TestExceptions.h
@@ -32,6 +32,7 @@ class Exceptions : public FairMQDevice
             throw std::runtime_error("exception in " + state + "()");
         }
     }
+
     auto Bind() -> void override
     {
         std::string state("Bind");
@@ -39,6 +40,7 @@ class Exceptions : public FairMQDevice
             throw std::runtime_error("exception in " + state + "()");
         }
     }
+
     auto Connect() -> void override
     {
         std::string state("Connect");

--- a/test/helper/devices/TestWaitFor.h
+++ b/test/helper/devices/TestWaitFor.h
@@ -24,10 +24,34 @@ namespace test
 class TestWaitFor : public FairMQDevice
 {
   public:
-    void Run()
+    void PreRun() override
     {
-        std::cout << "hello" << std::endl;
-        WaitFor(std::chrono::seconds(60));
+        std::string state("PreRun");
+        if (std::string::npos != GetId().find("_" + state)) {
+            LOG(info) << "Going to sleep via WaitFor() in " << state << "...";
+            bool result = WaitFor(std::chrono::seconds(60));
+            LOG(info) << (result == true ? "Sleeping Done. Not interrupted." : "Sleeping Done. Interrupted.");
+        }
+    }
+
+    void Run() override
+    {
+        std::string state("Run");
+        if (std::string::npos != GetId().find("_" + state)) {
+            LOG(info) << "Going to sleep via WaitFor() in " << state << "...";
+            bool result = WaitFor(std::chrono::seconds(60));
+            LOG(info) << (result == true ? "Sleeping Done. Not interrupted." : "Sleeping Done. Interrupted.");
+        }
+    }
+
+    void PostRun() override
+    {
+        std::string state("PostRun");
+        if (std::string::npos != GetId().find("_" + state)) {
+            LOG(info) << "Going to sleep via WaitFor() in " << state << "...";
+            bool result = WaitFor(std::chrono::seconds(60));
+            LOG(info) << (result == true ? "Sleeping Done. Not interrupted." : "Sleeping Done. Interrupted.");
+        }
     }
 };
 


### PR DESCRIPTION
- fair::mq::tools::execute - add output helper to avoid duplicate code.
- fair::mq::tools::execute - support sending of a signal to the process.
- tests: Use process tools in WaitFor test.
- Add more checks in WaitFor test.
- Reduce polling rate in Control::InteractiveMode() from 500 to 100 ms (accelerate some tests).
- Fix bug in WaitFor with wrong return value (didn't match the docs).

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
