### PR TITLE
Fix WaitForState(string stateName)

### DIFF
--- a/fairmq/FairMQDevice.h
+++ b/fairmq/FairMQDevice.h
@@ -492,7 +492,7 @@ class FairMQDevice
 
     fair::mq::State WaitForNextState();
     void WaitForState(fair::mq::State state);
-    void WaitForState(const std::string& state) { fair::mq::StateMachine::GetState(state); }
+    void WaitForState(const std::string& state) { WaitForState(fair::mq::StateMachine::GetState(state)); }
 
     void SubscribeToStateChange(const std::string& key, std::function<void(const fair::mq::State)> callback) { fStateMachine.SubscribeToStateChange(key, callback); }
     void UnsubscribeFromStateChange(const std::string& key) { fStateMachine.UnsubscribeFromStateChange(key); }


### PR DESCRIPTION
Fix `WaitForState(const string& stateName)` to actually call `WaitForState(fair::mq::State state)`.

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
