### PR TITLE
QC example update

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -40,7 +40,7 @@ A topology consisting of three layers of devices: synchronizer -> n * senders ->
 
 ## QC
 
-A topology consisting of 4 devices - Sampler, QCProducer, QCConsumer and Sink. The data flows from Sampler through QCProducer to Sink. On demand - by setting the corresponding configuration property - the QCProducer device will duplicate the data to the QCConsumer device. The property is set by the topology controller, in this example this is the `fairmq-dds-command-ui` utility.
+A topology consisting of 4 devices - Sampler, QCDispatcher, QCTask and Sink. The data flows from Sampler through QCDispatcher to Sink. On demand - by setting the corresponding configuration property - the QCDispatcher device will duplicate the data to the QCTask device. The property is set by the topology controller, in this example this is the `fairmq-dds-command-ui` utility.
 
 ## Readout
 

--- a/examples/qc/CMakeLists.txt
+++ b/examples/qc/CMakeLists.txt
@@ -9,16 +9,16 @@
 add_executable(fairmq-ex-qc-sampler runSampler.cxx)
 target_link_libraries(fairmq-ex-qc-sampler PRIVATE FairMQ)
 
-add_executable(fairmq-ex-qc-producer runQCProducer.cxx)
-target_link_libraries(fairmq-ex-qc-producer PRIVATE FairMQ)
+add_executable(fairmq-ex-qc-dispatcher runQCDispatcher.cxx)
+target_link_libraries(fairmq-ex-qc-dispatcher PRIVATE FairMQ)
 
-add_executable(fairmq-ex-qc-consumer runQCConsumer.cxx)
-target_link_libraries(fairmq-ex-qc-consumer PRIVATE FairMQ)
+add_executable(fairmq-ex-qc-task runQCTask.cxx)
+target_link_libraries(fairmq-ex-qc-task PRIVATE FairMQ)
 
 add_executable(fairmq-ex-qc-sink runSink.cxx)
 target_link_libraries(fairmq-ex-qc-sink PRIVATE FairMQ)
 
-add_custom_target(ExampleQC DEPENDS fairmq-ex-qc-sampler fairmq-ex-qc-producer fairmq-ex-qc-consumer fairmq-ex-qc-sink)
+add_custom_target(ExampleQC DEPENDS fairmq-ex-qc-sampler fairmq-ex-qc-dispatcher fairmq-ex-qc-task fairmq-ex-qc-sink)
 
 list(JOIN Boost_LIBRARY_DIRS ":" LIB_DIR)
 set(BIN_DIR ${CMAKE_CURRENT_BINARY_DIR}:${CMAKE_BINARY_DIR}/fairmq/plugins/DDS)
@@ -37,8 +37,8 @@ endif()
 install(
   TARGETS
   fairmq-ex-qc-sampler
-  fairmq-ex-qc-producer
-  fairmq-ex-qc-consumer
+  fairmq-ex-qc-dispatcher
+  fairmq-ex-qc-task
   fairmq-ex-qc-sink
 
   LIBRARY DESTINATION ${PROJECT_INSTALL_LIBDIR}

--- a/examples/qc/README.md
+++ b/examples/qc/README.md
@@ -1,4 +1,4 @@
 QC
 ==
 
-A topology consisting of 4 devices - Sampler, QCProducer, QCConsumer and Sink. The data flows from Sampler through QCProducer to Sink. On demand - by setting the corresponding configuration property - the QCProducer device will duplicate the data to the QCConsumer device. The property is set by the topology controller, in this example this is the `fairmq-dds-command-ui` utility.
+A topology consisting of 4 devices - Sampler, QCDispatcher, QCTask and Sink. The data flows from Sampler through QCDispatcher to Sink. On demand - by setting the corresponding configuration property - the QCDispatcher device will duplicate the data to the QCTask device. The property is set by the topology controller, in this example this is the `fairmq-dds-command-ui` utility.

--- a/examples/qc/ex-qc-topology.xml
+++ b/examples/qc/ex-qc-topology.xml
@@ -12,8 +12,8 @@
         </properties>
     </decltask>
 
-    <decltask name="QCProducer">
-        <exe>fairmq-ex-qc-producer --color false --channel-config name=data1,type=pull,method=connect name=data2,type=push,method=connect name=qc,type=push,method=connect -P dds</exe>
+    <decltask name="QCDispatcher">
+        <exe>fairmq-ex-qc-dispatcher --color false --channel-config name=data1,type=pull,method=connect name=data2,type=push,method=connect name=qc,type=push,method=connect -P dds</exe>
         <env reachable="false">fairmq-ex-qc-env.sh</env>
         <properties>
             <name access="read">fmqchan_data1</name>
@@ -22,8 +22,8 @@
         </properties>
     </decltask>
 
-    <decltask name="QCConsumer">
-        <exe>fairmq-ex-qc-consumer --color false --channel-config name=qc,type=pull,method=bind -P dds</exe>
+    <decltask name="QCTask">
+        <exe>fairmq-ex-qc-task --color false --channel-config name=qc,type=pull,method=bind -P dds</exe>
         <env reachable="false">fairmq-ex-qc-env.sh</env>
         <properties>
             <name access="write">fmqchan_qc</name>
@@ -40,8 +40,8 @@
 
     <main name="main">
         <task>Sampler</task>
-        <task>QCProducer</task>
-        <task>QCConsumer</task>
+        <task>QCDispatcher</task>
+        <task>QCTask</task>
         <task>Sink</task>
     </main>
 

--- a/examples/qc/fairmq-start-ex-qc.sh.in
+++ b/examples/qc/fairmq-start-ex-qc.sh.in
@@ -51,12 +51,14 @@ fairmq-dds-command-ui -c k
 fairmq-dds-command-ui -c b
 fairmq-dds-command-ui -c x
 fairmq-dds-command-ui -c j
-fairmq-dds-command-ui -c r
-qcconsumer="main/QCConsumer.*"
-qcproducer="main/QCProducer.*"
-fairmq-dds-command-ui -c p --property-key qc --property-value active -p $qcproducer
-fairmq-dds-command-ui -w "RUNNING->READY" -p $qcconsumer
-echo "...$qcconsumer received data and transitioned to READY, sending shutdown..."
+allexceptqctasks="main/(Sampler|QCDispatcher|Sink)"
+fairmq-dds-command-ui -c r -p $allexceptqctasks
+qctask="main/QCTask.*"
+qcdispatcher="main/QCDispatcher.*"
+fairmq-dds-command-ui -c p --property-key qc --property-value active -p $qcdispatcher
+fairmq-dds-command-ui -c r -p $qctask
+fairmq-dds-command-ui -w "RUNNING->READY" -p $qctask
+echo "...$qctask received data and transitioned to READY, sending shutdown..."
 fairmq-dds-command-ui -c s
 fairmq-dds-command-ui -c t
 fairmq-dds-command-ui -c d

--- a/examples/qc/runQCDispatcher.cxx
+++ b/examples/qc/runQCDispatcher.cxx
@@ -9,13 +9,13 @@
 #include "runFairMQDevice.h"
 #include "FairMQDevice.h"
 
-class QCProducer : public FairMQDevice
+class QCDispatcher : public FairMQDevice
 {
   public:
-    QCProducer()
+    QCDispatcher()
         : fDoQC(false)
     {
-        OnData("data1", &QCProducer::HandleData);
+        OnData("data1", &QCDispatcher::HandleData);
     }
 
     void InitTask() override
@@ -56,4 +56,4 @@ class QCProducer : public FairMQDevice
 };
 
 void addCustomOptions(boost::program_options::options_description& /*options*/) {}
-FairMQDevicePtr getDevice(const fair::mq::ProgOptions& /*config*/) { return new QCProducer(); }
+FairMQDevicePtr getDevice(const fair::mq::ProgOptions& /*config*/) { return new QCDispatcher(); }

--- a/examples/qc/runQCTask.cxx
+++ b/examples/qc/runQCTask.cxx
@@ -9,10 +9,10 @@
 #include "runFairMQDevice.h"
 #include "FairMQDevice.h"
 
-class QCConsumer : public FairMQDevice
+class QCTask : public FairMQDevice
 {
   public:
-    QCConsumer()
+    QCTask()
     {
         OnData("qc", [](FairMQMessagePtr& /*msg*/, int) {
             LOG(info) << "received data";
@@ -23,4 +23,4 @@ class QCConsumer : public FairMQDevice
 
 namespace bpo = boost::program_options;
 void addCustomOptions(bpo::options_description& /*options*/) {}
-FairMQDevicePtr getDevice(const fair::mq::ProgOptions& /*config*/) { return new QCConsumer(); }
+FairMQDevicePtr getDevice(const fair::mq::ProgOptions& /*config*/) { return new QCTask(); }

--- a/fairmq/plugins/DDS/runDDSCommandUI.cxx
+++ b/fairmq/plugins/DDS/runDDSCommandUI.cxx
@@ -65,7 +65,7 @@ void handleCommand(const string& command, const string& path, unsigned int timeo
             cout << d.taskId << " : " << d.state << endl;
         }
     } else if (command == "o") {
-        cout << "> dumping config of the devices" << endl;
+        cout << "> dumping config of the devices (" << path << ")" << endl;
         // TODO: extend this regex to return all properties, once command size limitation is removed.
         auto const result = topo.GetProperties("^(session|id)$", path, std::chrono::milliseconds(timeout));
         for (const auto& d : result.second.devices) {
@@ -79,43 +79,43 @@ void handleCommand(const string& command, const string& path, unsigned int timeo
             return;
         }
         const DeviceProperties props{{pKey, pVal}};
-        cout << "> sending property" << endl;
+        cout << "> sending property (" << path << ")" << endl;
         topo.SetProperties(props, path);
         // give dds time to complete request
         this_thread::sleep_for(chrono::milliseconds(100));
     } else if (command == "i") {
-        cout << "> init devices" << endl;
-        topo.ChangeState(TopologyTransition::InitDevice, std::chrono::milliseconds(timeout));
+        cout << "> init devices (" << path << ")" << endl;
+        topo.ChangeState(TopologyTransition::InitDevice, path, std::chrono::milliseconds(timeout));
     } else if (command == "k") {
-        cout << "> complete init" << endl;
-        topo.ChangeState(TopologyTransition::CompleteInit, std::chrono::milliseconds(timeout));
+        cout << "> complete init (" << path << ")" << endl;
+        topo.ChangeState(TopologyTransition::CompleteInit, path, std::chrono::milliseconds(timeout));
     } else if (command == "b") {
-        cout << "> bind devices" << endl;
-        topo.ChangeState(TopologyTransition::Bind, std::chrono::milliseconds(timeout));
+        cout << "> bind devices (" << path << ")" << endl;
+        topo.ChangeState(TopologyTransition::Bind, path, std::chrono::milliseconds(timeout));
     } else if (command == "x") {
-        cout << "> connect devices" << endl;
-        topo.ChangeState(TopologyTransition::Connect, std::chrono::milliseconds(timeout));
+        cout << "> connect devices (" << path << ")" << endl;
+        topo.ChangeState(TopologyTransition::Connect, path, std::chrono::milliseconds(timeout));
     } else if (command == "j") {
-        cout << "> init tasks" << endl;
-        topo.ChangeState(TopologyTransition::InitTask, std::chrono::milliseconds(timeout));
+        cout << "> init tasks (" << path << ")" << endl;
+        topo.ChangeState(TopologyTransition::InitTask, path, std::chrono::milliseconds(timeout));
     } else if (command == "r") {
-        cout << "> run tasks" << endl;
-        topo.ChangeState(TopologyTransition::Run, std::chrono::milliseconds(timeout));
+        cout << "> run tasks (" << path << ")" << endl;
+        topo.ChangeState(TopologyTransition::Run, path, std::chrono::milliseconds(timeout));
     } else if (command == "s") {
-        cout << "> stop devices" << endl;
-        topo.ChangeState(TopologyTransition::Stop, std::chrono::milliseconds(timeout));
+        cout << "> stop devices (" << path << ")" << endl;
+        topo.ChangeState(TopologyTransition::Stop, path, std::chrono::milliseconds(timeout));
     } else if (command == "t") {
-        cout << "> reset tasks" << endl;
-        topo.ChangeState(TopologyTransition::ResetTask, std::chrono::milliseconds(timeout));
+        cout << "> reset tasks (" << path << ")" << endl;
+        topo.ChangeState(TopologyTransition::ResetTask, path, std::chrono::milliseconds(timeout));
     } else if (command == "d") {
-        cout << "> reset devices" << endl;
-        topo.ChangeState(TopologyTransition::ResetDevice, std::chrono::milliseconds(timeout));
+        cout << "> reset devices (" << path << ")" << endl;
+        topo.ChangeState(TopologyTransition::ResetDevice, path, std::chrono::milliseconds(timeout));
+    } else if (command == "q") {
+        cout << "> end (" << path << ")" << endl;
+        topo.ChangeState(TopologyTransition::End, path, std::chrono::milliseconds(timeout));
     } else if (command == "h") {
         cout << "> help" << endl;
         printControlsHelp();
-    } else if (command == "q") {
-        cout << "> end" << endl;
-        topo.ChangeState(TopologyTransition::End, std::chrono::milliseconds(timeout));
     } else {
         cout << "\033[01;32mInvalid input: [" << command << "]\033[0m" << endl;
         printControlsHelp();


### PR DESCRIPTION
- SDK: refactor subscriptions to allow reuse.
- DDSCommandUI: include path argument in ChangeState.
- QC example: rename QC devices, more granular state control in the script.
