### PR TITLE
Shmem region: support huge pages via path to hugetlbfs mount

### DIFF
--- a/examples/region/Sampler.cxx
+++ b/examples/region/Sampler.cxx
@@ -40,8 +40,7 @@ void Sampler::InitTask()
                                                              10000000,
                                                              [this](void* /*data*/, size_t /*size*/, void* /*hint*/) { // callback to be called when message buffers no longer needed by transport
                                                                  --fNumUnackedMsgs;
-                                                                 if (fMaxIterations > 0)
-                                                                 {
+                                                                 if (fMaxIterations > 0) {
                                                                      LOG(debug) << "Received ack";
                                                                  }
                                                              }
@@ -58,12 +57,14 @@ bool Sampler::ConditionalRun()
                                         nullptr // hint
                                         ));
 
-    if (Send(msg, "data", 0) > 0)
-    {
+    // static_cast<char*>(fRegion->GetData())[3] = 97;
+    // LOG(info) << "check: " << static_cast<char*>(fRegion->GetData())[3];
+    // std::this_thread::sleep_for(std::chrono::seconds(1));
+
+    if (Send(msg, "data", 0) > 0) {
         ++fNumUnackedMsgs;
 
-        if (fMaxIterations > 0 && ++fNumIterations >= fMaxIterations)
-        {
+        if (fMaxIterations > 0 && ++fNumIterations >= fMaxIterations) {
             LOG(info) << "Configured maximum number of iterations reached. Leaving RUNNING state.";
             return false;
         }
@@ -75,8 +76,7 @@ bool Sampler::ConditionalRun()
 void Sampler::ResetTask()
 {
     // if not all messages acknowledged, wait for a bit. But only once, since receiver could be already dead.
-    if (fNumUnackedMsgs != 0)
-    {
+    if (fNumUnackedMsgs != 0) {
         LOG(debug) << "waiting for all acknowledgements... (" << fNumUnackedMsgs << ")";
         this_thread::sleep_for(chrono::milliseconds(500));
         LOG(debug) << "done, still unacked: " << fNumUnackedMsgs;

--- a/examples/region/Sink.cxx
+++ b/examples/region/Sink.cxx
@@ -35,14 +35,15 @@ void Sink::Run()
 {
     FairMQChannel& dataInChannel = fChannels.at("data").at(0);
 
-    while (!NewStatePending())
-    {
+    while (!NewStatePending()) {
         FairMQMessagePtr msg(dataInChannel.Transport()->CreateMessage());
         dataInChannel.Receive(msg);
-        // void* ptr = msg->GetData();
 
-        if (fMaxIterations > 0 && ++fNumIterations >= fMaxIterations)
-        {
+        // void* ptr = msg->GetData();
+        // char* cptr = static_cast<char*>(ptr);
+        // LOG(info) << "check: " << cptr[3];
+
+        if (fMaxIterations > 0 && ++fNumIterations >= fMaxIterations) {
             LOG(info) << "Configured maximum number of iterations reached. Leaving RUNNING state.";
             break;
         }

--- a/fairmq/FairMQChannel.h
+++ b/fairmq/FairMQChannel.h
@@ -345,9 +345,9 @@ class FairMQChannel
         return Transport()->NewStaticMessage(data);
     }
 
-    FairMQUnmanagedRegionPtr NewUnmanagedRegion(const size_t size, FairMQRegionCallback callback = nullptr)
+    FairMQUnmanagedRegionPtr NewUnmanagedRegion(const size_t size, FairMQRegionCallback callback = nullptr, const std::string& path = "", int flags = 0)
     {
-        return Transport()->CreateUnmanagedRegion(size, callback);
+        return Transport()->CreateUnmanagedRegion(size, callback, path, flags);
     }
 
   private:

--- a/fairmq/FairMQDevice.h
+++ b/fairmq/FairMQDevice.h
@@ -240,9 +240,9 @@ class FairMQDevice
     }
 
     // creates unmanaged region with the transport of the specified channel
-    FairMQUnmanagedRegionPtr NewUnmanagedRegionFor(const std::string& channel, int index, const size_t size, FairMQRegionCallback callback = nullptr)
+    FairMQUnmanagedRegionPtr NewUnmanagedRegionFor(const std::string& channel, int index, const size_t size, FairMQRegionCallback callback = nullptr, const std::string& path = "", int flags = 0)
     {
-        return GetChannel(channel, index).NewUnmanagedRegion(size, callback);
+        return GetChannel(channel, index).NewUnmanagedRegion(size, callback, path, flags);
     }
 
     template<typename ...Ts>

--- a/fairmq/FairMQTransportFactory.h
+++ b/fairmq/FairMQTransportFactory.h
@@ -72,7 +72,7 @@ class FairMQTransportFactory
     /// Create a poller for specific channels (all subchannels)
     virtual FairMQPollerPtr CreatePoller(const std::unordered_map<std::string, std::vector<FairMQChannel>>& channelsMap, const std::vector<std::string>& channelList) const = 0;
 
-    virtual FairMQUnmanagedRegionPtr CreateUnmanagedRegion(const size_t size, FairMQRegionCallback callback = nullptr) const = 0;
+    virtual FairMQUnmanagedRegionPtr CreateUnmanagedRegion(const size_t size, FairMQRegionCallback callback = nullptr, const std::string& path = "", int flags = 0) const = 0;
 
     /// Get transport type
     virtual fair::mq::Transport GetType() const = 0;

--- a/fairmq/nanomsg/FairMQTransportFactoryNN.cxx
+++ b/fairmq/nanomsg/FairMQTransportFactoryNN.cxx
@@ -65,9 +65,9 @@ FairMQPollerPtr FairMQTransportFactoryNN::CreatePoller(const unordered_map<strin
     return unique_ptr<FairMQPoller>(new FairMQPollerNN(channelsMap, channelList));
 }
 
-FairMQUnmanagedRegionPtr FairMQTransportFactoryNN::CreateUnmanagedRegion(const size_t size, FairMQRegionCallback callback) const
+FairMQUnmanagedRegionPtr FairMQTransportFactoryNN::CreateUnmanagedRegion(const size_t size, FairMQRegionCallback callback, const std::string& path /* = "" */, int flags /* = 0 */) const
 {
-    return unique_ptr<FairMQUnmanagedRegion>(new FairMQUnmanagedRegionNN(size, callback));
+    return unique_ptr<FairMQUnmanagedRegion>(new FairMQUnmanagedRegionNN(size, callback, path, flags));
 }
 
 fair::mq::Transport FairMQTransportFactoryNN::GetType() const

--- a/fairmq/nanomsg/FairMQTransportFactoryNN.h
+++ b/fairmq/nanomsg/FairMQTransportFactoryNN.h
@@ -36,7 +36,7 @@ class FairMQTransportFactoryNN final : public FairMQTransportFactory
     FairMQPollerPtr CreatePoller(const std::vector<FairMQChannel*>& channels) const override;
     FairMQPollerPtr CreatePoller(const std::unordered_map<std::string, std::vector<FairMQChannel>>& channelsMap, const std::vector<std::string>& channelList) const override;
 
-    FairMQUnmanagedRegionPtr CreateUnmanagedRegion(const size_t size, FairMQRegionCallback callback) const override;
+    FairMQUnmanagedRegionPtr CreateUnmanagedRegion(const size_t size, FairMQRegionCallback callback, const std::string& path = "", int flags = 0) const override;
 
     fair::mq::Transport GetType() const override;
 

--- a/fairmq/nanomsg/FairMQUnmanagedRegionNN.cxx
+++ b/fairmq/nanomsg/FairMQUnmanagedRegionNN.cxx
@@ -11,7 +11,7 @@
 
 using namespace std;
 
-FairMQUnmanagedRegionNN::FairMQUnmanagedRegionNN(const size_t size, FairMQRegionCallback callback)
+FairMQUnmanagedRegionNN::FairMQUnmanagedRegionNN(const size_t size, FairMQRegionCallback callback, const std::string& /*path = "" */, int /*flags = 0 */)
     : fBuffer(malloc(size))
     , fSize(size)
     , fCallback(callback)

--- a/fairmq/nanomsg/FairMQUnmanagedRegionNN.h
+++ b/fairmq/nanomsg/FairMQUnmanagedRegionNN.h
@@ -12,13 +12,14 @@
 #include "FairMQUnmanagedRegion.h"
 
 #include <cstddef> // size_t
+#include <string>
 
 class FairMQUnmanagedRegionNN final : public FairMQUnmanagedRegion
 {
     friend class FairMQSocketNN;
 
   public:
-    FairMQUnmanagedRegionNN(const size_t size, FairMQRegionCallback callback);
+    FairMQUnmanagedRegionNN(const size_t size, FairMQRegionCallback callback, const std::string& path = "", int flags = 0);
     FairMQUnmanagedRegionNN(const FairMQUnmanagedRegionNN&) = delete;
     FairMQUnmanagedRegionNN operator=(const FairMQUnmanagedRegionNN&) = delete;
 

--- a/fairmq/ofi/TransportFactory.cxx
+++ b/fairmq/ofi/TransportFactory.cxx
@@ -85,7 +85,7 @@ auto TransportFactory::CreatePoller(const unordered_map<string, vector<FairMQCha
     // return PollerPtr{new Poller(channelsMap, channelList)};
 }
 
-auto TransportFactory::CreateUnmanagedRegion(const size_t /*size*/, FairMQRegionCallback /*callback*/) const -> UnmanagedRegionPtr
+auto TransportFactory::CreateUnmanagedRegion(const size_t /*size*/, FairMQRegionCallback /*callback*/, const std::string& /* path = "" */, int /* flags = 0 */) const -> UnmanagedRegionPtr
 {
     throw runtime_error{"Not yet implemented UMR."};
 }

--- a/fairmq/ofi/TransportFactory.h
+++ b/fairmq/ofi/TransportFactory.h
@@ -46,7 +46,7 @@ class TransportFactory final : public FairMQTransportFactory
     auto CreatePoller(const std::vector<FairMQChannel*>& channels) const -> PollerPtr override;
     auto CreatePoller(const std::unordered_map<std::string, std::vector<FairMQChannel>>& channelsMap, const std::vector<std::string>& channelList) const -> PollerPtr override;
 
-    auto CreateUnmanagedRegion(const size_t size, FairMQRegionCallback callback = nullptr) const -> UnmanagedRegionPtr override;
+    auto CreateUnmanagedRegion(const size_t size, FairMQRegionCallback callback = nullptr, const std::string& path = "", int flags = 0) const -> UnmanagedRegionPtr override;
 
     auto GetType() const -> Transport override;
 

--- a/fairmq/shmem/FairMQMessageSHM.cxx
+++ b/fairmq/shmem/FairMQMessageSHM.cxx
@@ -223,25 +223,16 @@ zmq_msg_t* FairMQMessageSHM::GetMessage()
 
 void* FairMQMessageSHM::GetData() const
 {
-    if (fLocalPtr)
-    {
+    if (fLocalPtr) {
         return fLocalPtr;
-    }
-    else
-    {
-        if (fRegionId == 0)
-        {
+    } else {
+        if (fRegionId == 0) {
             return fManager.Segment().get_address_from_handle(fHandle);
-        }
-        else
-        {
+        } else {
             fRegionPtr = fManager.GetRemoteRegion(fRegionId);
-            if (fRegionPtr)
-            {
+            if (fRegionPtr) {
                 fLocalPtr = reinterpret_cast<char*>(fRegionPtr->fRegion.get_address()) + fHandle;
-            }
-            else
-            {
+            } else {
                 // LOG(warn) << "could not get pointer from a region message";
                 fLocalPtr = nullptr;
             }
@@ -257,15 +248,10 @@ size_t FairMQMessageSHM::GetSize() const
 
 bool FairMQMessageSHM::SetUsedSize(const size_t size)
 {
-    if (size == fSize)
-    {
+    if (size == fSize) {
         return true;
-    }
-    else if (size <= fSize)
-    {
-        try
-        {
-
+    } else if (size <= fSize) {
+        try {
             bipc::managed_shared_memory::size_type shrunkSize = size;
             fLocalPtr = fManager.Segment().allocation_command<char>(bipc::shrink_in_place, fSize + 128, shrunkSize, fLocalPtr);
             fSize = size;
@@ -274,15 +260,11 @@ bool FairMQMessageSHM::SetUsedSize(const size_t size)
             MetaHeader* hdrPtr = static_cast<MetaHeader*>(zmq_msg_data(&fMessage));
             hdrPtr->fSize = fSize;
             return true;
-        }
-        catch (bipc::interprocess_exception& e)
-        {
+        } catch (bipc::interprocess_exception& e) {
             LOG(info) << "could not set used size: " << e.what();
             return false;
         }
-    }
-    else
-    {
+    } else {
         LOG(error) << "cannot set used size higher than original.";
         return false;
     }

--- a/fairmq/shmem/FairMQSocketSHM.cxx
+++ b/fairmq/shmem/FairMQSocketSHM.cxx
@@ -375,20 +375,20 @@ int64_t FairMQSocketSHM::Receive(vector<FairMQMessagePtr>& msgVec, const int tim
 
             for (size_t m = 0; m < numMessages; m++)
             {
-                MetaHeader metaHeader;
-                memcpy(&metaHeader, &hdrVec[m], sizeof(MetaHeader));
+                MetaHeader hdr;
+                memcpy(&hdr, &hdrVec[m], sizeof(MetaHeader));
 
                 msgVec.emplace_back(fair::mq::tools::make_unique<FairMQMessageSHM>(fManager, GetTransport()));
 
                 FairMQMessageSHM* msg = static_cast<FairMQMessageSHM*>(msgVec.back().get());
                 MetaHeader* msgHdr = static_cast<MetaHeader*>(zmq_msg_data(msg->GetMessage()));
 
-                memcpy(msgHdr, &metaHeader, sizeof(MetaHeader));
+                memcpy(msgHdr, &hdr, sizeof(MetaHeader));
 
-                msg->fHandle = metaHeader.fHandle;
-                msg->fSize = metaHeader.fSize;
-                msg->fRegionId = metaHeader.fRegionId;
-                msg->fHint = metaHeader.fHint;
+                msg->fHandle = hdr.fHandle;
+                msg->fSize = hdr.fSize;
+                msg->fRegionId = hdr.fRegionId;
+                msg->fHint = hdr.fHint;
 
                 totalSize += msg->GetSize();
             }

--- a/fairmq/shmem/FairMQTransportFactorySHM.cxx
+++ b/fairmq/shmem/FairMQTransportFactorySHM.cxx
@@ -9,11 +9,11 @@
 #include "FairMQLogger.h"
 #include "FairMQTransportFactorySHM.h"
 
+#include <fairmq/Tools.h>
+
 #include <zmq.h>
 
 #include <boost/version.hpp>
-#include <boost/process.hpp>
-#include <boost/filesystem.hpp>
 #include <boost/interprocess/managed_shared_memory.hpp>
 
 #include <boost/interprocess/ipc/message_queue.hpp>
@@ -28,7 +28,6 @@
 using namespace std;
 using namespace fair::mq::shmem;
 
-namespace bfs = ::boost::filesystem;
 namespace bpt = ::boost::posix_time;
 namespace bipc = ::boost::interprocess;
 
@@ -38,175 +37,73 @@ FairMQTransportFactorySHM::FairMQTransportFactorySHM(const string& id, const Fai
     : FairMQTransportFactory(id)
     , fDeviceId(id)
     , fShmId()
-    , fContext(nullptr)
+    , fZMQContext(nullptr)
+    , fManager(nullptr)
     , fHeartbeatThread()
     , fSendHeartbeats(true)
-    , fShMutex(nullptr)
-    , fDeviceCounter(nullptr)
-    , fManager(nullptr)
 {
     int major, minor, patch;
     zmq_version(&major, &minor, &patch);
     LOG(debug) << "Transport: Using ZeroMQ (" << major << "." << minor << "." << patch << ") & "
                << "boost::interprocess (" << (BOOST_VERSION / 100000) << "." << (BOOST_VERSION / 100 % 1000) << "." << (BOOST_VERSION % 100) << ")";
 
-    fContext = zmq_ctx_new();
-    if (!fContext)
-    {
-        LOG(error) << "failed creating context, reason: " << zmq_strerror(errno);
-        exit(EXIT_FAILURE);
+    fZMQContext = zmq_ctx_new();
+    if (!fZMQContext) {
+        throw runtime_error(fair::mq::tools::ToString("failed creating context, reason: ", zmq_strerror(errno)));
     }
 
     int numIoThreads = 1;
     string sessionName = "default";
     size_t segmentSize = 2000000000;
     bool autolaunchMonitor = false;
-    if (config)
-    {
+    if (config) {
         numIoThreads = config->GetValue<int>("io-threads");
         sessionName = config->GetValue<string>("session");
         segmentSize = config->GetValue<size_t>("shm-segment-size");
         autolaunchMonitor = config->GetValue<bool>("shm-monitor");
-    }
-    else
-    {
+    } else {
         LOG(debug) << "FairMQProgOptions not available! Using defaults.";
     }
 
     fShmId = buildShmIdFromSessionIdAndUserId(sessionName);
 
-    try
-    {
-        fShMutex = fair::mq::tools::make_unique<bipc::named_mutex>(bipc::open_or_create, string("fmq_" + fShmId + "_mtx").c_str());
-
-        if (zmq_ctx_set(fContext, ZMQ_IO_THREADS, numIoThreads) != 0)
-        {
+    try {
+        if (zmq_ctx_set(fZMQContext, ZMQ_IO_THREADS, numIoThreads) != 0) {
             LOG(error) << "failed configuring context, reason: " << zmq_strerror(errno);
         }
 
         // Set the maximum number of allowed sockets on the context.
-        if (zmq_ctx_set(fContext, ZMQ_MAX_SOCKETS, 10000) != 0)
-        {
+        if (zmq_ctx_set(fZMQContext, ZMQ_MAX_SOCKETS, 10000) != 0) {
             LOG(error) << "failed configuring context, reason: " << zmq_strerror(errno);
         }
 
         fManager = fair::mq::tools::make_unique<Manager>(fShmId, segmentSize);
-        LOG(debug) << "created/opened shared memory segment '" << "fmq_" << fShmId << "_main" << "' of " << segmentSize << " bytes. Available are " << fManager->Segment().get_free_memory() << " bytes.";
 
-        {
-            bipc::scoped_lock<bipc::named_mutex> lock(*fShMutex);
-
-            fDeviceCounter = fManager->Segment().find<DeviceCounter>(bipc::unique_instance).first;
-            if (fDeviceCounter)
-            {
-                LOG(debug) << "device counter found, with value of " << fDeviceCounter->fCount << ". incrementing.";
-                (fDeviceCounter->fCount)++;
-                LOG(debug) << "incremented device counter, now: " << fDeviceCounter->fCount;
-            }
-            else
-            {
-                LOG(debug) << "no device counter found, creating one and initializing with 1";
-                fDeviceCounter = fManager->Segment().construct<DeviceCounter>(bipc::unique_instance)(1);
-                LOG(debug) << "initialized device counter with: " << fDeviceCounter->fCount;
-            }
-
-            // start shm monitor
-            if (autolaunchMonitor)
-            {
-                try
-                {
-                    MonitorStatus* monitorStatus = fManager->ManagementSegment().find<MonitorStatus>(bipc::unique_instance).first;
-                    if (monitorStatus == nullptr)
-                    {
-                        LOG(debug) << "no fairmq-shmmonitor found, starting...";
-                        StartMonitor();
-                    }
-                    else
-                    {
-                        LOG(debug) << "found fairmq-shmmonitor.";
-                    }
-                }
-                catch (exception& e)
-                {
-                    LOG(error) << "Exception during fairmq-shmmonitor initialization: " << e.what() << ", application will now exit";
-                    exit(EXIT_FAILURE);
-                }
-            }
+        if (autolaunchMonitor) {
+            fManager->StartMonitor();
         }
-    }
-    catch(bipc::interprocess_exception& e)
-    {
+    } catch (bipc::interprocess_exception& e) {
         LOG(error) << "Could not initialize shared memory transport: " << e.what();
-        throw runtime_error("Cannot update configuration. Socket method (bind/connect) not specified.");
+        throw runtime_error(fair::mq::tools::ToString("Could not initialize shared memory transport: ", e.what()));
     }
 
     fSendHeartbeats = true;
     fHeartbeatThread = thread(&FairMQTransportFactorySHM::SendHeartbeats, this);
 }
 
-void FairMQTransportFactorySHM::StartMonitor()
-{
-    auto env = boost::this_process::environment();
-
-    vector<bfs::path> ownPath = boost::this_process::path();
-
-    if (const char* fmqp = getenv("FAIRMQ_PATH"))
-    {
-        ownPath.insert(ownPath.begin(), bfs::path(fmqp));
-    }
-
-    bfs::path p = boost::process::search_path("fairmq-shmmonitor", ownPath);
-
-    if (!p.empty())
-    {
-        boost::process::spawn(p, "-x", "--shmid", fShmId, "-d", "-t", "2000", env);
-        int numTries = 0;
-        do
-        {
-            MonitorStatus* monitorStatus = fManager->ManagementSegment().find<MonitorStatus>(bipc::unique_instance).first;
-            if (monitorStatus)
-            {
-                LOG(debug) << "fairmq-shmmonitor started";
-                break;
-            }
-            else
-            {
-                this_thread::sleep_for(chrono::milliseconds(10));
-                if (++numTries > 1000)
-                {
-                    LOG(error) << "Did not get response from fairmq-shmmonitor after " << 10 * 1000 << " milliseconds. Exiting.";
-                    exit(EXIT_FAILURE);
-                }
-            }
-        }
-        while (true);
-    }
-    else
-    {
-        LOG(warn) << "could not find fairmq-shmmonitor in the path";
-    }
-}
-
 void FairMQTransportFactorySHM::SendHeartbeats()
 {
     string controlQueueName("fmq_" + fShmId + "_cq");
-    while (fSendHeartbeats)
-    {
-        try
-        {
+    while (fSendHeartbeats) {
+        try {
             bipc::message_queue mq(bipc::open_only, controlQueueName.c_str());
             bpt::ptime sndTill = bpt::microsec_clock::universal_time() + bpt::milliseconds(100);
-            if (mq.timed_send(fDeviceId.c_str(), fDeviceId.size(), 0, sndTill))
-            {
+            if (mq.timed_send(fDeviceId.c_str(), fDeviceId.size(), 0, sndTill)) {
                 this_thread::sleep_for(chrono::milliseconds(100));
-            }
-            else
-            {
+            } else {
                 LOG(debug) << "control queue timeout";
             }
-        }
-        catch (bipc::interprocess_exception& ie)
-        {
+        } catch (bipc::interprocess_exception& ie) {
             this_thread::sleep_for(chrono::milliseconds(500));
             // LOG(warn) << "no " << controlQueueName << " found";
         }
@@ -235,8 +132,8 @@ FairMQMessagePtr FairMQTransportFactorySHM::CreateMessage(FairMQUnmanagedRegionP
 
 FairMQSocketPtr FairMQTransportFactorySHM::CreateSocket(const string& type, const string& name)
 {
-    assert(fContext);
-    return unique_ptr<FairMQSocket>(new FairMQSocketSHM(*fManager, type, name, GetId(), fContext, this));
+    assert(fZMQContext);
+    return unique_ptr<FairMQSocket>(new FairMQSocketSHM(*fManager, type, name, GetId(), fZMQContext, this));
 }
 
 FairMQPollerPtr FairMQTransportFactorySHM::CreatePoller(const vector<FairMQChannel>& channels) const
@@ -254,9 +151,14 @@ FairMQPollerPtr FairMQTransportFactorySHM::CreatePoller(const unordered_map<stri
     return unique_ptr<FairMQPoller>(new FairMQPollerSHM(channelsMap, channelList));
 }
 
-FairMQUnmanagedRegionPtr FairMQTransportFactorySHM::CreateUnmanagedRegion(const size_t size, FairMQRegionCallback callback) const
+FairMQUnmanagedRegionPtr FairMQTransportFactorySHM::CreateUnmanagedRegion(const size_t size, FairMQRegionCallback callback, const std::string& path /* = "" */, int flags /* = 0 */) const
 {
-    return unique_ptr<FairMQUnmanagedRegion>(new FairMQUnmanagedRegionSHM(*fManager, size, callback));
+    return unique_ptr<FairMQUnmanagedRegion>(new FairMQUnmanagedRegionSHM(*fManager, size, callback, path, flags));
+}
+
+fair::mq::Transport FairMQTransportFactorySHM::GetType() const
+{
+    return fTransportType;
 }
 
 FairMQTransportFactorySHM::~FairMQTransportFactorySHM()
@@ -264,53 +166,16 @@ FairMQTransportFactorySHM::~FairMQTransportFactorySHM()
     fSendHeartbeats = false;
     fHeartbeatThread.join();
 
-    if (fContext)
-    {
-        if (zmq_ctx_term(fContext) != 0)
-        {
-            if (errno == EINTR)
-            {
+    if (fZMQContext) {
+        if (zmq_ctx_term(fZMQContext) != 0) {
+            if (errno == EINTR) {
                 LOG(error) << "failed closing context, reason: " << zmq_strerror(errno);
-            }
-            else
-            {
-                fContext = nullptr;
+            } else {
+                fZMQContext = nullptr;
                 return;
             }
         }
-    }
-    else
-    {
+    } else {
         LOG(error) << "context not available for shutdown";
     }
-
-    bool lastRemoved = false;
-
-    { // mutex scope
-        bipc::scoped_lock<bipc::named_mutex> lock(*fShMutex);
-
-        (fDeviceCounter->fCount)--;
-
-        if (fDeviceCounter->fCount == 0)
-        {
-            LOG(debug) << "last segment user, removing segment.";
-
-            fManager->RemoveSegment();
-            lastRemoved = true;
-        }
-        else
-        {
-            LOG(debug) << "other segment users present (" << fDeviceCounter->fCount << "), not removing it.";
-        }
-    }
-
-    if (lastRemoved)
-    {
-        bipc::named_mutex::remove(string("fmq_" + fShmId + "_mtx").c_str());
-    }
-}
-
-fair::mq::Transport FairMQTransportFactorySHM::GetType() const
-{
-    return fTransportType;
 }

--- a/fairmq/shmem/FairMQTransportFactorySHM.h
+++ b/fairmq/shmem/FairMQTransportFactorySHM.h
@@ -19,8 +19,6 @@
 #include "FairMQUnmanagedRegionSHM.h"
 #include <options/FairMQProgOptions.h>
 
-#include <boost/interprocess/sync/named_mutex.hpp>
-
 #include <vector>
 #include <string>
 #include <thread>
@@ -44,7 +42,7 @@ class FairMQTransportFactorySHM final : public FairMQTransportFactory
     FairMQPollerPtr CreatePoller(const std::vector<FairMQChannel*>& channels) const override;
     FairMQPollerPtr CreatePoller(const std::unordered_map<std::string, std::vector<FairMQChannel>>& channelsMap, const std::vector<std::string>& channelList) const override;
 
-    FairMQUnmanagedRegionPtr CreateUnmanagedRegion(const size_t size, FairMQRegionCallback callback = nullptr) const override;
+    FairMQUnmanagedRegionPtr CreateUnmanagedRegion(const size_t size, FairMQRegionCallback callback = nullptr, const std::string& path = "", int flags = 0) const override;
 
     fair::mq::Transport GetType() const override;
 
@@ -56,17 +54,14 @@ class FairMQTransportFactorySHM final : public FairMQTransportFactory
 
   private:
     void SendHeartbeats();
-    void StartMonitor();
 
     static fair::mq::Transport fTransportType;
     std::string fDeviceId;
     std::string fShmId;
-    void* fContext;
+    void* fZMQContext;
+    std::unique_ptr<fair::mq::shmem::Manager> fManager;
     std::thread fHeartbeatThread;
     std::atomic<bool> fSendHeartbeats;
-    std::unique_ptr<boost::interprocess::named_mutex> fShMutex;
-    fair::mq::shmem::DeviceCounter* fDeviceCounter;
-    std::unique_ptr<fair::mq::shmem::Manager> fManager;
 };
 
 #endif /* FAIRMQTRANSPORTFACTORYSHM_H_ */

--- a/fairmq/shmem/FairMQUnmanagedRegionSHM.cxx
+++ b/fairmq/shmem/FairMQUnmanagedRegionSHM.cxx
@@ -15,22 +15,18 @@ using namespace fair::mq::shmem;
 
 namespace bipc = ::boost::interprocess;
 
-FairMQUnmanagedRegionSHM::FairMQUnmanagedRegionSHM(Manager& manager, const size_t size, FairMQRegionCallback callback)
+FairMQUnmanagedRegionSHM::FairMQUnmanagedRegionSHM(Manager& manager, const size_t size, FairMQRegionCallback callback, const std::string& path /* = "" */, int flags /* = 0 */)
     : fManager(manager)
     , fRegion(nullptr)
     , fRegionId(0)
 {
-    try
-    {
+    try {
         RegionCounter* rc = fManager.ManagementSegment().find<RegionCounter>(bipc::unique_instance).first;
-        if (rc)
-        {
+        if (rc) {
             LOG(debug) << "region counter found, with value of " << rc->fCount << ". incrementing.";
             (rc->fCount)++;
             LOG(debug) << "incremented region counter, now: " << rc->fCount;
-        }
-        else
-        {
+        } else {
             LOG(debug) << "no region counter found, creating one and initializing with 1";
             rc = fManager.ManagementSegment().construct<RegionCounter>(bipc::unique_instance)(1);
             LOG(debug) << "initialized region counter with: " << rc->fCount;
@@ -38,13 +34,11 @@ FairMQUnmanagedRegionSHM::FairMQUnmanagedRegionSHM(Manager& manager, const size_
 
         fRegionId = rc->fCount;
 
-        fRegion = fManager.CreateRegion(size, fRegionId, callback);
-    }
-    catch (bipc::interprocess_exception& e)
-    {
+        fRegion = fManager.CreateRegion(size, fRegionId, callback, path, flags);
+    } catch (bipc::interprocess_exception& e) {
         LOG(error) << "cannot create region. Already created/not cleaned up?";
         LOG(error) << e.what();
-        exit(EXIT_FAILURE);
+        throw;
     }
 }
 

--- a/fairmq/shmem/FairMQUnmanagedRegionSHM.h
+++ b/fairmq/shmem/FairMQUnmanagedRegionSHM.h
@@ -18,6 +18,7 @@
 #include <boost/interprocess/mapped_region.hpp>
 
 #include <cstddef> // size_t
+#include <string>
 
 class FairMQUnmanagedRegionSHM final : public FairMQUnmanagedRegion
 {
@@ -25,7 +26,7 @@ class FairMQUnmanagedRegionSHM final : public FairMQUnmanagedRegion
     friend class FairMQMessageSHM;
 
   public:
-    FairMQUnmanagedRegionSHM(fair::mq::shmem::Manager& manager, const size_t size, FairMQRegionCallback callback = nullptr);
+    FairMQUnmanagedRegionSHM(fair::mq::shmem::Manager& manager, const size_t size, FairMQRegionCallback callback = nullptr, const std::string& path = "", int flags = 0);
 
     void* GetData() const override;
     size_t GetSize() const override;

--- a/fairmq/shmem/Manager.cxx
+++ b/fairmq/shmem/Manager.cxx
@@ -9,8 +9,12 @@
 #include <fairmq/shmem/Manager.h>
 #include <fairmq/shmem/Common.h>
 
+#include <boost/process.hpp>
+#include <boost/filesystem.hpp>
+
 using namespace std;
 namespace bipc = ::boost::interprocess;
+namespace bfs = ::boost::filesystem;
 
 namespace fair
 {
@@ -21,17 +25,84 @@ namespace shmem
 
 std::unordered_map<uint64_t, std::unique_ptr<Region>> Manager::fRegions;
 
-Manager::Manager(const string& name, size_t size)
-    : fSessionName(name)
-    , fSegmentName("fmq_" + fSessionName + "_main")
-    , fManagementSegmentName("fmq_" + fSessionName + "_mng")
+Manager::Manager(const std::string& id, size_t size)
+    : fShmId(id)
+    , fSegmentName("fmq_" + fShmId + "_main")
+    , fManagementSegmentName("fmq_" + fShmId + "_mng")
     , fSegment(bipc::open_or_create, fSegmentName.c_str(), size)
     , fManagementSegment(bipc::open_or_create, fManagementSegmentName.c_str(), 65536)
-{}
+    , fShmMtx(bipc::open_or_create, string("fmq_" + fShmId + "_mtx").c_str())
+    , fDeviceCounter(nullptr)
+{
+    LOG(debug) << "created/opened shared memory segment '" << "fmq_" << fShmId << "_main" << "' of " << size << " bytes. Available are " << fSegment.get_free_memory() << " bytes.";
+
+    bipc::scoped_lock<bipc::named_mutex> lock(fShmMtx);
+
+    fDeviceCounter = fManagementSegment.find<DeviceCounter>(bipc::unique_instance).first;
+
+    if (fDeviceCounter) {
+        LOG(debug) << "device counter found, with value of " << fDeviceCounter->fCount << ". incrementing.";
+        (fDeviceCounter->fCount)++;
+        LOG(debug) << "incremented device counter, now: " << fDeviceCounter->fCount;
+    } else {
+        LOG(debug) << "no device counter found, creating one and initializing with 1";
+        fDeviceCounter = fManagementSegment.construct<DeviceCounter>(bipc::unique_instance)(1);
+        LOG(debug) << "initialized device counter with: " << fDeviceCounter->fCount;
+    }
+}
 
 bipc::managed_shared_memory& Manager::Segment()
 {
     return fSegment;
+}
+
+bipc::managed_shared_memory& Manager::ManagementSegment()
+{
+    return fManagementSegment;
+}
+
+void Manager::StartMonitor()
+{
+    try {
+        MonitorStatus* monitorStatus = fManagementSegment.find<MonitorStatus>(bipc::unique_instance).first;
+        if (monitorStatus == nullptr) {
+            LOG(debug) << "no fairmq-shmmonitor found, starting...";
+            auto env = boost::this_process::environment();
+
+            vector<bfs::path> ownPath = boost::this_process::path();
+
+            if (const char* fmqp = getenv("FAIRMQ_PATH")) {
+                ownPath.insert(ownPath.begin(), bfs::path(fmqp));
+            }
+
+            bfs::path p = boost::process::search_path("fairmq-shmmonitor", ownPath);
+
+            if (!p.empty()) {
+                boost::process::spawn(p, "-x", "--shmid", fShmId, "-d", "-t", "2000", env);
+                int numTries = 0;
+                do {
+                    monitorStatus = fManagementSegment.find<MonitorStatus>(bipc::unique_instance).first;
+                    if (monitorStatus) {
+                        LOG(debug) << "fairmq-shmmonitor started";
+                        break;
+                    } else {
+                        this_thread::sleep_for(chrono::milliseconds(10));
+                        if (++numTries > 1000) {
+                            LOG(error) << "Did not get response from fairmq-shmmonitor after " << 10 * 1000 << " milliseconds. Exiting.";
+                            throw runtime_error(fair::mq::tools::ToString("Did not get response from fairmq-shmmonitor after ", 10 * 1000, " milliseconds. Exiting."));
+                        }
+                    }
+                } while (true);
+            } else {
+                LOG(warn) << "could not find fairmq-shmmonitor in the path";
+            }
+        } else {
+            LOG(debug) << "found fairmq-shmmonitor.";
+        }
+    } catch (std::exception& e) {
+        LOG(error) << "Exception during fairmq-shmmonitor initialization: " << e.what() << ", application will now exit";
+        exit(EXIT_FAILURE);
+    }
 }
 
 void Manager::Interrupt()
@@ -41,30 +112,31 @@ void Manager::Interrupt()
 void Manager::Resume()
 {
     // close remote regions before processing new transfers
-    for (auto it = fRegions.begin(); it != fRegions.end(); /**/)
-    {
-        if (it->second->fRemote)
-        {
+    for (auto it = fRegions.begin(); it != fRegions.end(); /**/) {
+        if (it->second->fRemote) {
            it = fRegions.erase(it);
-        }
-        else
-        {
+        } else {
             ++it;
         }
     }
 }
 
-bipc::mapped_region* Manager::CreateRegion(const size_t size, const uint64_t id, FairMQRegionCallback callback)
+bipc::mapped_region* Manager::CreateRegion(const size_t size, const uint64_t id, FairMQRegionCallback callback, const std::string& path /* = "" */, int flags /* = 0 */)
 {
     auto it = fRegions.find(id);
-    if (it != fRegions.end())
-    {
+    if (it != fRegions.end()) {
         LOG(error) << "Trying to create a region that already exists";
         return nullptr;
-    }
-    else
-    {
-        auto r = fRegions.emplace(id, fair::mq::tools::make_unique<Region>(*this, id, size, false, callback));
+    } else {
+        // create region info
+        {
+            bipc::scoped_lock<bipc::named_mutex> lock(fShmMtx);
+            VoidAlloc voidAlloc(fManagementSegment.get_segment_manager());
+            Uint64RegionInfoMap* m = fManagementSegment.find_or_construct<Uint64RegionInfoMap>(bipc::unique_instance)(voidAlloc);
+            m->emplace(id, RegionInfo(path.c_str(), flags, voidAlloc));
+        }
+
+        auto r = fRegions.emplace(id, fair::mq::tools::make_unique<Region>(*this, id, size, false, callback, path, flags));
 
         r.first->second->StartReceivingAcks();
 
@@ -76,20 +148,28 @@ Region* Manager::GetRemoteRegion(const uint64_t id)
 {
     // remote region could actually be a local one if a message originates from this device (has been sent out and returned)
     auto it = fRegions.find(id);
-    if (it != fRegions.end())
-    {
+    if (it != fRegions.end()) {
         return it->second.get();
-    }
-    else
-    {
-        try
-        {
-            auto r = fRegions.emplace(id, fair::mq::tools::make_unique<Region>(*this, id, 0, true, nullptr));
+    } else {
+        try {
+            string path;
+            int flags;
+
+            // get region info
+            {
+                bipc::scoped_lock<bipc::named_mutex> lock(fShmMtx);
+                VoidAlloc voidAlloc(fSegment.get_segment_manager());
+                Uint64RegionInfoMap* m = fManagementSegment.find<Uint64RegionInfoMap>(bipc::unique_instance).first;
+                RegionInfo ri = m->at(id);
+                path = ri.fPath.c_str();
+                flags = ri.fFlags;
+                // LOG(debug) << "path: " << path << ", flags: " << flags;
+            }
+
+            auto r = fRegions.emplace(id, fair::mq::tools::make_unique<Region>(*this, id, 0, true, nullptr, path, flags));
             return r.first->second.get();
-        }
-        catch (bipc::interprocess_exception& e)
-        {
-            // LOG(warn) << "remote region (" << id << ") no longer exists";
+        } catch (bipc::interprocess_exception& e) {
+            LOG(warn) << "Could not get remote region for id: " << id;
             return nullptr;
         }
 
@@ -101,30 +181,43 @@ void Manager::RemoveRegion(const uint64_t id)
     fRegions.erase(id);
 }
 
-void Manager::RemoveSegment()
+void Manager::RemoveSegments()
 {
-    if (bipc::shared_memory_object::remove(fSegmentName.c_str()))
-    {
+    if (bipc::shared_memory_object::remove(fSegmentName.c_str())) {
         LOG(debug) << "successfully removed '" << fSegmentName << "' segment after the device has stopped.";
-    }
-    else
-    {
+    } else {
         LOG(debug) << "did not remove " << fSegmentName << " segment after the device stopped. Already removed?";
     }
 
-    if (bipc::shared_memory_object::remove(fManagementSegmentName.c_str()))
-    {
+    if (bipc::shared_memory_object::remove(fManagementSegmentName.c_str())) {
         LOG(debug) << "successfully removed '" << fManagementSegmentName << "' segment after the device has stopped.";
-    }
-    else
-    {
+    } else {
         LOG(debug) << "did not remove '" << fManagementSegmentName << "' segment after the device stopped. Already removed?";
     }
 }
 
-bipc::managed_shared_memory& Manager::ManagementSegment()
+Manager::~Manager()
 {
-    return fManagementSegment;
+    bool lastRemoved = false;
+
+    {
+        bipc::scoped_lock<bipc::named_mutex> lock(fShmMtx);
+
+        (fDeviceCounter->fCount)--;
+
+        if (fDeviceCounter->fCount == 0) {
+            LOG(debug) << "last segment user, removing segment.";
+
+            RemoveSegments();
+            lastRemoved = true;
+        } else {
+            LOG(debug) << "other segment users present (" << fDeviceCounter->fCount << "), not removing it.";
+        }
+    }
+
+    if (lastRemoved) {
+        bipc::named_mutex::remove(string("fmq_" + fShmId + "_mtx").c_str());
+    }
 }
 
 } // namespace shmem

--- a/fairmq/shmem/Monitor.h
+++ b/fairmq/shmem/Monitor.h
@@ -26,7 +26,7 @@ namespace shmem
 class Monitor
 {
   public:
-    Monitor(const std::string& sessionName, bool selfDestruct, bool interactive, unsigned int timeoutInMS, bool runAsDaemon, bool cleanOnExit);
+    Monitor(const std::string& shmId, bool selfDestruct, bool interactive, unsigned int timeoutInMS, bool runAsDaemon, bool cleanOnExit);
 
     Monitor(const Monitor&) = delete;
     Monitor operator=(const Monitor&) = delete;
@@ -36,8 +36,9 @@ class Monitor
 
     virtual ~Monitor();
 
-    static void Cleanup(const std::string& sessionName);
+    static void Cleanup(const std::string& shmId);
     static void RemoveObject(const std::string&);
+    static void RemoveFileMapping(const std::string&);
     static void RemoveQueue(const std::string&);
     static void RemoveMutex(const std::string&);
 

--- a/fairmq/shmem/Region.h
+++ b/fairmq/shmem/Region.h
@@ -22,6 +22,7 @@
 #include <fairmq/shmem/Common.h>
 
 #include <boost/interprocess/managed_shared_memory.hpp>
+#include <boost/interprocess/file_mapping.hpp>
 #include <boost/interprocess/ipc/message_queue.hpp>
 
 #include <thread>
@@ -40,12 +41,14 @@ class Manager;
 
 struct Region
 {
-    Region(Manager& manager, uint64_t id, uint64_t size, bool remote, FairMQRegionCallback callback = nullptr);
+    Region(Manager& manager, uint64_t id, uint64_t size, bool remote, FairMQRegionCallback callback = nullptr, const std::string& path = "", int flags = 0);
 
     Region() = delete;
 
     Region(const Region&) = default;
     Region(Region&&) = default;
+
+    void InitializeQueues();
 
     void StartReceivingAcks();
     void ReceiveAcks();
@@ -61,6 +64,8 @@ struct Region
     std::string fName;
     std::string fQueueName;
     boost::interprocess::shared_memory_object fShmemObject;
+    FILE* fFile;
+    boost::interprocess::file_mapping fFileMapping;
     boost::interprocess::mapped_region fRegion;
 
     std::mutex fBlockLock;

--- a/fairmq/shmem/runMonitor.cxx
+++ b/fairmq/shmem/runMonitor.cxx
@@ -39,36 +39,30 @@ static void daemonize()
     umask(0);
 
     // Create a new SID for the child process
-    if (setsid() < 0)
-    {
+    if (setsid() < 0) {
         exit(1);
     }
 
     // Change the current working directory. This prevents the current directory from being locked; hence not being able to remove it.
-    if ((chdir("/")) < 0)
-    {
+    if ((chdir("/")) < 0) {
         exit(1);
     }
 
     // Redirect standard files to /dev/null
-    if (!freopen("/dev/null", "r", stdin))
-    {
+    if (!freopen("/dev/null", "r", stdin)) {
         cout << "could not redirect stdin to /dev/null" << endl;
     }
-    if (!freopen("/dev/null", "w", stdout))
-    {
+    if (!freopen("/dev/null", "w", stdout)) {
         cout << "could not redirect stdout to /dev/null" << endl;
     }
-    if (!freopen("/dev/null", "w", stderr))
-    {
+    if (!freopen("/dev/null", "w", stderr)) {
         cout << "could not redirect stderr to /dev/null" << endl;
     }
 }
 
 int main(int argc, char** argv)
 {
-    try
-    {
+    try {
         string sessionName;
         string shmId;
         bool cleanup = false;
@@ -93,26 +87,22 @@ int main(int argc, char** argv)
         variables_map vm;
         store(parse_command_line(argc, argv, desc), vm);
 
-        if (vm.count("help"))
-        {
+        if (vm.count("help")) {
             cout << "FairMQ Shared Memory Monitor" << endl << desc << endl;
             return 0;
         }
 
         notify(vm);
 
-        if (runAsDaemon)
-        {
+        if (runAsDaemon) {
             daemonize();
         }
 
-        if (shmId == "")
-        {
+        if (shmId == "") {
             shmId = buildShmIdFromSessionIdAndUserId(sessionName);
         }
 
-        if (cleanup)
-        {
+        if (cleanup) {
             cout << "Cleaning up \"" << shmId << "\"..." << endl;
             Monitor::Cleanup(shmId);
             Monitor::RemoveQueue("fmq_" + shmId + "_cq");
@@ -125,9 +115,7 @@ int main(int argc, char** argv)
 
         monitor.CatchSignals();
         monitor.Run();
-    }
-    catch (exception& e)
-    {
+    } catch (exception& e) {
         cerr << "Unhandled Exception reached the top of main: " << e.what() << ", application will now exit" << endl;
         return 2;
     }

--- a/fairmq/zeromq/FairMQTransportFactoryZMQ.cxx
+++ b/fairmq/zeromq/FairMQTransportFactoryZMQ.cxx
@@ -69,7 +69,7 @@ FairMQMessagePtr FairMQTransportFactoryZMQ::CreateMessage(FairMQUnmanagedRegionP
     return unique_ptr<FairMQMessage>(new FairMQMessageZMQ(region, data, size, hint, this));
 }
 
-FairMQSocketPtr FairMQTransportFactoryZMQ::CreateSocket(const string& type, const string& name) 
+FairMQSocketPtr FairMQTransportFactoryZMQ::CreateSocket(const string& type, const string& name)
 {
     assert(fContext);
     return unique_ptr<FairMQSocket>(new FairMQSocketZMQ(type, name, GetId(), fContext, this));
@@ -90,9 +90,9 @@ FairMQPollerPtr FairMQTransportFactoryZMQ::CreatePoller(const unordered_map<stri
     return unique_ptr<FairMQPoller>(new FairMQPollerZMQ(channelsMap, channelList));
 }
 
-FairMQUnmanagedRegionPtr FairMQTransportFactoryZMQ::CreateUnmanagedRegion(const size_t size, FairMQRegionCallback callback) const
+FairMQUnmanagedRegionPtr FairMQTransportFactoryZMQ::CreateUnmanagedRegion(const size_t size, FairMQRegionCallback callback, const std::string& path /* = "" */, int flags /* = 0 */) const
 {
-    return unique_ptr<FairMQUnmanagedRegion>(new FairMQUnmanagedRegionZMQ(size, callback));
+    return unique_ptr<FairMQUnmanagedRegion>(new FairMQUnmanagedRegionZMQ(size, callback, path, flags));
 }
 
 fair::mq::Transport FairMQTransportFactoryZMQ::GetType() const

--- a/fairmq/zeromq/FairMQTransportFactoryZMQ.h
+++ b/fairmq/zeromq/FairMQTransportFactoryZMQ.h
@@ -45,7 +45,7 @@ class FairMQTransportFactoryZMQ final : public FairMQTransportFactory
     FairMQPollerPtr CreatePoller(const std::vector<FairMQChannel*>& channels) const override;
     FairMQPollerPtr CreatePoller(const std::unordered_map<std::string, std::vector<FairMQChannel>>& channelsMap, const std::vector<std::string>& channelList) const override;
 
-    FairMQUnmanagedRegionPtr CreateUnmanagedRegion(const size_t size, FairMQRegionCallback callback) const override;
+    FairMQUnmanagedRegionPtr CreateUnmanagedRegion(const size_t size, FairMQRegionCallback callback, const std::string& path = "", int flags = 0) const override;
 
     fair::mq::Transport GetType() const override;
 

--- a/fairmq/zeromq/FairMQUnmanagedRegionZMQ.cxx
+++ b/fairmq/zeromq/FairMQUnmanagedRegionZMQ.cxx
@@ -11,7 +11,7 @@
 
 using namespace std;
 
-FairMQUnmanagedRegionZMQ::FairMQUnmanagedRegionZMQ(const size_t size, FairMQRegionCallback callback)
+FairMQUnmanagedRegionZMQ::FairMQUnmanagedRegionZMQ(const size_t size, FairMQRegionCallback callback, const std::string& /* path = "" */, int /* flags = 0 */)
     : fBuffer(malloc(size))
     , fSize(size)
     , fCallback(callback)

--- a/fairmq/zeromq/FairMQUnmanagedRegionZMQ.h
+++ b/fairmq/zeromq/FairMQUnmanagedRegionZMQ.h
@@ -12,6 +12,7 @@
 #include "FairMQUnmanagedRegion.h"
 
 #include <cstddef> // size_t
+#include <string>
 
 class FairMQUnmanagedRegionZMQ final : public FairMQUnmanagedRegion
 {
@@ -19,7 +20,7 @@ class FairMQUnmanagedRegionZMQ final : public FairMQUnmanagedRegion
     friend class FairMQMessageZMQ;
 
   public:
-    FairMQUnmanagedRegionZMQ(const size_t size, FairMQRegionCallback callback);
+    FairMQUnmanagedRegionZMQ(const size_t size, FairMQRegionCallback callback, const std::string& path = "", int flags = 0);
     FairMQUnmanagedRegionZMQ(const FairMQUnmanagedRegionZMQ&) = delete;
     FairMQUnmanagedRegionZMQ operator=(const FairMQUnmanagedRegionZMQ&) = delete;
 


### PR DESCRIPTION
- Support huge pages via path to hugetlbfs mount and/or flags to mmap. Adds optional path/flags arguments to interface of region creation.
- Store region info in shared memory with paths and flags,
- Shmem refactoring: move device counter and monitor launcher from factory to manager class,
- Formatting...

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
