### PR TITLE
FairMQ: Require Boost 1.66

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,7 +105,7 @@ if(BUILD_FAIRMQ OR BUILD_SDK)
     set(Boost_NO_BOOST_CMAKE ON)
   endif()
   find_package2(PUBLIC Boost REQUIRED
-    VERSION 1.64
+    VERSION 1.66
 
     COMPONENTS
     container


### PR DESCRIPTION
In `1.4` we use functionality only available since Boost `1.66` but we missed bumping the version requirement.