### PR TITLE
Bunch Region Acks when sending over IPC queue

### DIFF
--- a/fairmq/shmem/Manager.h
+++ b/fairmq/shmem/Manager.h
@@ -66,7 +66,7 @@ class Manager
     std::string fManagementSegmentName;
     boost::interprocess::managed_shared_memory fSegment;
     boost::interprocess::managed_shared_memory fManagementSegment;
-    static std::unordered_map<uint64_t, Region> fRegions;
+    static std::unordered_map<uint64_t, std::unique_ptr<Region>> fRegions;
 };
 
 } // namespace shmem

--- a/fairmq/shmem/Region.cxx
+++ b/fairmq/shmem/Region.cxx
@@ -12,6 +12,8 @@
 
 #include <boost/date_time/posix_time/posix_time.hpp>
 
+#include <chrono>
+
 using namespace std;
 
 namespace bipc = ::boost::interprocess;
@@ -32,7 +34,8 @@ Region::Region(Manager& manager, uint64_t id, uint64_t size, bool remote, FairMQ
     , fQueueName("fmq_" + fManager.fSessionName +"_rgq_" + to_string(id))
     , fShmemObject()
     , fQueue(nullptr)
-    , fWorker()
+    , fReceiveAcksWorker()
+    , fSendAcksWorker()
     , fCallback(callback)
 {
     if (fRemote)
@@ -49,52 +52,118 @@ Region::Region(Manager& manager, uint64_t id, uint64_t size, bool remote, FairMQ
         LOG(debug) << "shmem: created region: " << fName;
         fShmemObject.truncate(size);
 
-        fQueue = fair::mq::tools::make_unique<bipc::message_queue>(bipc::create_only, fQueueName.c_str(), 10000, sizeof(RegionBlock));
+        fQueue = fair::mq::tools::make_unique<bipc::message_queue>(bipc::create_only, fQueueName.c_str(), 1024, fAckBunchSize * sizeof(RegionBlock));
         LOG(debug) << "shmem: created region queue: " << fQueueName;
     }
     fRegion = bipc::mapped_region(fShmemObject, bipc::read_write); // TODO: add HUGEPAGES flag here
     // fRegion = bipc::mapped_region(fShmemObject, bipc::read_write, 0, 0, 0, MAP_ANONYMOUS | MAP_HUGETLB);
+
+    fSendAcksWorker = std::thread(&Region::SendAcks, this);
 }
 
 void Region::StartReceivingAcks()
 {
-    fWorker = std::thread(&Region::ReceiveAcks, this);
+    fReceiveAcksWorker = std::thread(&Region::ReceiveAcks, this);
 }
 
 void Region::ReceiveAcks()
 {
     unsigned int priority;
     bipc::message_queue::size_type recvdSize;
+    std::unique_ptr<RegionBlock[]> blocks = fair::mq::tools::make_unique<RegionBlock[]>(fAckBunchSize);
 
     while (!fStop) // end thread condition (should exist until region is destroyed)
     {
-        auto rcvTill = bpt::microsec_clock::universal_time() + bpt::milliseconds(200);
-        RegionBlock block;
-        if (fQueue->timed_receive(&block, sizeof(RegionBlock), recvdSize, priority, rcvTill))
+        auto rcvTill = bpt::microsec_clock::universal_time() + bpt::milliseconds(500);
+
+        while (fQueue->timed_receive(blocks.get(), fAckBunchSize * sizeof(RegionBlock), recvdSize, priority, rcvTill))
         {
             // LOG(debug) << "received: " << block.fHandle << " " << block.fSize << " " << block.fMessageId;
             if (fCallback)
             {
-                fCallback(reinterpret_cast<char*>(fRegion.get_address()) + block.fHandle, block.fSize, reinterpret_cast<void*>(block.fHint));
+                const auto numBlocks = recvdSize / sizeof(RegionBlock);
+                for (size_t i = 0; i < numBlocks; i++)
+                {
+                    fCallback(reinterpret_cast<char*>(fRegion.get_address()) + blocks[i].fHandle, blocks[i].fSize, reinterpret_cast<void*>(blocks[i].fHint));
+                }
             }
-        }
-        else
-        {
-            // LOG(debug) << "queue " << fQueueName << " timeout!";
         }
     } // while !fStop
 
-    LOG(debug) << "worker for " << fName << " leaving.";
+    LOG(debug) << "receive ack worker for " << fName << " leaving.";
+}
+
+void Region::ReleaseBlock(const RegionBlock &block)
+{
+    std::unique_lock<std::mutex> lock(fBlockLock);
+
+    fBlocksToFree.emplace_back(block);
+
+    if (fBlocksToFree.size() >= fAckBunchSize)
+    {
+        lock.unlock(); // reduces contention on fBlockLock
+        fBlockSendCV.notify_one();
+    }
+}
+
+void Region::SendAcks()
+{
+    std::unique_ptr<RegionBlock[]> blocks = fair::mq::tools::make_unique<RegionBlock[]>(fAckBunchSize);
+
+    while (true) // we'll try to send all acks before stopping
+    {
+        size_t blocksToSend = 0;
+
+        {   // mutex locking block
+            std::unique_lock<std::mutex> lock(fBlockLock);
+
+            // try to get more blocks without waiting (we can miss a notify from CloseMessage())
+            if (!fStop && (fBlocksToFree.size() < fAckBunchSize))
+            {
+                // cv.wait() timeout: send whatever blocks we have
+                fBlockSendCV.wait_for(lock, std::chrono::milliseconds(500));
+            }
+
+            blocksToSend = std::min(fBlocksToFree.size(), fAckBunchSize);
+
+            std::copy_n(fBlocksToFree.end() - blocksToSend, blocksToSend, blocks.get());
+            fBlocksToFree.resize(fBlocksToFree.size() - blocksToSend);
+        } // unlock the block mutex here while sending over IPC
+
+        if (blocksToSend > 0)
+        {
+            while (!fQueue->try_send(blocks.get(), blocksToSend * sizeof(RegionBlock), 0) && !fStop)
+            {
+                // receiver slow? yield and try again...
+                this_thread::yield();
+            }
+        }
+        else // blocksToSend == 0
+        {
+            if (fStop)
+            {
+                break;
+            }
+        }
+    }
+
+    LOG(debug) << "send ack worker for " << fName << " leaving.";
 }
 
 Region::~Region()
 {
+    fStop = true;
+
+    if (fSendAcksWorker.joinable())
+    {
+        fSendAcksWorker.join();
+    }
+
     if (!fRemote)
     {
-        fStop = true;
-        if (fWorker.joinable())
+        if (fReceiveAcksWorker.joinable())
         {
-            fWorker.join();
+            fReceiveAcksWorker.join();
         }
 
         if (bipc::shared_memory_object::remove(fName.c_str()))

--- a/fairmq/tools/CppSTL.h
+++ b/fairmq/tools/CppSTL.h
@@ -27,6 +27,13 @@ std::unique_ptr<T> make_unique(Args&& ...args)
     return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
 }
 
+// make_unique implementation (array variant), until C++14 is default
+template<typename T>
+std::unique_ptr<T> make_unique(std::size_t size)
+{
+    return std::unique_ptr<T>(new typename std::remove_extent<T>::type[size]());
+}
+
 // provide an enum hasher to compensate std::hash not supporting enums in C++11
 template<typename Enum>
 struct HashEnum


### PR DESCRIPTION
This is performance optimization for releasing of freed SHM messages allocated from a UnmanagedRegion. The change introduce another thread per Region object used to transmit freed region block information in batches. This reduces contention on the IPC synch objects and leads to lower CPU utilization in both, originating and freeing processes.

Also: refactor the `Manager` class since `Region` is no longer copyable or moveable (mutex).

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
