### PR TITLE
SDK: track (un-)subscriptions

### DIFF
--- a/fairmq/plugins/DDS/DDS.cxx
+++ b/fairmq/plugins/DDS/DDS.cxx
@@ -367,7 +367,7 @@ auto DDS::HandleCmd(const string& id, sdk::cmd::Cmd& cmd, const string& cond, ui
 
             LOG(debug) << "Publishing state-change: " << fLastState << "->" << fCurrentState << " to " << senderId;
 
-            Cmds outCmds(make<StateChangeSubscription>(id, Result::Ok),
+            Cmds outCmds(make<StateChangeSubscription>(id, fDDSTaskId, Result::Ok),
                          make<StateChange>(id, fDDSTaskId, fLastState, fCurrentState));
 
             fDDS.Send(outCmds.Serialize(), to_string(senderId));
@@ -377,7 +377,7 @@ auto DDS::HandleCmd(const string& id, sdk::cmd::Cmd& cmd, const string& cond, ui
                 lock_guard<mutex> lock{fStateChangeSubscriberMutex};
                 fStateChangeSubscribers.erase(senderId);
             }
-            Cmds outCmds(make<StateChangeUnsubscription>(id, Result::Ok));
+            Cmds outCmds(make<StateChangeUnsubscription>(id, fDDSTaskId, Result::Ok));
             fDDS.Send(outCmds.Serialize(), to_string(senderId));
         } break;
         case Type::get_properties: {

--- a/fairmq/plugins/PMIx/PMIxPlugin.cxx
+++ b/fairmq/plugins/PMIx/PMIxPlugin.cxx
@@ -171,7 +171,7 @@ auto PMIxPlugin::SubscribeForCommands() -> void
 
                     LOG(debug) << "Publishing state-change: " << fLastState << "->" << fCurrentState
                                << " to " << sender;
-                    Cmds outCmds(make<StateChangeSubscription>(fDeviceId, Result::Ok),
+                    Cmds outCmds(make<StateChangeSubscription>(fDeviceId, fProcess.rank, Result::Ok),
                                  make<StateChange>(fDeviceId, 0, fLastState, fCurrentState));
                     fCommands.Send(outCmds.Serialize(Format::JSON), {sender});
                 }
@@ -181,7 +181,7 @@ auto PMIxPlugin::SubscribeForCommands() -> void
                         lock_guard<mutex> lock{fStateChangeSubscriberMutex};
                         fStateChangeSubscribers.erase(sender.rank);
                     }
-                    fCommands.Send(Cmds(make<StateChangeUnsubscription>(fDeviceId, Result::Ok))
+                    fCommands.Send(Cmds(make<StateChangeUnsubscription>(fDeviceId, fProcess.rank, Result::Ok))
                                        .Serialize(Format::JSON),
                                    {sender});
                 }

--- a/fairmq/sdk/commands/Commands.cxx
+++ b/fairmq/sdk/commands/Commands.cxx
@@ -293,6 +293,7 @@ string Cmds::Serialize(const Format type) const
                 auto deviceId = fbb.CreateString(_cmd.GetDeviceId());
                 cmdBuilder = tools::make_unique<FBCommandBuilder>(fbb);
                 cmdBuilder->add_device_id(deviceId);
+                cmdBuilder->add_task_id(_cmd.GetTaskId());
                 cmdBuilder->add_result(GetFBResult(_cmd.GetResult()));
             }
             break;
@@ -301,6 +302,7 @@ string Cmds::Serialize(const Format type) const
                 auto deviceId = fbb.CreateString(_cmd.GetDeviceId());
                 cmdBuilder = tools::make_unique<FBCommandBuilder>(fbb);
                 cmdBuilder->add_device_id(deviceId);
+                cmdBuilder->add_task_id(_cmd.GetTaskId());
                 cmdBuilder->add_result(GetFBResult(_cmd.GetResult()));
             }
             break;
@@ -433,10 +435,10 @@ void Cmds::Deserialize(const string& str, const Format type)
                 fCmds.emplace_back(make<Config>(cmdPtr.device_id()->str(), cmdPtr.config_string()->str()));
             break;
             case FBCmd_state_change_subscription:
-                fCmds.emplace_back(make<StateChangeSubscription>(cmdPtr.device_id()->str(), GetResult(cmdPtr.result())));
+                fCmds.emplace_back(make<StateChangeSubscription>(cmdPtr.device_id()->str(), cmdPtr.task_id(), GetResult(cmdPtr.result())));
             break;
             case FBCmd_state_change_unsubscription:
-                fCmds.emplace_back(make<StateChangeUnsubscription>(cmdPtr.device_id()->str(), GetResult(cmdPtr.result())));
+                fCmds.emplace_back(make<StateChangeUnsubscription>(cmdPtr.device_id()->str(), cmdPtr.task_id(), GetResult(cmdPtr.result())));
             break;
             case FBCmd_state_change:
                 fCmds.emplace_back(make<StateChange>(cmdPtr.device_id()->str(), cmdPtr.task_id(), GetMQState(cmdPtr.last_state()), GetMQState(cmdPtr.current_state())));

--- a/fairmq/sdk/commands/Commands.h
+++ b/fairmq/sdk/commands/Commands.h
@@ -51,8 +51,8 @@ enum class Type : int
     current_state,                 // args: { device_id, current_state }
     transition_status,             // args: { device_id, task_id, Result, transition }
     config,                        // args: { device_id, config_string }
-    state_change_subscription,     // args: { device_id, Result }
-    state_change_unsubscription,   // args: { device_id, Result }
+    state_change_subscription,     // args: { device_id, task_id, Result }
+    state_change_unsubscription,   // args: { device_id, task_id, Result }
     state_change,                  // args: { device_id, task_id, last_state, current_state }
     properties,                    // args: { device_id, request_id, Result, properties }
     properties_set                 // args: { device_id, request_id, Result }
@@ -208,37 +208,45 @@ struct Config : Cmd
 
 struct StateChangeSubscription : Cmd
 {
-    explicit StateChangeSubscription(const std::string& id, const Result result)
+    explicit StateChangeSubscription(const std::string& id, const uint64_t taskId, const Result result)
         : Cmd(Type::state_change_subscription)
         , fDeviceId(id)
+        , fTaskId(taskId)
         , fResult(result)
     {}
 
     std::string GetDeviceId() const { return fDeviceId; }
     void SetDeviceId(const std::string& deviceId) { fDeviceId = deviceId; }
+    uint64_t GetTaskId() const { return fTaskId; }
+    void SetTaskId(const uint64_t taskId) { fTaskId = taskId; }
     Result GetResult() const { return fResult; }
     void SetResult(const Result result) { fResult = result; }
 
   private:
     std::string fDeviceId;
+    uint64_t fTaskId;
     Result fResult;
 };
 
 struct StateChangeUnsubscription : Cmd
 {
-    explicit StateChangeUnsubscription(const std::string& id, const Result result)
+    explicit StateChangeUnsubscription(const std::string& id, const uint64_t taskId, const Result result)
         : Cmd(Type::state_change_unsubscription)
         , fDeviceId(id)
+        , fTaskId(taskId)
         , fResult(result)
     {}
 
     std::string GetDeviceId() const { return fDeviceId; }
     void SetDeviceId(const std::string& deviceId) { fDeviceId = deviceId; }
+    uint64_t GetTaskId() const { return fTaskId; }
+    void SetTaskId(const uint64_t taskId) { fTaskId = taskId; }
     Result GetResult() const { return fResult; }
     void SetResult(const Result result) { fResult = result; }
 
   private:
     std::string fDeviceId;
+    uint64_t fTaskId;
     Result fResult;
 };
 

--- a/fairmq/sdk/commands/CommandsFormat.fbs
+++ b/fairmq/sdk/commands/CommandsFormat.fbs
@@ -54,10 +54,10 @@ enum FBCmd:byte {
     set_properties,                // args: { request_id, properties }
 
     current_state,                 // args: { device_id, current_state }
-    transition_status,             // args: { device_id, Result, transition }
+    transition_status,             // args: { device_id, task_id, Result, transition }
     config,                        // args: { device_id, config_string }
-    state_change_subscription,     // args: { device_id, Result }
-    state_change_unsubscription,   // args: { device_id, Result }
+    state_change_subscription,     // args: { device_id, task_id, Result }
+    state_change_unsubscription,   // args: { device_id, task_id, Result }
     state_change,                  // args: { device_id, task_id, last_state, current_state }
     properties,                    // args: { device_id, request_id, Result, properties }
     properties_set                 // args: { device_id, request_id, Result }

--- a/test/commands/_commands.cxx
+++ b/test/commands/_commands.cxx
@@ -32,8 +32,8 @@ TEST(Format, Construction)
     Cmds currentStateCmds(make<CurrentState>("somedeviceid", State::Running));
     Cmds transitionStatusCmds(make<TransitionStatus>("somedeviceid", 123456, Result::Ok, Transition::Stop));
     Cmds configCmds(make<Config>("somedeviceid", "someconfig"));
-    Cmds stateChangeSubscriptionCmds(make<StateChangeSubscription>("somedeviceid", Result::Ok));
-    Cmds stateChangeUnsubscriptionCmds(make<StateChangeUnsubscription>("somedeviceid", Result::Ok));
+    Cmds stateChangeSubscriptionCmds(make<StateChangeSubscription>("somedeviceid", 123456, Result::Ok));
+    Cmds stateChangeUnsubscriptionCmds(make<StateChangeUnsubscription>("somedeviceid", 123456, Result::Ok));
     Cmds stateChangeCmds(make<StateChange>("somedeviceid", 123456, State::Running, State::Ready));
     Cmds propertiesCmds(make<Properties>("somedeviceid", 66, Result::Ok, props));
     Cmds propertiesSetCmds(make<PropertiesSet>("somedeviceid", 42, Result::Ok));
@@ -64,9 +64,11 @@ TEST(Format, Construction)
     ASSERT_EQ(static_cast<Config&>(configCmds.At(0)).GetConfig(), "someconfig");
     ASSERT_EQ(stateChangeSubscriptionCmds.At(0).GetType(), Type::state_change_subscription);
     ASSERT_EQ(static_cast<StateChangeSubscription&>(stateChangeSubscriptionCmds.At(0)).GetDeviceId(), "somedeviceid");
+    ASSERT_EQ(static_cast<StateChangeSubscription&>(stateChangeSubscriptionCmds.At(0)).GetTaskId(), 123456);
     ASSERT_EQ(static_cast<StateChangeSubscription&>(stateChangeSubscriptionCmds.At(0)).GetResult(), Result::Ok);
     ASSERT_EQ(stateChangeUnsubscriptionCmds.At(0).GetType(), Type::state_change_unsubscription);
     ASSERT_EQ(static_cast<StateChangeUnsubscription&>(stateChangeUnsubscriptionCmds.At(0)).GetDeviceId(), "somedeviceid");
+    ASSERT_EQ(static_cast<StateChangeUnsubscription&>(stateChangeUnsubscriptionCmds.At(0)).GetTaskId(), 123456);
     ASSERT_EQ(static_cast<StateChangeUnsubscription&>(stateChangeUnsubscriptionCmds.At(0)).GetResult(), Result::Ok);
     ASSERT_EQ(stateChangeCmds.At(0).GetType(), Type::state_change);
     ASSERT_EQ(static_cast<StateChange&>(stateChangeCmds.At(0)).GetDeviceId(), "somedeviceid");
@@ -99,8 +101,8 @@ void fillCommands(Cmds& cmds)
     cmds.Add<CurrentState>("somedeviceid", State::Running);
     cmds.Add<TransitionStatus>("somedeviceid", 123456, Result::Ok, Transition::Stop);
     cmds.Add<Config>("somedeviceid", "someconfig");
-    cmds.Add<StateChangeSubscription>("somedeviceid", Result::Ok);
-    cmds.Add<StateChangeUnsubscription>("somedeviceid", Result::Ok);
+    cmds.Add<StateChangeSubscription>("somedeviceid", 123456, Result::Ok);
+    cmds.Add<StateChangeUnsubscription>("somedeviceid", 123456, Result::Ok);
     cmds.Add<StateChange>("somedeviceid", 123456, State::Running, State::Ready);
     cmds.Add<Properties>("somedeviceid", 66, Result::Ok, props);
     cmds.Add<PropertiesSet>("somedeviceid", 42, Result::Ok);
@@ -164,11 +166,13 @@ void checkCommands(Cmds& cmds)
             case Type::state_change_subscription:
                 ++count;
                 ASSERT_EQ(static_cast<StateChangeSubscription&>(*cmd).GetDeviceId(), "somedeviceid");
+                ASSERT_EQ(static_cast<StateChangeSubscription&>(*cmd).GetTaskId(), 123456);
                 ASSERT_EQ(static_cast<StateChangeSubscription&>(*cmd).GetResult(), Result::Ok);
             break;
             case Type::state_change_unsubscription:
                 ++count;
                 ASSERT_EQ(static_cast<StateChangeUnsubscription&>(*cmd).GetDeviceId(), "somedeviceid");
+                ASSERT_EQ(static_cast<StateChangeUnsubscription&>(*cmd).GetTaskId(), 123456);
                 ASSERT_EQ(static_cast<StateChangeUnsubscription&>(*cmd).GetResult(), Result::Ok);
             break;
             case Type::state_change:


### PR DESCRIPTION
- Replace the `sleep()` in the destructor of `sdk::Topology` with a proper tracking of state unsubscription commands, to make sure all of them arrived at each task. Also set a task as unsubscribed if it is exiting, since it won't respond to an unsubscription command anymore.
- Add task ID to state subscription commands.
- Some minor refactoring of the command handling.

The `initialized` member of `sdk::DeviceStatus` is renamed to `subscribed_to_state_changes`. The subscription status conveys similar information (and more) and is now used to implement first point.

