### PR TITLE
Fix regression in the DDS plugin shutdown handling

### DIFF
--- a/fairmq/plugins/DDS/DDS.h
+++ b/fairmq/plugins/DDS/DDS.h
@@ -161,7 +161,6 @@ class DDS : public Plugin
 
     std::thread fControllerThread;
     DeviceState fCurrentState, fLastState;
-    fair::mq::StateQueue fStateQueue;
 
     std::atomic<bool> fDeviceTerminationRequested;
 


### PR DESCRIPTION
Part of the shutdown handling code was accidentally removed with the introduction of commands format.

Also removing StateQueue in the plugin that is unused.