### PR TITLE
Sdk subscription heartbeats

### DIFF
--- a/fairmq/plugins/DDS/DDS.h
+++ b/fairmq/plugins/DDS/DDS.h
@@ -24,12 +24,12 @@
 #include <chrono>
 #include <condition_variable>
 #include <mutex>
-#include <set>
 #include <string>
 #include <atomic>
 #include <thread>
 #include <map>
 #include <unordered_map>
+#include <utility> // pair
 #include <vector>
 
 namespace fair
@@ -159,7 +159,7 @@ class DDS : public Plugin
 
     std::atomic<bool> fDeviceTerminationRequested;
 
-    std::set<uint64_t> fStateChangeSubscribers;
+    std::unordered_map<uint64_t, std::pair<std::chrono::steady_clock::time_point, int64_t>> fStateChangeSubscribers;
     uint64_t fLastExternalController;
     bool fExitingAckedByLastExternalController;
     std::condition_variable fExitingAcked;

--- a/fairmq/plugins/PMIx/runPMIxCommandUI.cxx
+++ b/fairmq/plugins/PMIx/runPMIxCommandUI.cxx
@@ -53,7 +53,7 @@ struct StateSubscription
     explicit StateSubscription(pmix::Commands& commands)
         : fCommands(commands)
     {
-        fCommands.Send(Cmds(make<SubscribeToStateChange>()).Serialize(Format::JSON));
+        fCommands.Send(Cmds(make<SubscribeToStateChange>(600000)).Serialize(Format::JSON));
     }
 
     ~StateSubscription()

--- a/fairmq/sdk/commands/Commands.h
+++ b/fairmq/sdk/commands/Commands.h
@@ -47,6 +47,7 @@ enum class Type : int
     state_change_exiting_received, // args: { }
     get_properties,                // args: { request_id, property_query }
     set_properties,                // args: { request_id, properties }
+    subscription_heartbeat,        // args: { interval }
 
     current_state,                 // args: { device_id, current_state }
     transition_status,             // args: { device_id, task_id, Result, transition }
@@ -95,7 +96,16 @@ struct DumpConfig : Cmd
 
 struct SubscribeToStateChange : Cmd
 {
-    explicit SubscribeToStateChange() : Cmd(Type::subscribe_to_state_change) {}
+    explicit SubscribeToStateChange(int64_t interval)
+        : Cmd(Type::subscribe_to_state_change)
+        , fInterval(interval)
+    {}
+
+    int64_t GetInterval() const { return fInterval; }
+    void SetInterval(int64_t interval) { fInterval = interval; }
+
+  private:
+    int64_t fInterval;
 };
 
 struct UnsubscribeFromStateChange : Cmd
@@ -142,6 +152,20 @@ struct SetProperties : Cmd
   private:
     std::size_t fRequestId;
     std::vector<std::pair<std::string, std::string>> fProperties;
+};
+
+struct SubscriptionHeartbeat : Cmd
+{
+    explicit SubscriptionHeartbeat(int64_t interval)
+        : Cmd(Type::subscription_heartbeat)
+        , fInterval(interval)
+    {}
+
+    int64_t GetInterval() const { return fInterval; }
+    void SetInterval(int64_t interval) { fInterval = interval; }
+
+  private:
+    int64_t fInterval;
 };
 
 struct CurrentState : Cmd

--- a/fairmq/sdk/commands/CommandsFormat.fbs
+++ b/fairmq/sdk/commands/CommandsFormat.fbs
@@ -47,11 +47,12 @@ enum FBCmd:byte {
     check_state,                   // args: { }
     change_state,                  // args: { transition }
     dump_config,                   // args: { }
-    subscribe_to_state_change,     // args: { }
+    subscribe_to_state_change,     // args: { interval }
     unsubscribe_from_state_change, // args: { }
     state_change_exiting_received, // args: { }
     get_properties,                // args: { request_id, property_query }
     set_properties,                // args: { request_id, properties }
+    subscription_heartbeat,        // args: { interval }
 
     current_state,                 // args: { device_id, current_state }
     transition_status,             // args: { device_id, task_id, Result, transition }
@@ -68,6 +69,7 @@ table FBCommand {
     device_id:string;
     task_id:uint64;
     request_id:uint64;
+    interval:int64;
     state:FBState;
     transition:FBTransition;
     result:FBResult;


### PR DESCRIPTION
Solves #190.

When subscribed to state changes SDK will send heartbeats in regular intervals (by default every 60 seconds, configurable) to the devices.

Plugin that receives the heartbeats, will check (lazily, before attempting to send a changed state command) if the last heartbeat from this subscriber arrived less than 3 times the declared interval ago. If so, it will send the command, and if not it will assume subscriber is no longer there and remove it.


