### PR TITLE
DDS plugin: Improve error messages

### DIFF
--- a/fairmq/plugins/DDS/DDS.cxx
+++ b/fairmq/plugins/DDS/DDS.cxx
@@ -283,7 +283,10 @@ auto DDS::SubscribeForConnectingChannels() -> void
                     if (mi.second.fNumSubChannels == mi.second.fDDSValues.size()) {
                         int i = 0;
                         for (const auto& e : mi.second.fDDSValues) {
-                            SetProperty<string>(string{"chans." + mi.first + "." + to_string(i) + ".address"}, e.second);
+                            auto result = UpdateProperty<string>(string{"chans." + mi.first + "." + to_string(i) + ".address"}, e.second);
+                            if (!result) {
+                                LOG(error) << "UpdateProperty failed for: " << "chans." << mi.first << "." << to_string(i) << ".address" << " - property does not exist";
+                            }
                             ++i;
                         }
                     }

--- a/fairmq/plugins/DDS/DDS.cxx
+++ b/fairmq/plugins/DDS/DDS.cxx
@@ -243,6 +243,12 @@ auto DDS::SubscribeForConnectingChannels() -> void
                     unique_lock<mutex> lk(fUpdateMutex);
                     fUpdateCondition.wait(lk, [&]{ return fUpdatesAllowed; });
                 }
+
+                if (fConnectingChans.find(channelName) == fConnectingChans.end()) {
+                    LOG(error) << "Received an update for a connecting channel, but either no channel with given channel name exists or it has already been configured: '" << channelName << "', ignoring...";
+                    return;
+                }
+
                 string val = value;
                 // check if it is to handle as one out of multiple values
                 auto it = fIofN.find(channelName);

--- a/fairmq/plugins/DDS/DDS.h
+++ b/fairmq/plugins/DDS/DDS.h
@@ -144,6 +144,7 @@ class DDS : public Plugin
     auto SubscribeForCustomCommands() -> void;
 
     DDSSubscription fDDS;
+    size_t fDDSTaskId;
 
     std::unordered_map<std::string, std::vector<std::string>> fBindingChans;
     std::unordered_map<std::string, DDSConfig> fConnectingChans;

--- a/fairmq/plugins/DDS/DDS.h
+++ b/fairmq/plugins/DDS/DDS.h
@@ -12,6 +12,7 @@
 #include <fairmq/Plugin.h>
 #include <fairmq/StateQueue.h>
 #include <fairmq/Version.h>
+#include <fairmq/sdk/commands/Commands.h>
 
 #include <dds/dds.h>
 
@@ -142,6 +143,7 @@ class DDS : public Plugin
     auto SubscribeForConnectingChannels() -> void;
     auto PublishBoundChannels() -> void;
     auto SubscribeForCustomCommands() -> void;
+    auto HandleCmd(const std::string& id, sdk::cmd::Cmd& cmd, const std::string& cond, uint64_t senderId) -> void;
 
     DDSSubscription fDDS;
     size_t fDDSTaskId;


### PR DESCRIPTION
Provide descriptive error message when DDS plugin receives an update for a non-existing channel.
Refactor parts of the DDS plugin code for better readability.

Resolves #206.
