### PR TITLE
SDK: Refactor StateChangeOp and add path parameter

### DIFF
--- a/fairmq/shmem/Socket.cxx
+++ b/fairmq/shmem/Socket.cxx
@@ -184,7 +184,10 @@ int Socket::Receive(MessagePtr& msg, const int timeout)
         if (nbytes > 0) {
             // check for number of received messages. must be 1
             if (nbytes != sizeof(MetaHeader)) {
-                throw SocketError("Received message is not a valid FairMQ shared memory message. Possibly due to a misconfigured transport on the sender side.");
+                throw SocketError(
+                    tools::ToString("Received message is not a valid FairMQ shared memory message. ",
+                        "Possibly due to a misconfigured transport on the sender side. ",
+                        "Expected size of ", sizeof(MetaHeader), " bytes, received ", nbytes));
             }
 
             MetaHeader* hdr = static_cast<MetaHeader*>(zmqMsg.Data());
@@ -302,7 +305,10 @@ int64_t Socket::Receive(vector<MessagePtr>& msgVec, const int timeout)
 
             assert(hdrVecSize > 0);
             if (hdrVecSize % sizeof(MetaHeader) != 0) {
-                throw SocketError("Received message is not a valid FairMQ shared memory message. Possibly due to a misconfigured transport on the sender side.");
+                throw SocketError(
+                    tools::ToString("Received message is not a valid FairMQ shared memory message. ",
+                        "Possibly due to a misconfigured transport on the sender side. ",
+                        "Expected size of ", sizeof(MetaHeader), " bytes, received ", nbytes));
             }
 
             const auto numMessages = hdrVecSize / sizeof(MetaHeader);


### PR DESCRIPTION
Refactors StateChangeOp to allow concurrent invocations and adds a path parameter to the call that allows to target subsets of the topology.