### PR TITLE
Shmem fixes

### DIFF
--- a/examples/1-1/Sampler.cxx
+++ b/examples/1-1/Sampler.cxx
@@ -6,9 +6,6 @@
  *                  copied verbatim in the file "LICENSE"                       *
  ********************************************************************************/
 
-#include <thread> // this_thread::sleep_for
-#include <chrono>
-
 #include "Sampler.h"
 
 using namespace std;

--- a/examples/multipart/CMakeLists.txt
+++ b/examples/multipart/CMakeLists.txt
@@ -32,19 +32,19 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/fairmq-start-ex-multipart.sh.in ${CMA
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/test-ex-multipart.sh.in ${CMAKE_CURRENT_BINARY_DIR}/test-ex-multipart.sh)
 
 add_test(NAME Example.Multipart.zeromq COMMAND ${CMAKE_CURRENT_BINARY_DIR}/test-ex-multipart.sh zeromq)
-set_tests_properties(Example.Multipart.zeromq PROPERTIES TIMEOUT "30" RUN_SERIAL true PASS_REGULAR_EXPRESSION "Received message with 5 parts")
+set_tests_properties(Example.Multipart.zeromq PROPERTIES TIMEOUT "30" RUN_SERIAL true PASS_REGULAR_EXPRESSION "Received message with 7 parts")
 
 if(BUILD_NANOMSG_TRANSPORT)
   add_test(NAME Example.Multipart.nanomsg COMMAND ${CMAKE_CURRENT_BINARY_DIR}/test-ex-multipart.sh nanomsg)
-  set_tests_properties(Example.Multipart.nanomsg PROPERTIES TIMEOUT "30" RUN_SERIAL true PASS_REGULAR_EXPRESSION "Received message with 5 parts")
+  set_tests_properties(Example.Multipart.nanomsg PROPERTIES TIMEOUT "30" RUN_SERIAL true PASS_REGULAR_EXPRESSION "Received message with 7 parts")
 endif()
 
 add_test(NAME Example.Multipart.shmem COMMAND ${CMAKE_CURRENT_BINARY_DIR}/test-ex-multipart.sh shmem)
-set_tests_properties(Example.Multipart.shmem PROPERTIES TIMEOUT "30" RUN_SERIAL true PASS_REGULAR_EXPRESSION "Received message with 5 parts")
+set_tests_properties(Example.Multipart.shmem PROPERTIES TIMEOUT "30" RUN_SERIAL true PASS_REGULAR_EXPRESSION "Received message with 7 parts")
 
 if(BUILD_OFI_TRANSPORT)
   add_test(NAME Example.Multipart.ofi COMMAND ${CMAKE_CURRENT_BINARY_DIR}/test-ex-multipart.sh ofi)
-  set_tests_properties(Example.Multipart.ofi PROPERTIES TIMEOUT "30" RUN_SERIAL true PASS_REGULAR_EXPRESSION "Received message with 5 parts")
+  set_tests_properties(Example.Multipart.ofi PROPERTIES TIMEOUT "30" RUN_SERIAL true PASS_REGULAR_EXPRESSION "Received message with 7 parts")
 endif()
 
 # install

--- a/examples/multipart/Sampler.cxx
+++ b/examples/multipart/Sampler.cxx
@@ -40,8 +40,7 @@ bool Sampler::ConditionalRun()
     header.stopFlag = 0;
 
     // Set stopFlag to 1 for last message.
-    if (fMaxIterations > 0 && fNumIterations == fMaxIterations - 1)
-    {
+    if (fMaxIterations > 0 && fNumIterations == fMaxIterations - 1) {
         header.stopFlag = 1;
     }
     LOG(info) << "Sending header with stopFlag: " << header.stopFlag;
@@ -60,13 +59,16 @@ bool Sampler::ConditionalRun()
     assert(auxData.Size() == 0);
     assert(parts.Size() == 5);
 
+    parts.AddPart(NewMessage());
+
+    assert(parts.Size() == 6);
+
     LOG(info) << "Sending body of size: " << parts.At(1)->GetSize();
 
     Send(parts, "data");
 
     // Go out of the sending loop if the stopFlag was sent.
-    if (fMaxIterations > 0 && ++fNumIterations >= fMaxIterations)
-    {
+    if (fMaxIterations > 0 && ++fNumIterations >= fMaxIterations) {
         LOG(info) << "Configured maximum number of iterations reached. Leaving RUNNING state.";
         return false;
     }
@@ -75,10 +77,6 @@ bool Sampler::ConditionalRun()
     this_thread::sleep_for(chrono::seconds(1));
 
     return true;
-}
-
-Sampler::~Sampler()
-{
 }
 
 } // namespace example_multipart

--- a/examples/multipart/Sampler.cxx
+++ b/examples/multipart/Sampler.cxx
@@ -63,6 +63,10 @@ bool Sampler::ConditionalRun()
 
     assert(parts.Size() == 6);
 
+    parts.AddPart(NewMessage(100));
+
+    assert(parts.Size() == 7);
+
     LOG(info) << "Sending body of size: " << parts.At(1)->GetSize();
 
     Send(parts, "data");

--- a/examples/multipart/Sampler.h
+++ b/examples/multipart/Sampler.h
@@ -24,7 +24,7 @@ class Sampler : public FairMQDevice
 {
   public:
     Sampler();
-    virtual ~Sampler();
+    virtual ~Sampler() {}
 
   protected:
     virtual void InitTask();

--- a/examples/multipart/Sink.cxx
+++ b/examples/multipart/Sink.cxx
@@ -20,11 +20,6 @@ using namespace std;
 namespace example_multipart
 {
 
-Sink::Sink()
-{
-    OnData("data", &Sink::HandleData);
-}
-
 bool Sink::HandleData(FairMQParts& parts, int /*index*/)
 {
     Header header;
@@ -35,17 +30,12 @@ bool Sink::HandleData(FairMQParts& parts, int /*index*/)
     LOG(info) << "Received header with stopFlag: " << header.stopFlag;
     LOG(info) << "Received body of size: " << parts.At(1)->GetSize();
 
-    if (header.stopFlag == 1)
-    {
+    if (header.stopFlag == 1) {
         LOG(info) << "stopFlag is 1, going IDLE";
         return false;
     }
 
     return true;
-}
-
-Sink::~Sink()
-{
 }
 
 }

--- a/examples/multipart/Sink.cxx
+++ b/examples/multipart/Sink.cxx
@@ -22,13 +22,24 @@ namespace example_multipart
 
 bool Sink::HandleData(FairMQParts& parts, int /*index*/)
 {
+    LOG(info) << "Received message with " << parts.Size() << " parts";
+
     Header header;
     header.stopFlag = (static_cast<Header*>(parts.At(0)->GetData()))->stopFlag;
 
-    LOG(info) << "Received message with " << parts.Size() << " parts";
-
-    LOG(info) << "Received header with stopFlag: " << header.stopFlag;
-    LOG(info) << "Received body of size: " << parts.At(1)->GetSize();
+    LOG(info) << "Received part 1 (header) with stopFlag: " << header.stopFlag;
+    LOG(info) << "Received part 2 of size: " << parts.At(1)->GetSize();
+    assert(parts.At(1)->GetSize() == 1000);
+    LOG(info) << "Received part 3 of size: " << parts.At(2)->GetSize();
+    assert(parts.At(2)->GetSize() == 500);
+    LOG(info) << "Received part 4 of size: " << parts.At(3)->GetSize();
+    assert(parts.At(3)->GetSize() == 600);
+    LOG(info) << "Received part 5 of size: " << parts.At(4)->GetSize();
+    assert(parts.At(4)->GetSize() == 700);
+    LOG(info) << "Received part 6 of size: " << parts.At(5)->GetSize();
+    assert(parts.At(5)->GetSize() == 0);
+    LOG(info) << "Received part 7 of size: " << parts.At(6)->GetSize();
+    assert(parts.At(6)->GetSize() == 100);
 
     if (header.stopFlag == 1) {
         LOG(info) << "stopFlag is 1, going IDLE";

--- a/examples/multipart/Sink.h
+++ b/examples/multipart/Sink.h
@@ -23,8 +23,8 @@ namespace example_multipart
 class Sink : public FairMQDevice
 {
   public:
-    Sink();
-    virtual ~Sink();
+    Sink() { OnData("data", &Sink::HandleData); }
+    virtual ~Sink() {}
 
   protected:
     bool HandleData(FairMQParts&, int);

--- a/examples/multipart/fairmq-start-ex-multipart.sh.in
+++ b/examples/multipart/fairmq-start-ex-multipart.sh.in
@@ -2,12 +2,24 @@
 
 export FAIRMQ_PATH=@FAIRMQ_BIN_DIR@
 
+transport="zeromq"
+
+if [[ $1 =~ ^[a-z]+$ ]]; then
+    transport=$1
+fi
+
+SESSION="$(@CMAKE_BINARY_DIR@/fairmq/fairmq-uuid-gen -h)"
+
 SAMPLER="fairmq-ex-multipart-sampler"
 SAMPLER+=" --id sampler1"
+SAMPLER+=" --transport $transport"
+SAMPLER+=" --session $SESSION"
 SAMPLER+=" --channel-config name=data,type=push,method=connect,rateLogging=0,address=tcp://127.0.0.1:5555"
 xterm -geometry 80x23+0+0 -hold -e @EX_BIN_DIR@/$SAMPLER &
 
 SINK="fairmq-ex-multipart-sink"
 SINK+=" --id sink1"
+SINK+=" --transport $transport"
+SINK+=" --session $SESSION"
 SINK+=" --channel-config name=data,type=pull,method=bind,rateLogging=0,address=tcp://127.0.0.1:5555"
 xterm -geometry 80x23+500+0 -hold -e @EX_BIN_DIR@/$SINK &

--- a/examples/readout/fairmq-start-ex-readout-processing.sh.in
+++ b/examples/readout/fairmq-start-ex-readout-processing.sh.in
@@ -31,10 +31,12 @@ SENDER="fairmq-ex-readout-sender"
 SENDER+=" --id sender1"
 SENDER+=" --input-name ps"
 SENDER+=" --channel-config name=ps,type=pair,method=bind,address=tcp://localhost:7779,transport=shmem"
-SENDER+="                  name=sr,type=pair,method=connect,address=tcp://localhost:7780,transport=ofi"
+#SENDER+="                  name=sr,type=pair,method=connect,address=tcp://localhost:7780,transport=ofi"
+SENDER+="                  name=sr,type=pair,method=connect,address=tcp://localhost:7780,transport=zeromq"
 xterm -geometry 80x23+1000+0 -hold -e @EX_BIN_DIR@/$SENDER &
 
 RECEIVER="fairmq-ex-readout-receiver"
 RECEIVER+=" --id receiver1"
-RECEIVER+=" --channel-config name=sr,type=pair,method=bind,address=tcp://localhost:7780,transport=ofi"
+#RECEIVER+=" --channel-config name=sr,type=pair,method=bind,address=tcp://localhost:7780,transport=ofi"
+RECEIVER+=" --channel-config name=sr,type=pair,method=bind,address=tcp://localhost:7780,transport=zeromq"
 xterm -geometry 80x23+1500+0 -hold -e @EX_BIN_DIR@/$RECEIVER &

--- a/examples/readout/fairmq-start-ex-readout.sh.in
+++ b/examples/readout/fairmq-start-ex-readout.sh.in
@@ -25,10 +25,12 @@ SENDER="fairmq-ex-readout-sender"
 SENDER+=" --id sender1"
 SENDER+=" --input-name bs"
 SENDER+=" --channel-config name=bs,type=pair,method=bind,address=tcp://localhost:7778,transport=shmem"
-SENDER+="                  name=sr,type=pair,method=connect,address=tcp://localhost:7779,transport=ofi"
+# SENDER+="                  name=sr,type=pair,method=connect,address=tcp://localhost:7779,transport=ofi"
+SENDER+="                  name=sr,type=pair,method=connect,address=tcp://localhost:7779,transport=zeromq"
 xterm -geometry 80x23+1000+0 -hold -e @EX_BIN_DIR@/$SENDER &
 
 RECEIVER="fairmq-ex-readout-receiver"
 RECEIVER+=" --id receiver1"
-RECEIVER+=" --channel-config name=sr,type=pair,method=bind,address=tcp://localhost:7779,transport=ofi"
+# RECEIVER+=" --channel-config name=sr,type=pair,method=bind,address=tcp://localhost:7779,transport=ofi"
+RECEIVER+=" --channel-config name=sr,type=pair,method=bind,address=tcp://localhost:7779,transport=zeromq"
 xterm -geometry 80x23+1500+0 -hold -e @EX_BIN_DIR@/$RECEIVER &

--- a/fairmq/EventManager.h
+++ b/fairmq/EventManager.h
@@ -12,12 +12,10 @@
 #include <memory>
 #include <mutex>
 #include <string>
-#include <tuple>
 #include <typeindex>
-#include <typeinfo>
 #include <unordered_map>
 #include <utility>
-#include <vector>
+#include <functional>
 
 #include <boost/any.hpp>
 #include <boost/functional/hash.hpp>

--- a/fairmq/FairMQChannel.cxx
+++ b/fairmq/FairMQChannel.cxx
@@ -7,7 +7,8 @@
  ********************************************************************************/
 
 #include "FairMQChannel.h"
-#include <fairmq/Tools.h>
+#include <fairmq/tools/Strings.h>
+#include <fairmq/Properties.h>
 
 #include <boost/algorithm/string.hpp> // join/split
 

--- a/fairmq/FairMQChannel.h
+++ b/fairmq/FairMQChannel.h
@@ -10,6 +10,7 @@
 #define FAIRMQCHANNEL_H_
 
 #include <FairMQTransportFactory.h>
+#include <FairMQUnmanagedRegion.h>
 #include <FairMQSocket.h>
 #include <fairmq/Transports.h>
 #include <FairMQLogger.h>
@@ -17,15 +18,14 @@
 #include <fairmq/Properties.h>
 #include <FairMQMessage.h>
 
-#include <boost/any.hpp>
-
 #include <string>
 #include <memory> // unique_ptr, shared_ptr
 #include <vector>
-#include <atomic>
 #include <mutex>
 #include <stdexcept>
 #include <utility> // std::move
+#include <cstddef> // size_t
+#include <cstdint> // int64_t
 
 class FairMQChannel
 {

--- a/fairmq/FairMQDevice.cxx
+++ b/fairmq/FairMQDevice.cxx
@@ -8,15 +8,15 @@
 
 #include <FairMQDevice.h>
 
+#include <fairmq/tools/RateLimit.h>
+#include <fairmq/tools/Network.h>
+
 #include <boost/algorithm/string.hpp> // join/split
 
 #include <list>
-#include <cstdlib>
 #include <chrono>
 #include <mutex>
 #include <thread>
-#include <functional>
-#include <sstream>
 #include <iomanip>
 #include <future>
 #include <algorithm> // std::max

--- a/fairmq/FairMQDevice.h
+++ b/fairmq/FairMQDevice.h
@@ -14,7 +14,6 @@
 #include <fairmq/Transports.h>
 #include <fairmq/StateQueue.h>
 
-#include <FairMQSocket.h>
 #include <FairMQChannel.h>
 #include <FairMQMessage.h>
 #include <FairMQParts.h>
@@ -24,21 +23,19 @@
 
 #include <vector>
 #include <memory> // unique_ptr
-#include <algorithm> // std::sort()
+#include <algorithm> // find
 #include <string>
 #include <chrono>
 #include <iostream>
 #include <unordered_map>
 #include <functional>
-#include <assert.h> // static_assert
-#include <type_traits> // is_trivially_copyable
 #include <stdexcept>
-#include <queue>
-
 #include <mutex>
-#include <condition_variable>
+#include <atomic>
+#include <cstddef>
+#include <utility> // pair
 
-#include <fairmq/Tools.h>
+#include <fairmq/tools/Version.h>
 
 using FairMQChannelMap = std::unordered_map<std::string, std::vector<FairMQChannel>>;
 

--- a/fairmq/FairMQTransportFactory.cxx
+++ b/fairmq/FairMQTransportFactory.cxx
@@ -16,11 +16,10 @@
 #include <fairmq/ofi/TransportFactory.h>
 #endif
 #include <FairMQLogger.h>
-#include <fairmq/Tools.h>
+#include <fairmq/tools/Unique.h>
 
 #include <memory>
 #include <string>
-#include <sstream>
 
 FairMQTransportFactory::FairMQTransportFactory(const std::string& id)
     : fkId(id)

--- a/fairmq/FairMQTransportFactory.h
+++ b/fairmq/FairMQTransportFactory.h
@@ -12,7 +12,6 @@
 #include <FairMQLogger.h>
 #include <FairMQMessage.h>
 #include <FairMQPoller.h>
-#include <fairmq/ProgOptionsFwd.h>
 #include <FairMQSocket.h>
 #include <FairMQUnmanagedRegion.h>
 #include <fairmq/MemoryResources.h>
@@ -22,8 +21,11 @@
 #include <memory>
 #include <vector>
 #include <unordered_map>
+#include <stdexcept>
+#include <cstddef> // size_t
 
 class FairMQChannel;
+namespace fair { namespace mq { class ProgOptions; } }
 
 class FairMQTransportFactory
 {

--- a/fairmq/MemoryResources.h
+++ b/fairmq/MemoryResources.h
@@ -23,11 +23,7 @@ class FairMQTransportFactory;
 #include <boost/container/pmr/monotonic_buffer_resource.hpp>
 #include <boost/container/pmr/polymorphic_allocator.hpp>
 #include <cstring>
-#include <string>
-#include <type_traits>
-#include <unordered_map>
 #include <utility>
-#include <vector>
 
 namespace fair {
 namespace mq {

--- a/fairmq/Plugin.h
+++ b/fairmq/Plugin.h
@@ -9,7 +9,8 @@
 #ifndef FAIR_MQ_PLUGIN_H
 #define FAIR_MQ_PLUGIN_H
 
-#include <fairmq/Tools.h>
+#include <fairmq/tools/CppSTL.h>
+#include <fairmq/tools/Version.h>
 #include <fairmq/PluginServices.h>
 
 #include <boost/dll/alias.hpp>

--- a/fairmq/PluginManager.cxx
+++ b/fairmq/PluginManager.cxx
@@ -8,7 +8,7 @@
 
 #include <fairmq/plugins/Builtin.h>
 #include <fairmq/PluginManager.h>
-#include <fairmq/Tools.h>
+#include <fairmq/tools/Strings.h>
 #include <boost/program_options.hpp>
 #include <algorithm>
 #include <iterator>

--- a/fairmq/PluginManager.h
+++ b/fairmq/PluginManager.h
@@ -11,8 +11,9 @@
 
 #include <fairmq/Plugin.h>
 #include <fairmq/PluginServices.h>
-#include <fairmq/Tools.h>
-#include <FairMQDevice.h>
+#include <fairmq/tools/CppSTL.h>
+#include <fairmq/tools/Strings.h>
+
 #define BOOST_FILESYSTEM_VERSION 3
 #define BOOST_FILESYSTEM_NO_DEPRECATED
 #include <boost/filesystem.hpp>
@@ -21,13 +22,14 @@
 #include <boost/dll/import.hpp>
 #include <boost/dll/shared_library.hpp>
 #include <boost/dll/runtime_symbol_info.hpp>
+
 #include <functional>
 #include <map>
 #include <memory>
 #include <stdexcept>
 #include <string>
-#include <tuple>
 #include <vector>
+#include <utility> // forward
 
 namespace fair
 {

--- a/fairmq/PluginServices.cxx
+++ b/fairmq/PluginServices.cxx
@@ -7,6 +7,7 @@
  ********************************************************************************/
 
 #include <fairmq/PluginServices.h>
+#include <fairmq/tools/Strings.h>
 
 using namespace fair::mq;
 using namespace std;

--- a/fairmq/PluginServices.h
+++ b/fairmq/PluginServices.h
@@ -9,7 +9,6 @@
 #ifndef FAIR_MQ_PLUGINSERVICES_H
 #define FAIR_MQ_PLUGINSERVICES_H
 
-#include <fairmq/Tools.h>
 #include <fairmq/States.h>
 #include <FairMQDevice.h>
 #include <fairmq/ProgOptions.h>

--- a/fairmq/ProgOptions.cxx
+++ b/fairmq/ProgOptions.cxx
@@ -15,7 +15,7 @@
 #include "FairMQLogger.h"
 #include <fairmq/ProgOptions.h>
 
-#include "tools/Unique.h"
+#include <fairmq/tools/Strings.h>
 
 #include <boost/any.hpp>
 #include <boost/regex.hpp>

--- a/fairmq/ProgOptions.h
+++ b/fairmq/ProgOptions.h
@@ -14,7 +14,7 @@
 #include <fairmq/EventManager.h>
 #include <fairmq/ProgOptionsFwd.h>
 #include <fairmq/Properties.h>
-#include <fairmq/Tools.h>
+#include <fairmq/tools/Strings.h>
 
 #include <boost/program_options.hpp>
 

--- a/fairmq/Transports.h
+++ b/fairmq/Transports.h
@@ -9,7 +9,7 @@
 #ifndef FAIR_MQ_TRANSPORTS_H
 #define FAIR_MQ_TRANSPORTS_H
 
-#include <fairmq/Tools.h>
+#include <fairmq/tools/CppSTL.h>
 
 #include <memory>
 #include <string>

--- a/fairmq/devices/FairMQBenchmarkSampler.cxx
+++ b/fairmq/devices/FairMQBenchmarkSampler.cxx
@@ -8,10 +8,9 @@
 
 #include "FairMQBenchmarkSampler.h"
 
-#include <fairmq/Tools.h>
+#include "tools/RateLimit.h"
 #include "../FairMQLogger.h"
 
-#include <vector>
 #include <chrono>
 
 using namespace std;
@@ -24,10 +23,6 @@ FairMQBenchmarkSampler::FairMQBenchmarkSampler()
     , fNumIterations(0)
     , fMaxIterations(0)
     , fOutChannelName()
-{
-}
-
-FairMQBenchmarkSampler::~FairMQBenchmarkSampler()
 {
 }
 

--- a/fairmq/devices/FairMQBenchmarkSampler.h
+++ b/fairmq/devices/FairMQBenchmarkSampler.h
@@ -10,8 +10,10 @@
 #define FAIRMQBENCHMARKSAMPLER_H_
 
 #include <string>
-#include <thread>
 #include <atomic>
+#include <cstddef> // size_t
+#include <cstdint> // uint64_t
+
 
 #include "FairMQDevice.h"
 
@@ -23,7 +25,7 @@ class FairMQBenchmarkSampler : public FairMQDevice
 {
   public:
     FairMQBenchmarkSampler();
-    virtual ~FairMQBenchmarkSampler();
+    virtual ~FairMQBenchmarkSampler() {}
 
   protected:
     bool fMultipart;

--- a/fairmq/plugins/DDS/DDS.cxx
+++ b/fairmq/plugins/DDS/DDS.cxx
@@ -10,19 +10,16 @@
 
 #include <fairmq/sdk/commands/Commands.h>
 
-#include <fairmq/Tools.h>
+#include <fairmq/tools/Strings.h>
 
 #include <boost/algorithm/string/join.hpp>
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/asio/post.hpp>
 
-#include <termios.h> // for the interactive mode
-#include <poll.h> // for the interactive mode
-#include <sstream>
-#include <iostream>
 #include <cstdlib>
 #include <stdexcept>
+#include <sstream>
 
 using namespace std;
 using fair::mq::tools::ToString;
@@ -184,7 +181,7 @@ auto DDS::StaticControl() -> void
         ReleaseDeviceControl();
     } catch (exception& e) {
         ReleaseDeviceControl();
-        LOG(error) << "Error: " << e.what() << endl;
+        LOG(error) << "Error: " << e.what() << "\n";
         return;
     }
 }
@@ -395,7 +392,7 @@ auto DDS::SubscribeForCustomCommands() -> void
                 case Type::dump_config: {
                     stringstream ss;
                     for (const auto pKey: GetPropertyKeys()) {
-                        ss << id << ": " << pKey << " -> " << GetPropertyAsString(pKey) << endl;
+                        ss << id << ": " << pKey << " -> " << GetPropertyAsString(pKey) << "\n";
                     }
                     Cmds outCmds(make<Config>(id, ss.str()));
                     fDDS.Send(outCmds.Serialize(), to_string(senderId));

--- a/fairmq/plugins/DDS/DDS.h
+++ b/fairmq/plugins/DDS/DDS.h
@@ -9,22 +9,24 @@
 #ifndef FAIR_MQ_PLUGINS_DDS
 #define FAIR_MQ_PLUGINS_DDS
 
-#include <DDS/dds_env_prop.h>
-#include <DDS/dds_intercom.h>
-#include <boost/asio/executor.hpp>
-#include <boost/asio/executor_work_guard.hpp>
-#include <boost/asio/io_context.hpp>
-#include <cassert>
-#include <chrono>
-#include <condition_variable>
 #include <fairmq/Plugin.h>
 #include <fairmq/StateQueue.h>
 #include <fairmq/Version.h>
-#include <functional>
+
+#include <DDS/dds_env_prop.h>
+#include <DDS/dds_intercom.h>
+
+#include <boost/asio/executor.hpp>
+#include <boost/asio/executor_work_guard.hpp>
+#include <boost/asio/io_context.hpp>
+
+#include <cassert>
+#include <chrono>
+#include <condition_variable>
 #include <mutex>
-#include <queue>
 #include <set>
 #include <string>
+#include <atomic>
 #include <thread>
 #include <unordered_map>
 #include <vector>

--- a/fairmq/plugins/DDS/runDDSCommandUI.cxx
+++ b/fairmq/plugins/DDS/runDDSCommandUI.cxx
@@ -11,21 +11,14 @@
 
 #include <DDS/dds_intercom.h>
 
-#include <boost/algorithm/string/classification.hpp>
-#include <boost/algorithm/string/predicate.hpp>
-#include <boost/algorithm/string/split.hpp>
-#include <boost/algorithm/string/trim.hpp>
 #include <boost/program_options.hpp>
 
-#include <algorithm>
-#include <atomic>
 #include <condition_variable>
 #include <cstdlib>
-#include <exception>
 #include <iostream>
 #include <mutex>
 #include <string>
-#include <termios.h>   // raw mode console input
+#include <termios.h> // raw mode console input
 #include <thread>
 #include <utility>
 #include <unistd.h>

--- a/fairmq/sdk/Error.h
+++ b/fairmq/sdk/Error.h
@@ -9,7 +9,7 @@
 #ifndef FAIR_MQ_SDK_ERROR_H
 #define FAIR_MQ_SDK_ERROR_H
 
-#include <fairmq/Tools.h>
+#include <fairmq/tools/Strings.h>
 #include <stdexcept>
 #include <system_error>
 

--- a/fairmq/sdk/Topology.h
+++ b/fairmq/sdk/Topology.h
@@ -19,7 +19,7 @@
 #include <fairmq/sdk/DDSTopology.h>
 #include <fairmq/sdk/Error.h>
 #include <fairmq/States.h>
-#include <fairmq/Tools.h>
+#include <fairmq/tools/Semaphore.h>
 
 #include <fairlogger/Logger.h>
 

--- a/fairmq/sdk/commands/Commands.h
+++ b/fairmq/sdk/commands/Commands.h
@@ -10,7 +10,7 @@
 #define FAIR_MQ_SDK_COMMANDFACTORY
 
 #include <fairmq/States.h>
-#include <fairmq/Tools.h>
+#include <fairmq/tools/CppSTL.h>
 
 #include <vector>
 #include <string>

--- a/fairmq/shmem/FairMQMessageSHM.h
+++ b/fairmq/shmem/FairMQMessageSHM.h
@@ -40,15 +40,15 @@ class FairMQMessageSHM final : public FairMQMessage
     void Rebuild(void* data, const size_t size, fairmq_free_fn* ffn, void* hint = nullptr) override;
 
     void* GetData() const override;
-    size_t GetSize() const override;
+    size_t GetSize() const override { return fSize; }
 
     bool SetUsedSize(const size_t size) override;
 
-    fair::mq::Transport GetType() const override;
+    fair::mq::Transport GetType() const override { return fTransportType; }
 
     void Copy(const FairMQMessage& msg) override;
 
-    ~FairMQMessageSHM() override;
+    ~FairMQMessageSHM() override { CloseMessage(); }
 
   private:
     fair::mq::shmem::Manager& fManager;
@@ -65,7 +65,7 @@ class FairMQMessageSHM final : public FairMQMessage
     mutable char* fLocalPtr;
 
     bool InitializeChunk(const size_t size);
-    zmq_msg_t* GetMessage();
+    zmq_msg_t* GetMessage() { return &fMessage; }
     void CloseMessage();
 };
 

--- a/fairmq/shmem/FairMQSocketSHM.h
+++ b/fairmq/shmem/FairMQSocketSHM.h
@@ -34,7 +34,7 @@ class FairMQSocketSHM final : public FairMQSocket
     int64_t Send(std::vector<std::unique_ptr<FairMQMessage>>& msgVec, const int timeout = -1) override;
     int64_t Receive(std::vector<std::unique_ptr<FairMQMessage>>& msgVec, const int timeout = -1) override;
 
-    void* GetSocket() const;
+    void* GetSocket() const { return fSocket; }
 
     void Close() override;
 
@@ -55,14 +55,14 @@ class FairMQSocketSHM final : public FairMQSocket
     void SetRcvKernelSize(const int value) override;
     int GetRcvKernelSize() const override;
 
-    unsigned long GetBytesTx() const override;
-    unsigned long GetBytesRx() const override;
-    unsigned long GetMessagesTx() const override;
-    unsigned long GetMessagesRx() const override;
+    unsigned long GetBytesTx() const override { return fBytesTx; }
+    unsigned long GetBytesRx() const override { return fBytesRx; }
+    unsigned long GetMessagesTx() const override { return fMessagesTx; }
+    unsigned long GetMessagesRx() const override { return fMessagesRx; }
 
     static int GetConstant(const std::string& constant);
 
-    ~FairMQSocketSHM() override;
+    ~FairMQSocketSHM() override { Close(); }
 
   private:
     void* fSocket;

--- a/fairmq/shmem/FairMQUnmanagedRegionSHM.cxx
+++ b/fairmq/shmem/FairMQUnmanagedRegionSHM.cxx
@@ -6,7 +6,7 @@
  *                  copied verbatim in the file "LICENSE"                       *
  ********************************************************************************/
 
-#include <fairmq/shmem/Common.h>
+#include "Common.h"
 
 #include "FairMQUnmanagedRegionSHM.h"
 
@@ -40,19 +40,4 @@ FairMQUnmanagedRegionSHM::FairMQUnmanagedRegionSHM(Manager& manager, const size_
         LOG(error) << e.what();
         throw;
     }
-}
-
-void* FairMQUnmanagedRegionSHM::GetData() const
-{
-    return fRegion->get_address();
-}
-
-size_t FairMQUnmanagedRegionSHM::GetSize() const
-{
-    return fRegion->get_size();
-}
-
-FairMQUnmanagedRegionSHM::~FairMQUnmanagedRegionSHM()
-{
-    fManager.RemoveRegion(fRegionId);
 }

--- a/fairmq/shmem/FairMQUnmanagedRegionSHM.h
+++ b/fairmq/shmem/FairMQUnmanagedRegionSHM.h
@@ -28,10 +28,10 @@ class FairMQUnmanagedRegionSHM final : public FairMQUnmanagedRegion
   public:
     FairMQUnmanagedRegionSHM(fair::mq::shmem::Manager& manager, const size_t size, FairMQRegionCallback callback = nullptr, const std::string& path = "", int flags = 0);
 
-    void* GetData() const override;
-    size_t GetSize() const override;
+    void* GetData() const override { return fRegion->get_address(); }
+    size_t GetSize() const override { return fRegion->get_size(); }
 
-    ~FairMQUnmanagedRegionSHM() override;
+    ~FairMQUnmanagedRegionSHM() override { fManager.RemoveRegion(fRegionId); }
 
   private:
     fair::mq::shmem::Manager& fManager;

--- a/fairmq/shmem/Manager.cxx
+++ b/fairmq/shmem/Manager.cxx
@@ -8,6 +8,8 @@
 
 #include <fairmq/shmem/Manager.h>
 #include <fairmq/shmem/Common.h>
+#include <fairmq/tools/CppSTL.h>
+#include <fairmq/tools/Strings.h>
 
 #include <boost/process.hpp>
 #include <boost/filesystem.hpp>

--- a/fairmq/shmem/Manager.h
+++ b/fairmq/shmem/Manager.h
@@ -15,7 +15,6 @@
 #ifndef FAIR_MQ_SHMEM_MANAGER_H_
 #define FAIR_MQ_SHMEM_MANAGER_H_
 
-#include <fairmq/Tools.h>
 #include <fairmq/shmem/Region.h>
 #include <fairmq/shmem/Common.h>
 

--- a/fairmq/shmem/Manager.h
+++ b/fairmq/shmem/Manager.h
@@ -28,6 +28,7 @@
 
 #include <string>
 #include <unordered_map>
+#include <stdexcept>
 
 namespace fair
 {
@@ -35,6 +36,8 @@ namespace mq
 {
 namespace shmem
 {
+
+struct SharedMemoryError : std::runtime_error { using std::runtime_error::runtime_error; };
 
 class Manager
 {

--- a/fairmq/shmem/Region.cxx
+++ b/fairmq/shmem/Region.cxx
@@ -9,6 +9,8 @@
 #include <fairmq/shmem/Region.h>
 #include <fairmq/shmem/Common.h>
 #include <fairmq/shmem/Manager.h>
+#include <fairmq/tools/CppSTL.h>
+#include <fairmq/tools/Strings.h>
 
 #include <boost/filesystem.hpp>
 #include <boost/process.hpp>

--- a/fairmq/shmem/Region.h
+++ b/fairmq/shmem/Region.h
@@ -18,7 +18,6 @@
 #include "FairMQLogger.h"
 #include "FairMQUnmanagedRegion.h"
 
-#include <fairmq/Tools.h>
 #include <fairmq/shmem/Common.h>
 
 #include <boost/interprocess/managed_shared_memory.hpp>

--- a/fairmq/shmem/runMonitor.cxx
+++ b/fairmq/shmem/runMonitor.cxx
@@ -26,19 +26,25 @@ using namespace fair::mq::shmem;
 static void daemonize()
 {
     // already a daemon?
-    // if (getppid() == 1) return;
+    if (getppid() == 1) {
+        return;
+    }
 
-    // Fork off the parent process
-    // pid_t pid = fork();
-    // if (pid < 0) exit(1);
+    // Fork
+    pid_t pid = fork();
+    if (pid < 0) {
+        exit(1);
+    }
 
     // If we got a good PID, then we can exit the parent process.
-    // if (pid > 0) exit(0);
+    if (pid > 0) {
+        exit(0);
+    }
 
     // Change the file mode mask
     umask(0);
 
-    // Create a new SID for the child process
+    // Create a new session with the calling process as its leader.
     if (setsid() < 0) {
         exit(1);
     }

--- a/fairmq/tools/Strings.h
+++ b/fairmq/tools/Strings.h
@@ -10,7 +10,6 @@
 #define FAIR_MQ_TOOLS_STRINGS_H
 
 #include <array>
-#include <boost/beast/core/span.hpp>
 #include <initializer_list>
 #include <sstream>
 #include <string>
@@ -37,16 +36,11 @@ auto ToString(T&&... t) -> std::string
 /// @brief convert command line arguments from main function to vector of strings
 inline auto ToStrVector(const int argc, char*const* argv, const bool dropProgramName = true) -> std::vector<std::string>
 {
-    auto res = std::vector<std::string>{};
-    boost::beast::span<char*const> argvView(argv, argc);
-    if (dropProgramName)
-    {
-        res.assign(argvView.begin() + 1, argvView.end());
-    } else
-    {
-        res.assign(argvView.begin(), argvView.end());
+    if (dropProgramName) {
+        return std::vector<std::string>(argv + 1, argv + argc);
+    } else {
+        return std::vector<std::string>(argv, argv + argc);
     }
-    return res;
 }
 
 } /* namespace tools */

--- a/test/sdk/Fixtures.h
+++ b/test/sdk/Fixtures.h
@@ -16,7 +16,7 @@
 #include <cstdlib>
 #include <fairlogger/Logger.h>
 #include <fairmq/SDK.h>
-#include <fairmq/Tools.h>
+#include <fairmq/tools/Strings.h>
 #include <gtest/gtest.h>
 #include <thread>
 


### PR DESCRIPTION
- Shared memory transport: Fix handling of empty message parts. Should fix AliceO2Group/AliceO2#2547, at least partially, still not clear why the empty parts are produced in the first place.
- Extend multipart example/test to include empty parts.
- Fix shmmonitor daemonization. Fixes #216.
- Minor include cleanup, formatting of shmem classes.


