### PR TITLE
Handle invalid transition to init in the control plugin

### DIFF
--- a/fairmq/plugins/Control.cxx
+++ b/fairmq/plugins/Control.cxx
@@ -203,9 +203,10 @@ try {
                 break;
                 case 'i':
                     cout << "\n --> [i] init device\n\n" << flush;
-                    ChangeDeviceState(DeviceStateTransition::InitDevice);
-                    while (WaitForNextState() != DeviceState::InitializingDevice) {}
-                    ChangeDeviceState(DeviceStateTransition::CompleteInit);
+                    if (ChangeDeviceState(DeviceStateTransition::InitDevice)) {
+                        while (WaitForNextState() != DeviceState::InitializingDevice) {}
+                        ChangeDeviceState(DeviceStateTransition::CompleteInit);
+                    }
                 break;
                 case 'b':
                     cout << "\n --> [b] bind\n\n" << flush;


### PR DESCRIPTION
The control plugin assumed transition to init is always successful.

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
