### PR TITLE
Detect network interface of the default route without use of ip

### DIFF
--- a/fairmq/FairMQDevice.cxx
+++ b/fairmq/FairMQDevice.cxx
@@ -299,10 +299,15 @@ void FairMQDevice::InitWrapper()
                 // if binding address is not specified, try getting it from the configured network interface
                 if (subChannel.fAddress == "unspecified" || subChannel.fAddress == "") {
                     // if the configured network interface is default, get its name from the default route
-                    if (networkInterface == "default") {
-                        networkInterface = tools::getDefaultRouteNetworkInterface();
+                    try {
+                        if (networkInterface == "default") {
+                            networkInterface = tools::getDefaultRouteNetworkInterface();
+                        }
+                        subChannel.fAddress = "tcp://" + tools::getInterfaceIP(networkInterface) + ":1";
+                    } catch(const tools::DefaultRouteDetectionError& e) {
+                        LOG(debug) << "binding on tcp://*:1";
+                        subChannel.fAddress = "tcp://*:1";
                     }
-                    subChannel.fAddress = "tcp://" + tools::getInterfaceIP(networkInterface) + ":1";
                 }
                 // fill the uninitialized list
                 fUninitializedBindingChannels.push_back(&subChannel);

--- a/fairmq/tools/Network.h
+++ b/fairmq/tools/Network.h
@@ -11,6 +11,7 @@
 
 #include <map>
 #include <string>
+#include <stdexcept>
 
 // forward declarations
 namespace boost
@@ -30,6 +31,8 @@ namespace mq
 {
 namespace tools
 {
+
+struct DefaultRouteDetectionError : std::runtime_error { using std::runtime_error::runtime_error; };
 
 // returns a map with network interface names as keys and their IP addresses as values
 std::map<std::string, std::string> getHostIPs();


### PR DESCRIPTION
Fixes #230.

detection will first try `/proc/net/route` then `ip route | grep default | cut -d " " -f 5 | head -n 1` and if both fail we will bind on `tcp://*:1`.