### PR TITLE
Sdk tweaks

### DIFF
--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -46,6 +46,10 @@ def buildMatrix(List specs, Closure callback) {
 
           deleteDir()
         } catch (e) {
+          def tarball = "${label}_dds_logs.tar.gz"
+          sh "tar czvf ${tarball} -C \${WORKSPACE}/build/test/ .DDS/"
+          archiveArtifacts tarball
+
           deleteDir()
           throw e
         }

--- a/examples/dds/ex-dds-topology-infinite.xml
+++ b/examples/dds/ex-dds-topology-infinite.xml
@@ -1,7 +1,7 @@
 <topology name="ExampleDDS">
 
-    <property name="data1" />
-    <property name="data2" />
+    <property name="fmqchan_data1" />
+    <property name="fmqchan_data2" />
 
     <declrequirement name="SamplerWorker" type="wnname" value="sampler"/>
     <declrequirement name="ProcessorWorker" type="wnname" value="processor"/>
@@ -14,7 +14,7 @@
             <name>SamplerWorker</name>
         </requirements>
         <properties>
-            <name access="write">data1</name>
+            <name access="write">fmqchan_data1</name>
         </properties>
     </decltask>
 
@@ -25,8 +25,8 @@
             <name>ProcessorWorker</name>
         </requirements>
         <properties>
-            <name access="read">data1</name>
-            <name access="read">data2</name>
+            <name access="read">fmqchan_data1</name>
+            <name access="read">fmqchan_data2</name>
         </properties>
     </decltask>
 
@@ -37,7 +37,7 @@
             <name>SinkWorker</name>
         </requirements>
         <properties>
-            <name access="write">data2</name>
+            <name access="write">fmqchan_data2</name>
         </properties>
     </decltask>
 

--- a/examples/dds/ex-dds-topology.xml
+++ b/examples/dds/ex-dds-topology.xml
@@ -1,7 +1,7 @@
 <topology name="ExampleDDS">
 
-    <property name="data1" />
-    <property name="data2" />
+    <property name="fmqchan_data1" />
+    <property name="fmqchan_data2" />
 
     <declrequirement name="SamplerWorker" type="wnname" value="sampler"/>
     <declrequirement name="ProcessorWorker" type="wnname" value="processor"/>
@@ -14,7 +14,7 @@
             <name>SamplerWorker</name>
         </requirements>
         <properties>
-            <name access="write">data1</name>
+            <name access="write">fmqchan_data1</name>
         </properties>
     </decltask>
 
@@ -25,8 +25,8 @@
             <name>ProcessorWorker</name>
         </requirements>
         <properties>
-            <name access="read">data1</name>
-            <name access="read">data2</name>
+            <name access="read">fmqchan_data1</name>
+            <name access="read">fmqchan_data2</name>
         </properties>
     </decltask>
 
@@ -37,7 +37,7 @@
             <name>SinkWorker</name>
         </requirements>
         <properties>
-            <name access="write">data2</name>
+            <name access="write">fmqchan_data2</name>
         </properties>
     </decltask>
 

--- a/fairmq/FairMQDevice.cxx
+++ b/fairmq/FairMQDevice.cxx
@@ -10,10 +10,6 @@
 
 #include <boost/algorithm/string.hpp> // join/split
 
-#include <boost/uuid/uuid.hpp>
-#include <boost/uuid/uuid_generators.hpp>
-#include <boost/uuid/uuid_io.hpp>
-
 #include <list>
 #include <cstdlib>
 #include <chrono>

--- a/fairmq/sdk/DDSTopology.h
+++ b/fairmq/sdk/DDSTopology.h
@@ -16,6 +16,7 @@
 #include <fairmq/sdk/DDSTask.h>
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace fair {
 namespace mq {

--- a/test/sdk/test_topo.xml
+++ b/test/sdk/test_topo.xml
@@ -1,6 +1,6 @@
 <topology name="ExampleDDS">
 
-    <property name="data" />
+    <property name="fmqchan_data" />
 
     <declrequirement name="SamplerWorker" type="wnname" value="sampler"/>
     <declrequirement name="SinkWorker" type="wnname" value="sink"/>
@@ -11,7 +11,7 @@
             <name>SamplerWorker</name>
         </requirements>
         <properties>
-            <name access="write">data</name>
+            <name access="write">fmqchan_data</name>
         </properties>
     </decltask>
 
@@ -21,7 +21,7 @@
             <name>SinkWorker</name>
         </requirements>
         <properties>
-            <name access="read">data</name>
+            <name access="read">fmqchan_data</name>
         </properties>
     </decltask>
 


### PR DESCRIPTION
- Slight optimization in the container handling in the SDK::Topology - simplify the map content and keep the final vector around from the beginning to avoid copy at the end.

- breaking change in the topology xml files: properties that are used for channel communication are now prefixed with `fmqchan_<property_name>`.
