### PR TITLE
Shm monitor: fix startup race and enable view-only mode

### DIFF
--- a/fairmq/shmem/Common.h
+++ b/fairmq/shmem/Common.h
@@ -73,15 +73,6 @@ struct RegionCounter
     std::atomic<uint64_t> fCount;
 };
 
-struct MonitorStatus
-{
-    MonitorStatus()
-        : fActive(true)
-    {}
-
-    bool fActive;
-};
-
 struct MetaHeader
 {
     size_t fSize;

--- a/fairmq/shmem/FairMQTransportFactorySHM.cxx
+++ b/fairmq/shmem/FairMQTransportFactorySHM.cxx
@@ -77,11 +77,12 @@ FairMQTransportFactorySHM::FairMQTransportFactorySHM(const string& id, const fai
             LOG(error) << "failed configuring context, reason: " << zmq_strerror(errno);
         }
 
+        if (autolaunchMonitor) {
+            Manager::StartMonitor(fShmId);
+        }
+
         fManager = fair::mq::tools::make_unique<Manager>(fShmId, segmentSize);
 
-        if (autolaunchMonitor) {
-            fManager->StartMonitor();
-        }
     } catch (bipc::interprocess_exception& e) {
         LOG(error) << "Could not initialize shared memory transport: " << e.what();
         throw runtime_error(fair::mq::tools::ToString("Could not initialize shared memory transport: ", e.what()));

--- a/fairmq/shmem/Manager.h
+++ b/fairmq/shmem/Manager.h
@@ -52,10 +52,10 @@ class Manager
 
     ~Manager();
 
-    boost::interprocess::managed_shared_memory& Segment();
-    boost::interprocess::managed_shared_memory& ManagementSegment();
+    boost::interprocess::managed_shared_memory& Segment() { return fSegment; }
+    boost::interprocess::managed_shared_memory& ManagementSegment() { return fManagementSegment; }
 
-    void StartMonitor();
+    static void StartMonitor(const std::string&);
 
     static void Interrupt();
     static void Resume();

--- a/fairmq/shmem/Monitor.h
+++ b/fairmq/shmem/Monitor.h
@@ -14,6 +14,7 @@
 #include <chrono>
 #include <atomic>
 #include <string>
+#include <stdexcept>
 #include <unordered_map>
 
 namespace fair
@@ -26,21 +27,23 @@ namespace shmem
 class Monitor
 {
   public:
-    Monitor(const std::string& shmId, bool selfDestruct, bool interactive, unsigned int timeoutInMS, bool runAsDaemon, bool cleanOnExit);
+    Monitor(const std::string& shmId, bool selfDestruct, bool interactive, bool viewOnly, unsigned int timeoutInMS, bool runAsDaemon, bool cleanOnExit);
 
     Monitor(const Monitor&) = delete;
     Monitor operator=(const Monitor&) = delete;
 
+    virtual ~Monitor();
+
     void CatchSignals();
     void Run();
-
-    virtual ~Monitor();
 
     static void Cleanup(const std::string& shmId);
     static void RemoveObject(const std::string&);
     static void RemoveFileMapping(const std::string&);
     static void RemoveQueue(const std::string&);
     static void RemoveMutex(const std::string&);
+
+    struct DaemonPresent : std::runtime_error { using std::runtime_error::runtime_error; };
 
   private:
     void PrintHeader();
@@ -53,8 +56,9 @@ class Monitor
 
     bool fSelfDestruct; // will self-destruct after the memory has been closed
     bool fInteractive; // running in interactive mode
-    bool fSeenOnce; // true is segment has been opened successfully at least once
+    bool fViewOnly; // view only mode
     bool fIsDaemon;
+    bool fSeenOnce; // true is segment has been opened successfully at least once
     bool fCleanOnExit;
     unsigned int fTimeoutInMS;
     std::string fShmId;

--- a/fairmq/shmem/README.md
+++ b/fairmq/shmem/README.md
@@ -32,5 +32,6 @@ FairMQ Shared Memory currently uses following names to register shared memory on
 `fmq_<shmId>_mng` - management segment name, used for storing management data.
 `fmq_<shmId>_cq` - message queue for communicating between shm transport and shm monitor (exists independent of above segments).
 `fmq_<shmId>_mtx` - boost::interprocess::named_mutex for management purposes (exists independent of above segments).
+`fmq_<shmId>_ms` - shmmonitor status used to signal if it is active or not (exists independent of above segments).
 `fmq_<shmId>_rg_<index>` - names of unmanaged regions.
 `fmq_<shmId>_rgq_<index>` - names of queues for the unmanaged regions.


### PR DESCRIPTION
- Start monitor before creating the segments.
- Allow running the monitor in view-only mode (with `--view`) that will ignore that presence of any other active monitor and will only allow viewing the segment info without modifying it.
- Some refactoring.


