### PR TITLE
Add include/DDS to path_suffixes

### DIFF
--- a/cmake/FindDDS.cmake
+++ b/cmake/FindDDS.cmake
@@ -9,7 +9,7 @@
 find_path(DDS_INCLUDE_DIR
   NAMES dds_intercom.h
   HINTS ${DDS_ROOT} $ENV{DDS_ROOT}
-  PATH_SUFFIXES include
+  PATH_SUFFIXES include include/DDS
 )
 
 find_path(DDS_LIBRARY_DIR


### PR DESCRIPTION
For some reason, in our case DDS 2.4 installs in `include/DDS`, not simply `include`.