### PR TITLE
Add sdk::GroupByCollectionId(TopologyState)

### DIFF
--- a/FairMQTest.cmake
+++ b/FairMQTest.cmake
@@ -29,13 +29,13 @@ Set(configure_options "${configure_options};-DCMAKE_PREFIX_PATH=$ENV{SIMPATH}")
 Set(configure_options "${configure_options};-DBUILD_NANOMSG_TRANSPORT=ON")
 # Set(configure_options "${configure_options};-DBUILD_OFI_TRANSPORT=ON")
 Set(configure_options "${configure_options};-DBUILD_DDS_PLUGIN=ON")
-Set(configure_options "${configure_options};-DBUILD_SDK=OFF")
+Set(configure_options "${configure_options};-DBUILD_SDK=ON")
 Set(configure_options "${configure_options};-DFAST_BUILD=ON")
 Set(configure_options "${configure_options};-DCOTIRE_MAXIMUM_NUMBER_OF_UNITY_INCLUDES=-j$ENV{number_of_processors}")
 
 Set(EXTRA_FLAGS $ENV{EXTRA_FLAGS})
 If(EXTRA_FLAGS)
-  Set(configure_options "${configure_options};${EXTRA_FLAGS}") 
+  Set(configure_options "${configure_options};${EXTRA_FLAGS}")
 EndIf()
 
 If($ENV{ctest_model} MATCHES Profile)
@@ -58,7 +58,7 @@ Ctest_Configure(BUILD "${CTEST_BINARY_DIRECTORY}"
 
 Ctest_Build(BUILD "${CTEST_BINARY_DIRECTORY}")
 
-Ctest_Test(BUILD "${CTEST_BINARY_DIRECTORY}" 
+Ctest_Test(BUILD "${CTEST_BINARY_DIRECTORY}"
            # PARALLEL_LEVEL $ENV{number_of_processors}
            PARALLEL_LEVEL $ENV{number_of_processors}
            RETURN_VALUE _ctest_test_ret_val
@@ -78,7 +78,7 @@ If("$ENV{do_codecov_upload}")
 EndIf()
 
 Ctest_Submit()
- 
+
 if (_ctest_test_ret_val)
   Message(FATAL_ERROR "Some tests failed.")
 endif()

--- a/FairMQTest.cmake
+++ b/FairMQTest.cmake
@@ -43,6 +43,7 @@ If($ENV{ctest_model} MATCHES Profile)
   If(GCOV_COMMAND)
     Message("Found GCOV: ${GCOV_COMMAND}")
     Set(CTEST_COVERAGE_COMMAND ${GCOV_COMMAND})
+    set(CTEST_COVERAGE_EXTRA_FLAGS "-p")
   EndIf(GCOV_COMMAND)
 EndIf()
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,11 +22,11 @@ def jobMatrix(String prefix, List specs, Closure callback) {
             echo "export SIMPATH=\${SIMPATH_PREFIX}${fairsoft}" >> Dart.cfg
             echo "export FAIRSOFT_VERSION=${fairsoft}" >> Dart.cfg
           """
-          if (os =~ /Debian/ && compiler =~ /gcc8/) {
+          if (os =~ /Debian/ && compiler =~ /gcc9/) {
             sh '''\
               echo "source /etc/profile.d/modules.sh" >> Dart.cfg
               echo "module use /cvmfs/it.gsi.de/modulefiles" >> Dart.cfg
-              echo "module load compiler/gcc/8" >> Dart.cfg
+              echo "module load compiler/gcc/9.1.0" >> Dart.cfg
             '''
           }
           if (os =~ /MacOS/) {
@@ -66,7 +66,7 @@ pipeline{
       steps{
         script {
           def build_jobs = jobMatrix('alfa-ci/build', [
-            [os: 'Debian8',    arch: 'x86_64', compiler: 'gcc8.1.0',        fairsoft: 'fairmq_dev'],
+            [os: 'Debian8',    arch: 'x86_64', compiler: 'gcc9.1.0',        fairsoft: 'fairmq_dev'],
             [os: 'MacOS10.13', arch: 'x86_64', compiler: 'AppleLLVM10.0.0', fairsoft: 'fairmq_dev'],
             [os: 'MacOS10.14', arch: 'x86_64', compiler: 'AppleLLVM10.0.0', fairsoft: 'fairmq_dev'],
           ]) { spec, label ->
@@ -74,7 +74,7 @@ pipeline{
           }
 
           def profile_jobs = jobMatrix('alfa-ci/codecov', [
-            [os: 'Debian8',    arch: 'x86_64', compiler: 'gcc8.1.0',        fairsoft: 'fairmq_dev'],
+            [os: 'Debian8',    arch: 'x86_64', compiler: 'gcc9.1.0',        fairsoft: 'fairmq_dev'],
           ]) { spec, label ->
             withCredentials([string(credentialsId: 'fairmq_codecov_token', variable: 'CODECOV_TOKEN')]) {
               sh './Dart.sh codecov Dart.cfg'

--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -21,11 +21,11 @@ def buildMatrix(List specs, Closure callback) {
             echo "export SIMPATH=\${SIMPATH_PREFIX}${fairsoft}" >> Dart.cfg
             echo "export FAIRSOFT_VERSION=${fairsoft}" >> Dart.cfg
           """
-          if (os =~ /Debian/ && compiler =~ /gcc8/) {
+          if (os =~ /Debian/ && compiler =~ /gcc9/) {
             sh '''\
               echo "source /etc/profile.d/modules.sh" >> Dart.cfg
               echo "module use /cvmfs/it.gsi.de/modulefiles" >> Dart.cfg
-              echo "module load compiler/gcc/8" >> Dart.cfg
+              echo "module load compiler/gcc/9.1.0" >> Dart.cfg
             '''
           }
           if (os =~ /MacOS/) {
@@ -63,7 +63,7 @@ pipeline{
       steps{
         script {
           parallel(buildMatrix([
-            [os: 'Debian8',    arch: 'x86_64', compiler: 'gcc8.1.0',        fairsoft: 'fairmq_dev'],
+            [os: 'Debian8',    arch: 'x86_64', compiler: 'gcc9.1.0',        fairsoft: 'fairmq_dev'],
             [os: 'MacOS10.13', arch: 'x86_64', compiler: 'AppleLLVM10.0.0', fairsoft: 'fairmq_dev'],
             [os: 'MacOS10.14', arch: 'x86_64', compiler: 'AppleLLVM10.0.0', fairsoft: 'fairmq_dev'],
           ]) { spec, label ->

--- a/fairmq/plugins/Control.cxx
+++ b/fairmq/plugins/Control.cxx
@@ -427,6 +427,9 @@ auto Control::RunShutdownSequence() -> void
             case DeviceState::Idle:
                 ChangeDeviceState(DeviceStateTransition::End);
                 break;
+            case DeviceState::InitializingDevice:
+                ChangeDeviceState(DeviceStateTransition::CompleteInit);
+                break;
             case DeviceState::Initialized:
             case DeviceState::Bound:
             case DeviceState::DeviceReady:

--- a/fairmq/sdk/CMakeLists.txt
+++ b/fairmq/sdk/CMakeLists.txt
@@ -18,6 +18,7 @@ set(SDK_PUBLIC_HEADER_FILES
   AsioAsyncOp.h
   AsioBase.h
   DDSAgent.h
+  DDSCollection.h
   DDSEnvironment.h
   DDSSession.h
   DDSTask.h

--- a/fairmq/sdk/DDSCollection.h
+++ b/fairmq/sdk/DDSCollection.h
@@ -1,0 +1,49 @@
+/********************************************************************************
+ *    Copyright (C) 2019 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ *                                                                              *
+ *              This software is distributed under the terms of the             *
+ *              GNU Lesser General Public Licence (LGPL) version 3,             *
+ *                  copied verbatim in the file "LICENSE"                       *
+ ********************************************************************************/
+
+#ifndef FAIR_MQ_SDK_DDSCOLLECTION_H
+#define FAIR_MQ_SDK_DDSCOLLECTION_H
+
+// #include <fairmq/sdk/DDSAgent.h>
+
+#include <ostream>
+#include <cstdint>
+
+namespace fair {
+namespace mq {
+namespace sdk {
+
+/**
+ * @class DDSCollection <fairmq/sdk/DDSCollection.h>
+ * @brief Represents a DDS collection
+ */
+class DDSCollection
+{
+  public:
+    using Id = std::uint64_t;
+
+    explicit DDSCollection(Id id)
+        : fId(id)
+    {}
+
+    Id GetId() const { return fId; }
+
+    friend auto operator<<(std::ostream& os, const DDSCollection& collection) -> std::ostream&
+    {
+        return os << "DDSCollection id: " << collection.fId;
+    }
+
+  private:
+    Id fId;
+};
+
+}   // namespace sdk
+}   // namespace mq
+}   // namespace fair
+
+#endif /* FAIR_MQ_SDK_DDSCOLLECTION_H */

--- a/fairmq/sdk/DDSSession.cxx
+++ b/fairmq/sdk/DDSSession.cxx
@@ -254,7 +254,7 @@ auto DDSSession::RequestTaskInfo() -> std::vector<DDSTask>
     std::vector<DDSTask> taskInfo;
     taskInfo.reserve(res.size());
     for (auto& a : res) {
-        taskInfo.emplace_back(a.m_taskID);
+        taskInfo.emplace_back(a.m_taskID, 0);
     }
 
     return taskInfo;

--- a/fairmq/sdk/DDSTask.h
+++ b/fairmq/sdk/DDSTask.h
@@ -9,7 +9,7 @@
 #ifndef FAIR_MQ_SDK_DDSTASK_H
 #define FAIR_MQ_SDK_DDSTASK_H
 
-// #include <fairmq/sdk/DDSAgent.h>
+#include <fairmq/sdk/DDSCollection.h>
 
 #include <ostream>
 #include <cstdint>
@@ -27,19 +27,22 @@ class DDSTask
   public:
     using Id = std::uint64_t;
 
-    explicit DDSTask(Id id)
+    explicit DDSTask(Id id, Id collectionId)
         : fId(id)
+        , fCollectionId(collectionId)
     {}
 
     Id GetId() const { return fId; }
+    DDSCollection::Id GetCollectionId() const { return fCollectionId; }
 
     friend auto operator<<(std::ostream& os, const DDSTask& task) -> std::ostream&
     {
-        return os << "DDSTask id: " << task.fId;
+        return os << "DDSTask id: " << task.fId << ", collection id: " << task.fCollectionId;
     }
 
   private:
     Id fId;
+    DDSCollection::Id fCollectionId;
 };
 
 }   // namespace sdk

--- a/fairmq/sdk/DDSTopology.cxx
+++ b/fairmq/sdk/DDSTopology.cxx
@@ -80,10 +80,31 @@ auto DDSTopology::GetTasks() const -> std::vector<DDSTask>
     auto tasks = boost::make_iterator_range(itPair.first, itPair.second);
 
     for (const auto& task : tasks) {
-        LOG(debug) << "Found task " << task.first << ": "
+        LOG(debug) << "Found task with id: " << task.first << ", "
                    << "Path: " << task.second.m_taskPath << ", "
+                   << "Collection id: " << task.second.m_taskCollectionId << ", "
                    << "Name: " << task.second.m_task->getName() << "_" << task.second.m_taskIndex;
-        list.emplace_back(task.first);
+        list.emplace_back(task.first, task.second.m_taskCollectionId);
+    }
+
+    return list;
+}
+
+auto DDSTopology::GetCollections() const -> std::vector<DDSCollection>
+{
+    std::vector<DDSCollection> list;
+
+    auto itPair = fImpl->fTopo.getRuntimeCollectionIterator(
+        [](const dds::topology_api::STopoRuntimeCollection::FilterIterator_t::value_type&) -> bool {
+            return true;
+        });
+    auto collections = boost::make_iterator_range(itPair.first, itPair.second);
+
+    for (const auto& c : collections) {
+        LOG(debug) << "Found collection with id: " << c.first << ", "
+                   << "Index: " << c.second.m_collectionIndex << ", "
+                   << "Path: " << c.second.m_collectionPath;
+        list.emplace_back(c.first);
     }
 
     return list;

--- a/fairmq/sdk/DDSTopology.h
+++ b/fairmq/sdk/DDSTopology.h
@@ -10,6 +10,7 @@
 #define FAIR_MQ_SDK_DDSTOPOLOGY_H
 
 #include <boost/filesystem.hpp>
+#include <fairmq/sdk/DDSCollection.h>
 #include <fairmq/sdk/DDSEnvironment.h>
 #include <fairmq/sdk/DDSInfo.h>
 #include <fairmq/sdk/DDSTask.h>
@@ -53,6 +54,9 @@ class DDSTopology
 
     /// @brief Get list of tasks in this topology
     auto GetTasks() const -> std::vector<DDSTask>;
+
+    /// @brief Get list of tasks in this topology
+    auto GetCollections() const -> std::vector<DDSCollection>;
 
     /// @brief Get the name of the topology
     auto GetName() const -> std::string;

--- a/fairmq/sdk/Topology.h
+++ b/fairmq/sdk/Topology.h
@@ -102,6 +102,16 @@ inline TopologyStateByCollection GroupByCollectionId(const TopologyState& topolo
     return state;
 }
 
+inline TopologyStateByTask GroupByTaskId(const TopologyState& topologyState)
+{
+    TopologyStateByTask state;
+    for (const auto& ds : topologyState) {
+        state[ds.taskId] = ds;
+    }
+
+    return state;
+}
+
 /**
  * @class BasicTopology Topology.h <fairmq/sdk/Topology.h>
  * @tparam Executor Associated I/O executor

--- a/test/sdk/Fixtures.h
+++ b/test/sdk/Fixtures.h
@@ -59,13 +59,26 @@ struct TopologyFixture : ::testing::Test
         auto n(mDDSTopo.GetNumRequiredAgents());
         mDDSSession.SubmitAgents(n);
         mDDSSession.ActivateTopology(mDDSTopo);
+
         std::vector<sdk::DDSAgent> agents = mDDSSession.RequestAgentInfo();
+        LOG(debug) << "##### AgentInfo:";
+        LOG(debug) << "size: " << agents.size();
         for (const auto& a : agents) {
             LOG(debug) << a;
         }
+
         std::vector<sdk::DDSTask> tasks = mDDSSession.RequestTaskInfo();
+        LOG(debug) << "##### TaskInfo:";
+        LOG(debug) << "size: " << tasks.size();
         for (const auto& t : tasks) {
             LOG(debug) << t;
+        }
+
+        std::vector<sdk::DDSCollection> collections = mDDSTopo.GetCollections();
+        LOG(debug) << "##### CollectionInfo:";
+        LOG(debug) << "size: " << collections.size();
+        for (const auto& c : collections) {
+            LOG(debug) << c;
         }
     }
 

--- a/test/sdk/test_topo.xml
+++ b/test/sdk/test_topo.xml
@@ -25,10 +25,16 @@
         </properties>
     </decltask>
 
+    <declcollection name="Sinks">
+        <tasks>
+            <name>Sink</name>
+        </tasks>
+    </declcollection>
+
     <main name="main">
         <task>Sampler</task>
         <group name="SinkGroup" n="5">
-            <task>Sink</task>
+            <collection>Sinks</collection>
         </group>
     </main>
 


### PR DESCRIPTION
Add a simple GroupByCollectionId implementation and related (or less related) changes:

- sdk: Add `DDSCollection` class
- sdk: Add `DDSTopology::GetCollections()` and extend `DDSTask`
- Add collections to test topology
- Add `sdk::GroupByCollectionId(TopologyState)`
- Add test for `sdk::GroupByCollectionId(TopologyState)`
- Handle InitializingDevice in the ShutdownSequence 

`sdk::TopologyState` is now a `std::vector<DeviceStatus>`, and `DeviceStatus` contains task id and collection id.

For #204.