### PR TITLE
DDS plugin: Add --control external support

### DIFF
--- a/examples/dds/CMakeLists.txt
+++ b/examples/dds/CMakeLists.txt
@@ -65,6 +65,12 @@ install(
 )
 
 install(
+    FILES ${CMAKE_CURRENT_BINARY_DIR}/ex-dds-topology-infinite.xml_install
+    DESTINATION ${PROJECT_INSTALL_DATADIR}
+    RENAME ex-dds-topology-infinite.xml
+)
+
+install(
     FILES ${CMAKE_CURRENT_BINARY_DIR}/ex-dds-hosts.cfg
     DESTINATION ${PROJECT_INSTALL_DATADIR}
 )

--- a/examples/dds/CMakeLists.txt
+++ b/examples/dds/CMakeLists.txt
@@ -31,6 +31,7 @@ add_custom_target(ExampleDDS DEPENDS fairmq-ex-dds-sampler fairmq-ex-dds-process
 set(BIN_DIR ${CMAKE_CURRENT_BINARY_DIR}:${CMAKE_BINARY_DIR}/fairmq/plugins/DDS)
 set(DATA_DIR ${CMAKE_CURRENT_BINARY_DIR})
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/ex-dds-topology.xml ${CMAKE_CURRENT_BINARY_DIR}/ex-dds-topology.xml @ONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/ex-dds-topology-infinite.xml ${CMAKE_CURRENT_BINARY_DIR}/ex-dds-topology-infinite.xml @ONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/ex-dds-hosts.cfg ${CMAKE_CURRENT_BINARY_DIR}/ex-dds-hosts.cfg COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/fairmq-ex-dds-env.sh ${CMAKE_CURRENT_BINARY_DIR}/fairmq-ex-dds-env.sh @ONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/fairmq-start-ex-dds.sh.in ${CMAKE_CURRENT_BINARY_DIR}/fairmq-start-ex-dds.sh @ONLY)
@@ -53,6 +54,7 @@ install(
 set(BIN_DIR ${CMAKE_INSTALL_PREFIX}/${PROJECT_INSTALL_BINDIR})
 set(DATA_DIR ${CMAKE_INSTALL_PREFIX}/${PROJECT_INSTALL_DATADIR})
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/ex-dds-topology.xml ${CMAKE_CURRENT_BINARY_DIR}/ex-dds-topology.xml_install @ONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/ex-dds-topology-infinite.xml ${CMAKE_CURRENT_BINARY_DIR}/ex-dds-topology-infinite.xml_install @ONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/fairmq-ex-dds-env.sh ${CMAKE_CURRENT_BINARY_DIR}/fairmq-ex-dds-env.sh_install @ONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/fairmq-start-ex-dds.sh.in ${CMAKE_CURRENT_BINARY_DIR}/fairmq-start-ex-dds.sh_install @ONLY)
 

--- a/examples/dds/ex-dds-topology-infinite.xml
+++ b/examples/dds/ex-dds-topology-infinite.xml
@@ -9,7 +9,7 @@
 
     <decltask name="Sampler">
         <env reachable="false">fairmq-ex-dds-env.sh</env>
-        <exe>fairmq-ex-dds-sampler --id sampler --color false --channel-config name=data1,type=push,method=bind -P dds</exe>
+        <exe>fairmq-ex-dds-sampler --id sampler --color false --channel-config name=data1,type=push,method=bind --rate 100 -P dds</exe>
         <requirements>
             <name>SamplerWorker</name>
         </requirements>

--- a/examples/dds/ex-dds-topology-infinite.xml
+++ b/examples/dds/ex-dds-topology-infinite.xml
@@ -1,0 +1,52 @@
+<topology name="ExampleDDS">
+
+    <property name="data1" />
+    <property name="data2" />
+
+    <declrequirement name="SamplerWorker" type="wnname" value="sampler"/>
+    <declrequirement name="ProcessorWorker" type="wnname" value="processor"/>
+    <declrequirement name="SinkWorker" type="wnname" value="sink"/>
+
+    <decltask name="Sampler">
+        <env reachable="false">fairmq-ex-dds-env.sh</env>
+        <exe>fairmq-ex-dds-sampler --id sampler --color false --channel-config name=data1,type=push,method=bind -P dds</exe>
+        <requirements>
+            <name>SamplerWorker</name>
+        </requirements>
+        <properties>
+            <name access="write">data1</name>
+        </properties>
+    </decltask>
+
+    <decltask name="Processor">
+        <env reachable="false">fairmq-ex-dds-env.sh</env>
+        <exe>fairmq-ex-dds-processor --id processor_%taskIndex% --color false --channel-config name=data1,type=pull,method=connect name=data2,type=push,method=connect -P dds</exe>
+        <requirements>
+            <id>ProcessorWorker</id>
+        </requirements>
+        <properties>
+            <name access="read">data1</name>
+            <name access="read">data2</name>
+        </properties>
+    </decltask>
+
+    <decltask name="Sink">
+        <env reachable="false">fairmq-ex-dds-env.sh</env>
+        <exe>fairmq-ex-dds-sink --id sink --color false --channel-config name=data2,type=pull,method=bind -P dds</exe>
+        <requirements>
+            <name>SinkWorker</name>
+        </requirements>
+        <properties>
+            <name access="write">data2</name>
+        </properties>
+    </decltask>
+
+    <main name="main">
+        <task>Sampler</task>
+        <task>Sink</task>
+        <group name="ProcessorGroup" n="10">
+            <task>Processor</task>
+        </group>
+    </main>
+
+</topology>

--- a/examples/dds/fairmq-start-ex-dds.sh.in
+++ b/examples/dds/fairmq-start-ex-dds.sh.in
@@ -48,13 +48,26 @@ echo "TOPOLOGY FILE: ${topologyFile}"
 # dds-info --active-topology
 dds-topology --disable-validation --activate ${topologyFile}
 # dds-info --active-topology
+# dds-info --wait-for-executing-agents ${requiredNofAgents}
+sleep 1
 
 echo "------------------------"
 echo "...waiting for Topology to finish..."
+# TODO Retrieve number of devices from DDS topology API instead of having the user pass it explicitely
+fairmq-dds-command-ui -w "IDLE" -n ${requiredNofAgents}
+fairmq-dds-command-ui -c i -w "INITIALIZING DEVICE" -n ${requiredNofAgents}
+fairmq-dds-command-ui -c k -w "INITIALIZED" -n ${requiredNofAgents}
+fairmq-dds-command-ui -c b -w "BOUND" -n ${requiredNofAgents}
+fairmq-dds-command-ui -c x -w "DEVICE READY" -n ${requiredNofAgents}
+fairmq-dds-command-ui -c j -w "READY" -n ${requiredNofAgents}
+fairmq-dds-command-ui -c r
 sampler_and_sink="main/(Sampler|Sink)"
-fairmq-dds-command-ui -p $sampler_and_sink -w "RUNNING->READY"
+fairmq-dds-command-ui -p $sampler_and_sink -w "RUNNING->READY" -n 2
 echo "...$sampler_and_sink are READY, sending shutdown..."
-fairmq-dds-command-ui -c q! -w "EXITING"
+fairmq-dds-command-ui -c s -w "RUNNING->READY" -n ${requiredNofAgents}
+fairmq-dds-command-ui -c t -w "DEVICE READY" -n ${requiredNofAgents}
+fairmq-dds-command-ui -c d -w "IDLE" -n ${requiredNofAgents}
+fairmq-dds-command-ui -c q
 echo "...waiting for ${requiredNofAgents} idle agents..."
 dds-info --wait-for-idle-agents ${requiredNofAgents}
 echo "------------------------"

--- a/fairmq/plugins/Control.cxx
+++ b/fairmq/plugins/Control.cxx
@@ -70,7 +70,7 @@ Control::Control(const string& name, const Plugin::Version version, const string
         if (control == "static") {
             LOG(debug) << "Running builtin controller: static";
             fControllerThread = thread(&Control::StaticMode, this);
-        } else if (control == "interactive") {
+        } else if (control == "dynamic" || control == "external" || control == "interactive") {
             LOG(debug) << "Running builtin controller: interactive";
             fControllerThread = thread(&Control::InteractiveMode, this);
         } else {
@@ -113,7 +113,7 @@ auto ControlPluginProgramOptions() -> Plugin::ProgOptions
     namespace po = boost::program_options;
     auto pluginOptions = po::options_description{"Control (builtin) Plugin"};
     pluginOptions.add_options()
-        ("control",       po::value<string>()->default_value("interactive"), "Control mode, 'static' or 'interactive'")
+        ("control",       po::value<string>()->default_value("dynamic"), "Control mode, 'static' or 'dynamic' (aliases for dynamic are external and interactive)")
         ("catch-signals", po::value<int   >()->default_value(1),             "Enable signal handling (1/0).");
     return pluginOptions;
 }

--- a/fairmq/plugins/DDS/DDS.cxx
+++ b/fairmq/plugins/DDS/DDS.cxx
@@ -285,8 +285,6 @@ auto DDS::SubscribeForCustomCommands() -> void
         } else if (cmd == "INIT DEVICE") {
             if (ChangeDeviceState(ToDeviceStateTransition(cmd))) {
                 fDDS.Send(id + ": queued, " + cmd, to_string(senderId));
-                while (fStateQueue.WaitForNext() != DeviceState::InitializingDevice) {}
-                ChangeDeviceState(DeviceStateTransition::CompleteInit);
             } else {
                 fDDS.Send(id + ": could not queue, " + cmd, to_string(senderId));
             }

--- a/fairmq/plugins/DDS/DDS.cxx
+++ b/fairmq/plugins/DDS/DDS.cxx
@@ -80,6 +80,7 @@ auto DDS::HandleControl() -> void
 
         SubscribeForCustomCommands();
         SubscribeForConnectingChannels();
+        fDDS.Start();
 
         // subscribe to device state changes, pushing new state changes into the event queue
         SubscribeToDeviceStateChange([&](DeviceState newState) {

--- a/fairmq/plugins/DDS/DDS.h
+++ b/fairmq/plugins/DDS/DDS.h
@@ -64,7 +64,10 @@ struct DDSSubscription
         });
 
         assert(!dds_session_id.empty());
-        fService.start(dds_session_id);
+    }
+
+    auto Start() -> void {
+        fService.start(dds::env_prop<dds::dds_session_id>());
     }
 
     ~DDSSubscription() {

--- a/fairmq/sdk/Topology.cxx
+++ b/fairmq/sdk/Topology.cxx
@@ -72,7 +72,7 @@ Topology::Topology(DDSTopology topo, DDSSession session)
 {
     std::vector<uint64_t> deviceList = fDDSTopo.GetDeviceList();
     for (const auto& d : deviceList) {
-        LOG(info) << "Adding device " << d;
+        // LOG(debug) << "Adding device " << d;
         fState.emplace(d, DeviceStatus{ false, DeviceState::Ok });
     }
     fDDSSession.SubscribeToCommands([this](const std::string& msg, const std::string& /* condition */, uint64_t senderId) {
@@ -122,7 +122,7 @@ auto Topology::ChangeState(TopologyTransition transition, ChangeStateCallback cb
             throw std::runtime_error("A state change request is already in progress, concurrent requests are currently not supported");
             lock.unlock();
         }
-        LOG(info) << "Initiating ChangeState with " << transition << " to " << expectedState.at(transition);
+        LOG(debug) << "Initiating ChangeState with " << transition << " to " << expectedState.at(transition);
         fStateChangeOngoing = true;
         fChangeStateCallback = cb;
         fStateChangeTimeout = timeout;
@@ -204,7 +204,7 @@ void Topology::AddNewStateEntry(uint64_t senderId, const std::string& state)
 {
     std::size_t pos = state.find("->");
     std::string endState = state.substr(pos + 2);
-    LOG(info) << "Adding new state entry: " << senderId << ", " << state << ", end state: " << endState;
+    // LOG(debug) << "Adding new state entry: " << senderId << ", " << state << ", end state: " << endState;
     {
         try {
             std::unique_lock<std::mutex> lock(fMtx);

--- a/fairmq/sdk/Topology.h
+++ b/fairmq/sdk/Topology.h
@@ -139,6 +139,7 @@ class Topology
     DDSSession fDDSSession;
     DDSTopology fDDSTopo;
     TopologyState fState;
+    std::unordered_map<uint64_t, DeviceStatus> fStateChangesSubscriptions;
     bool fStateChangeOngoing;
     DeviceState fTargetState;
     mutable std::mutex fMtx;

--- a/test/sdk/Fixtures.h
+++ b/test/sdk/Fixtures.h
@@ -57,7 +57,7 @@ struct TopologyFixture : ::testing::Test
         LOG(info) << mDDSTopo;
         auto n(mDDSTopo.GetNumRequiredAgents());
         mDDSSession.SubmitAgents(n);
-        mDDSSession.ActivateTopology(mDDSTopoFile);
+        mDDSSession.ActivateTopology(mDDSTopo);
     }
 
     auto TearDown() -> void override {

--- a/test/sdk/_topology.cxx
+++ b/test/sdk/_topology.cxx
@@ -43,19 +43,11 @@ TEST_F(Topology, ChangeStateAsync)
 
     Topology topo(mDDSTopo, mDDSSession);
     fair::mq::tools::Semaphore blocker;
-    topo.ChangeState(TopologyTransition::Run, [&blocker, &topo](Topology::ChangeStateResult result) {
+    topo.ChangeState(TopologyTransition::InitDevice, [&blocker, &topo](Topology::ChangeStateResult result) {
         LOG(info) << result;
         EXPECT_EQ(result.rc, fair::mq::AsyncOpResultCode::Ok);
         EXPECT_NO_THROW(fair::mq::sdk::AggregateState(result.state));
         EXPECT_EQ(fair::mq::sdk::StateEqualsTo(result.state, fair::mq::sdk::DeviceState::Running), true);
-        blocker.Signal();
-    });
-    blocker.Wait();
-    topo.ChangeState(TopologyTransition::Stop, [&blocker, &topo](Topology::ChangeStateResult result) {
-        LOG(info) << result;
-        EXPECT_EQ(result.rc, fair::mq::AsyncOpResultCode::Ok);
-        EXPECT_NO_THROW(fair::mq::sdk::AggregateState(result.state));
-        EXPECT_EQ(fair::mq::sdk::StateEqualsTo(result.state, fair::mq::sdk::DeviceState::Ready), true);
         blocker.Signal();
     });
     blocker.Wait();

--- a/test/sdk/test_topo.xml
+++ b/test/sdk/test_topo.xml
@@ -27,7 +27,7 @@
 
     <main name="main">
         <task>Sampler</task>
-        <group name="SinkGroup" n="50">
+        <group name="SinkGroup" n="5">
             <task>Sink</task>
         </group>
     </main>


### PR DESCRIPTION
Up to now the DDS plugin only support a mix of internal and external control. With `--control external` (alias for `dynamic` and `interactive`) it does not attempt to do any control action internally. Moreover, `external` is the default value now.

The `fairmq-dds-command-ui -n` option is only a temporary solution and should be improved on further (#188).

Resolves #184.