### PR TITLE
Implement region events for zmq

### DIFF
--- a/fairmq/FairMQTransportFactory.h
+++ b/fairmq/FairMQTransportFactory.h
@@ -97,6 +97,9 @@ class FairMQTransportFactory
     /// @brief Subscribe to region events (creation, destruction, ...)
     /// @param callback the callback that is called when a region event occurs
     virtual void SubscribeToRegionEvents(FairMQRegionEventCallback callback) = 0;
+    /// @brief Check if there is an active subscription to region events
+    /// @return true/false
+    virtual bool SubscribedToRegionEvents() = 0;
     /// @brief Unsubscribe from region events
     virtual void UnsubscribeFromRegionEvents() = 0;
 

--- a/fairmq/FairMQTransportFactory.h
+++ b/fairmq/FairMQTransportFactory.h
@@ -84,7 +84,7 @@ class FairMQTransportFactory
     /// @param path optional parameter to pass to the underlying transport
     /// @param flags optional parameter to pass to the underlying transport
     /// @return pointer to UnmanagedRegion
-    virtual FairMQUnmanagedRegionPtr CreateUnmanagedRegion(const size_t size, FairMQRegionCallback callback = nullptr, const std::string& path = "", int flags = 0) const = 0;
+    virtual FairMQUnmanagedRegionPtr CreateUnmanagedRegion(const size_t size, FairMQRegionCallback callback = nullptr, const std::string& path = "", int flags = 0) = 0;
     /// @brief Create new UnmanagedRegion
     /// @param size size of the region
     /// @param userFlags flags to be stored with the region, have no effect on the transport, but can be retrieved from the region by the user
@@ -92,7 +92,7 @@ class FairMQTransportFactory
     /// @param path optional parameter to pass to the underlying transport
     /// @param flags optional parameter to pass to the underlying transport
     /// @return pointer to UnmanagedRegion
-    virtual FairMQUnmanagedRegionPtr CreateUnmanagedRegion(const size_t size, const int64_t userFlags, FairMQRegionCallback callback = nullptr, const std::string& path = "", int flags = 0) const = 0;
+    virtual FairMQUnmanagedRegionPtr CreateUnmanagedRegion(const size_t size, const int64_t userFlags, FairMQRegionCallback callback = nullptr, const std::string& path = "", int flags = 0) = 0;
 
     /// @brief Subscribe to region events (creation, destruction, ...)
     /// @param callback the callback that is called when a region event occurs

--- a/fairmq/FairMQUnmanagedRegion.h
+++ b/fairmq/FairMQUnmanagedRegion.h
@@ -14,13 +14,32 @@
 #include <functional> // std::function
 #include <ostream> // std::ostream
 
+class FairMQTransportFactory;
+
 enum class FairMQRegionEvent : int
 {
     created,
     destroyed
 };
 
-struct FairMQRegionInfo {
+struct FairMQRegionInfo
+{
+    FairMQRegionInfo()
+        : id(0)
+        , ptr(nullptr)
+        , size(0)
+        , flags(0)
+        , event(FairMQRegionEvent::created)
+    {}
+
+    FairMQRegionInfo(uint64_t _id, void* _ptr, size_t _size, int64_t _flags, FairMQRegionEvent _event)
+        : id(_id)
+        , ptr(_ptr)
+        , size(_size)
+        , flags(_flags)
+        , event (_event)
+    {}
+
     uint64_t id;   // id of the region
     void* ptr;     // pointer to the start of the region
     size_t size;   // region size
@@ -34,10 +53,19 @@ using FairMQRegionEventCallback = std::function<void(FairMQRegionInfo)>;
 class FairMQUnmanagedRegion
 {
   public:
+    FairMQUnmanagedRegion() {}
+    FairMQUnmanagedRegion(FairMQTransportFactory* factory): fTransport(factory) {}
+
     virtual void* GetData() const = 0;
     virtual size_t GetSize() const = 0;
 
+    FairMQTransportFactory* GetTransport() { return fTransport; }
+    void SetTransport(FairMQTransportFactory* transport) { fTransport = transport; }
+
     virtual ~FairMQUnmanagedRegion() {};
+
+  private:
+    FairMQTransportFactory* fTransport{nullptr};
 };
 
 using FairMQUnmanagedRegionPtr = std::unique_ptr<FairMQUnmanagedRegion>;

--- a/fairmq/FairMQUnmanagedRegion.h
+++ b/fairmq/FairMQUnmanagedRegion.h
@@ -19,7 +19,8 @@ class FairMQTransportFactory;
 enum class FairMQRegionEvent : int
 {
     created,
-    destroyed
+    destroyed,
+    local_only
 };
 
 struct FairMQRegionInfo
@@ -72,10 +73,15 @@ using FairMQUnmanagedRegionPtr = std::unique_ptr<FairMQUnmanagedRegion>;
 
 inline std::ostream& operator<<(std::ostream& os, const FairMQRegionEvent& event)
 {
-    if (event == FairMQRegionEvent::created) {
-        return os << "created";
-    } else {
-        return os << "destroyed";
+    switch (event) {
+        case FairMQRegionEvent::created:
+            return os << "created";
+        case FairMQRegionEvent::destroyed:
+            return os << "destroyed";
+        case FairMQRegionEvent::local_only:
+            return os << "local_only";
+        default:
+            return os << "unrecognized event";
     }
 }
 

--- a/fairmq/FairMQUnmanagedRegion.h
+++ b/fairmq/FairMQUnmanagedRegion.h
@@ -59,6 +59,7 @@ class FairMQUnmanagedRegion
 
     virtual void* GetData() const = 0;
     virtual size_t GetSize() const = 0;
+    virtual uint64_t GetId() const = 0;
 
     FairMQTransportFactory* GetTransport() { return fTransport; }
     void SetTransport(FairMQTransportFactory* transport) { fTransport = transport; }

--- a/fairmq/nanomsg/FairMQTransportFactoryNN.cxx
+++ b/fairmq/nanomsg/FairMQTransportFactoryNN.cxx
@@ -19,6 +19,7 @@ fair::mq::Transport FairMQTransportFactoryNN::fTransportType = fair::mq::Transpo
 
 FairMQTransportFactoryNN::FairMQTransportFactoryNN(const string& id, const fair::mq::ProgOptions* /*config*/)
     : FairMQTransportFactory(id)
+    , fRegionCounter(0)
 {
     LOG(debug) << "Transport: Using nanomsg library";
 }
@@ -67,7 +68,7 @@ FairMQPollerPtr FairMQTransportFactoryNN::CreatePoller(const unordered_map<strin
 
 FairMQUnmanagedRegionPtr FairMQTransportFactoryNN::CreateUnmanagedRegion(const size_t size, FairMQRegionCallback callback, const std::string& path /* = "" */, int flags /* = 0 */)
 {
-    return unique_ptr<FairMQUnmanagedRegion>(new FairMQUnmanagedRegionNN(size, callback, path, flags, this));
+    return unique_ptr<FairMQUnmanagedRegion>(new FairMQUnmanagedRegionNN(++fRegionCounter, size, callback, path, flags, this));
 }
 
 FairMQUnmanagedRegionPtr FairMQTransportFactoryNN::CreateUnmanagedRegion(const size_t size, const int64_t userFlags, FairMQRegionCallback callback, const std::string& path /* = "" */, int flags /* = 0 */)

--- a/fairmq/nanomsg/FairMQTransportFactoryNN.cxx
+++ b/fairmq/nanomsg/FairMQTransportFactoryNN.cxx
@@ -65,14 +65,14 @@ FairMQPollerPtr FairMQTransportFactoryNN::CreatePoller(const unordered_map<strin
     return unique_ptr<FairMQPoller>(new FairMQPollerNN(channelsMap, channelList));
 }
 
-FairMQUnmanagedRegionPtr FairMQTransportFactoryNN::CreateUnmanagedRegion(const size_t size, FairMQRegionCallback callback, const std::string& path /* = "" */, int flags /* = 0 */) const
+FairMQUnmanagedRegionPtr FairMQTransportFactoryNN::CreateUnmanagedRegion(const size_t size, FairMQRegionCallback callback, const std::string& path /* = "" */, int flags /* = 0 */)
 {
-    return unique_ptr<FairMQUnmanagedRegion>(new FairMQUnmanagedRegionNN(size, callback, path, flags));
+    return unique_ptr<FairMQUnmanagedRegion>(new FairMQUnmanagedRegionNN(size, callback, path, flags, this));
 }
 
-FairMQUnmanagedRegionPtr FairMQTransportFactoryNN::CreateUnmanagedRegion(const size_t size, const int64_t userFlags, FairMQRegionCallback callback, const std::string& path /* = "" */, int flags /* = 0 */) const
+FairMQUnmanagedRegionPtr FairMQTransportFactoryNN::CreateUnmanagedRegion(const size_t size, const int64_t userFlags, FairMQRegionCallback callback, const std::string& path /* = "" */, int flags /* = 0 */)
 {
-    return unique_ptr<FairMQUnmanagedRegion>(new FairMQUnmanagedRegionNN(size, userFlags, callback, path, flags));
+    return unique_ptr<FairMQUnmanagedRegion>(new FairMQUnmanagedRegionNN(size, userFlags, callback, path, flags, this));
 }
 
 fair::mq::Transport FairMQTransportFactoryNN::GetType() const

--- a/fairmq/nanomsg/FairMQTransportFactoryNN.h
+++ b/fairmq/nanomsg/FairMQTransportFactoryNN.h
@@ -40,6 +40,7 @@ class FairMQTransportFactoryNN final : public FairMQTransportFactory
     FairMQUnmanagedRegionPtr CreateUnmanagedRegion(const size_t size, int64_t userFlags, FairMQRegionCallback callback = nullptr, const std::string& path = "", int flags = 0) override;
 
     void SubscribeToRegionEvents(FairMQRegionEventCallback /* callback */) override { LOG(error) << "SubscribeToRegionEvents not yet implemented for nanomsg"; }
+    bool SubscribedToRegionEvents() override { LOG(error) << "Region event subscriptions not yet implemented for nanomsg"; return false; }
     void UnsubscribeFromRegionEvents() override { LOG(error) << "UnsubscribeFromRegionEvents not yet implemented for nanomsg"; }
     std::vector<FairMQRegionInfo> GetRegionInfo() override { LOG(error) << "GetRegionInfo not yet implemented for nanomsg, returning empty vector"; return std::vector<FairMQRegionInfo>(); }
 

--- a/fairmq/nanomsg/FairMQTransportFactoryNN.h
+++ b/fairmq/nanomsg/FairMQTransportFactoryNN.h
@@ -52,6 +52,7 @@ class FairMQTransportFactoryNN final : public FairMQTransportFactory
 
   private:
     static fair::mq::Transport fTransportType;
+    uint64_t fRegionCounter;
     mutable std::vector<FairMQSocket*> fSockets;
 };
 

--- a/fairmq/nanomsg/FairMQTransportFactoryNN.h
+++ b/fairmq/nanomsg/FairMQTransportFactoryNN.h
@@ -36,8 +36,8 @@ class FairMQTransportFactoryNN final : public FairMQTransportFactory
     FairMQPollerPtr CreatePoller(const std::vector<FairMQChannel*>& channels) const override;
     FairMQPollerPtr CreatePoller(const std::unordered_map<std::string, std::vector<FairMQChannel>>& channelsMap, const std::vector<std::string>& channelList) const override;
 
-    FairMQUnmanagedRegionPtr CreateUnmanagedRegion(const size_t size, FairMQRegionCallback callback, const std::string& path = "", int flags = 0) const override;
-    FairMQUnmanagedRegionPtr CreateUnmanagedRegion(const size_t size, int64_t userFlags, FairMQRegionCallback callback = nullptr, const std::string& path = "", int flags = 0) const override;
+    FairMQUnmanagedRegionPtr CreateUnmanagedRegion(const size_t size, FairMQRegionCallback callback, const std::string& path = "", int flags = 0) override;
+    FairMQUnmanagedRegionPtr CreateUnmanagedRegion(const size_t size, int64_t userFlags, FairMQRegionCallback callback = nullptr, const std::string& path = "", int flags = 0) override;
 
     void SubscribeToRegionEvents(FairMQRegionEventCallback /* callback */) override { LOG(error) << "SubscribeToRegionEvents not yet implemented for nanomsg"; }
     void UnsubscribeFromRegionEvents() override { LOG(error) << "UnsubscribeFromRegionEvents not yet implemented for nanomsg"; }

--- a/fairmq/nanomsg/FairMQUnmanagedRegionNN.cxx
+++ b/fairmq/nanomsg/FairMQUnmanagedRegionNN.cxx
@@ -11,15 +11,17 @@
 
 using namespace std;
 
-FairMQUnmanagedRegionNN::FairMQUnmanagedRegionNN(const size_t size, FairMQRegionCallback callback, const std::string& /*path = "" */, int /*flags = 0 */)
-    : fBuffer(malloc(size))
+FairMQUnmanagedRegionNN::FairMQUnmanagedRegionNN(const size_t size, FairMQRegionCallback callback, const std::string& /*path = "" */, int /*flags = 0 */, FairMQTransportFactory* factory /* = nullptr */)
+    : FairMQUnmanagedRegion(factory)
+    , fBuffer(malloc(size))
     , fSize(size)
     , fCallback(callback)
 {
 }
 
-FairMQUnmanagedRegionNN::FairMQUnmanagedRegionNN(const size_t size, const int64_t /*userFlags*/, FairMQRegionCallback callback, const std::string& /*path = "" */, int /*flags = 0 */)
-    : fBuffer(malloc(size))
+FairMQUnmanagedRegionNN::FairMQUnmanagedRegionNN(const size_t size, const int64_t /*userFlags*/, FairMQRegionCallback callback, const std::string& /*path = "" */, int /*flags = 0 */, FairMQTransportFactory* factory /* = nullptr */)
+    : FairMQUnmanagedRegion(factory)
+    , fBuffer(malloc(size))
     , fSize(size)
     , fCallback(callback)
 {

--- a/fairmq/nanomsg/FairMQUnmanagedRegionNN.cxx
+++ b/fairmq/nanomsg/FairMQUnmanagedRegionNN.cxx
@@ -11,16 +11,18 @@
 
 using namespace std;
 
-FairMQUnmanagedRegionNN::FairMQUnmanagedRegionNN(const size_t size, FairMQRegionCallback callback, const std::string& /*path = "" */, int /*flags = 0 */, FairMQTransportFactory* factory /* = nullptr */)
+FairMQUnmanagedRegionNN::FairMQUnmanagedRegionNN(uint64_t id, const size_t size, FairMQRegionCallback callback, const std::string& /*path = "" */, int /*flags = 0 */, FairMQTransportFactory* factory /* = nullptr */)
     : FairMQUnmanagedRegion(factory)
+    , fId(id)
     , fBuffer(malloc(size))
     , fSize(size)
     , fCallback(callback)
 {
 }
 
-FairMQUnmanagedRegionNN::FairMQUnmanagedRegionNN(const size_t size, const int64_t /*userFlags*/, FairMQRegionCallback callback, const std::string& /*path = "" */, int /*flags = 0 */, FairMQTransportFactory* factory /* = nullptr */)
+FairMQUnmanagedRegionNN::FairMQUnmanagedRegionNN(uint64_t id, const size_t size, const int64_t /*userFlags*/, FairMQRegionCallback callback, const std::string& /*path = "" */, int /*flags = 0 */, FairMQTransportFactory* factory /* = nullptr */)
     : FairMQUnmanagedRegion(factory)
+    , fId(id)
     , fBuffer(malloc(size))
     , fSize(size)
     , fCallback(callback)
@@ -36,6 +38,12 @@ size_t FairMQUnmanagedRegionNN::GetSize() const
 {
     return fSize;
 }
+
+uint64_t FairMQUnmanagedRegionNN::GetId() const
+{
+    return fId;
+}
+
 
 FairMQUnmanagedRegionNN::~FairMQUnmanagedRegionNN()
 {

--- a/fairmq/nanomsg/FairMQUnmanagedRegionNN.h
+++ b/fairmq/nanomsg/FairMQUnmanagedRegionNN.h
@@ -19,18 +19,20 @@ class FairMQUnmanagedRegionNN final : public FairMQUnmanagedRegion
     friend class FairMQSocketNN;
 
   public:
-    FairMQUnmanagedRegionNN(const size_t size, FairMQRegionCallback callback, const std::string& path = "", int flags = 0, FairMQTransportFactory* factory = nullptr);
-    FairMQUnmanagedRegionNN(const size_t size, const int64_t userFlags, FairMQRegionCallback callback, const std::string& path = "", int flags = 0, FairMQTransportFactory* factory = nullptr);
+    FairMQUnmanagedRegionNN(uint64_t id, const size_t size, FairMQRegionCallback callback, const std::string& path = "", int flags = 0, FairMQTransportFactory* factory = nullptr);
+    FairMQUnmanagedRegionNN(uint64_t id, const size_t size, const int64_t userFlags, FairMQRegionCallback callback, const std::string& path = "", int flags = 0, FairMQTransportFactory* factory = nullptr);
 
     FairMQUnmanagedRegionNN(const FairMQUnmanagedRegionNN&) = delete;
     FairMQUnmanagedRegionNN operator=(const FairMQUnmanagedRegionNN&) = delete;
 
-    virtual void* GetData() const override;
-    virtual size_t GetSize() const override;
+    void* GetData() const override;
+    size_t GetSize() const override;
+    uint64_t GetId() const override;
 
     virtual ~FairMQUnmanagedRegionNN();
 
   private:
+    uint64_t fId;
     void* fBuffer;
     size_t fSize;
     FairMQRegionCallback fCallback;

--- a/fairmq/nanomsg/FairMQUnmanagedRegionNN.h
+++ b/fairmq/nanomsg/FairMQUnmanagedRegionNN.h
@@ -19,8 +19,8 @@ class FairMQUnmanagedRegionNN final : public FairMQUnmanagedRegion
     friend class FairMQSocketNN;
 
   public:
-    FairMQUnmanagedRegionNN(const size_t size, FairMQRegionCallback callback, const std::string& path = "", int flags = 0);
-    FairMQUnmanagedRegionNN(const size_t size, const int64_t userFlags, FairMQRegionCallback callback, const std::string& path = "", int flags = 0);
+    FairMQUnmanagedRegionNN(const size_t size, FairMQRegionCallback callback, const std::string& path = "", int flags = 0, FairMQTransportFactory* factory = nullptr);
+    FairMQUnmanagedRegionNN(const size_t size, const int64_t userFlags, FairMQRegionCallback callback, const std::string& path = "", int flags = 0, FairMQTransportFactory* factory = nullptr);
 
     FairMQUnmanagedRegionNN(const FairMQUnmanagedRegionNN&) = delete;
     FairMQUnmanagedRegionNN operator=(const FairMQUnmanagedRegionNN&) = delete;

--- a/fairmq/ofi/TransportFactory.cxx
+++ b/fairmq/ofi/TransportFactory.cxx
@@ -85,12 +85,12 @@ auto TransportFactory::CreatePoller(const unordered_map<string, vector<FairMQCha
     // return PollerPtr{new Poller(channelsMap, channelList)};
 }
 
-auto TransportFactory::CreateUnmanagedRegion(const size_t /*size*/, FairMQRegionCallback /*callback*/, const std::string& /* path = "" */, int /* flags = 0 */) const -> UnmanagedRegionPtr
+auto TransportFactory::CreateUnmanagedRegion(const size_t /*size*/, FairMQRegionCallback /*callback*/, const std::string& /* path = "" */, int /* flags = 0 */) -> UnmanagedRegionPtr
 {
     throw runtime_error{"Not yet implemented UMR."};
 }
 
-auto TransportFactory::CreateUnmanagedRegion(const size_t /*size*/, const int64_t /*userFlags*/, FairMQRegionCallback /*callback*/, const std::string& /* path = "" */, int /* flags = 0 */) const -> UnmanagedRegionPtr
+auto TransportFactory::CreateUnmanagedRegion(const size_t /*size*/, const int64_t /*userFlags*/, FairMQRegionCallback /*callback*/, const std::string& /* path = "" */, int /* flags = 0 */) -> UnmanagedRegionPtr
 {
     throw runtime_error{"Not yet implemented UMR."};
 }

--- a/fairmq/ofi/TransportFactory.h
+++ b/fairmq/ofi/TransportFactory.h
@@ -50,6 +50,7 @@ class TransportFactory final : public FairMQTransportFactory
     auto CreateUnmanagedRegion(const size_t size, int64_t userFlags, RegionCallback callback = nullptr, const std::string& path = "", int flags = 0) -> UnmanagedRegionPtr override;
 
     void SubscribeToRegionEvents(RegionEventCallback /* callback */) override { LOG(error) << "SubscribeToRegionEvents not yet implemented for OFI"; }
+    bool SubscribedToRegionEvents() override { LOG(error) << "Region event subscriptions not yet implemented for OFI"; return false; }
     void UnsubscribeFromRegionEvents() override { LOG(error) << "UnsubscribeFromRegionEvents not yet implemented for OFI"; }
     std::vector<FairMQRegionInfo> GetRegionInfo() override { LOG(error) << "GetRegionInfo not yet implemented for OFI, returning empty vector"; return std::vector<FairMQRegionInfo>(); }
 

--- a/fairmq/ofi/TransportFactory.h
+++ b/fairmq/ofi/TransportFactory.h
@@ -46,8 +46,8 @@ class TransportFactory final : public FairMQTransportFactory
     auto CreatePoller(const std::vector<FairMQChannel*>& channels) const -> PollerPtr override;
     auto CreatePoller(const std::unordered_map<std::string, std::vector<FairMQChannel>>& channelsMap, const std::vector<std::string>& channelList) const -> PollerPtr override;
 
-    auto CreateUnmanagedRegion(const size_t size, RegionCallback callback = nullptr, const std::string& path = "", int flags = 0) const -> UnmanagedRegionPtr override;
-    auto CreateUnmanagedRegion(const size_t size, int64_t userFlags, RegionCallback callback = nullptr, const std::string& path = "", int flags = 0) const -> UnmanagedRegionPtr override;
+    auto CreateUnmanagedRegion(const size_t size, RegionCallback callback = nullptr, const std::string& path = "", int flags = 0) -> UnmanagedRegionPtr override;
+    auto CreateUnmanagedRegion(const size_t size, int64_t userFlags, RegionCallback callback = nullptr, const std::string& path = "", int flags = 0) -> UnmanagedRegionPtr override;
 
     void SubscribeToRegionEvents(RegionEventCallback /* callback */) override { LOG(error) << "SubscribeToRegionEvents not yet implemented for OFI"; }
     void UnsubscribeFromRegionEvents() override { LOG(error) << "UnsubscribeFromRegionEvents not yet implemented for OFI"; }

--- a/fairmq/shmem/Manager.cxx
+++ b/fairmq/shmem/Manager.cxx
@@ -247,6 +247,11 @@ void Manager::SubscribeToRegionEvents(RegionEventCallback callback)
     fRegionEventThread = thread(&Manager::RegionEventsSubscription, this);
 }
 
+bool Manager::SubscribedToRegionEvents()
+{
+    return fRegionEventThread.joinable();
+}
+
 void Manager::UnsubscribeFromRegionEvents()
 {
     if (fRegionEventThread.joinable()) {

--- a/fairmq/shmem/Manager.h
+++ b/fairmq/shmem/Manager.h
@@ -78,6 +78,7 @@ class Manager
     std::vector<fair::mq::RegionInfo> GetRegionInfo();
     std::vector<fair::mq::RegionInfo> GetRegionInfoUnsafe();
     void SubscribeToRegionEvents(RegionEventCallback callback);
+    bool SubscribedToRegionEvents();
     void UnsubscribeFromRegionEvents();
     void RegionEventsSubscription();
 

--- a/fairmq/shmem/Manager.h
+++ b/fairmq/shmem/Manager.h
@@ -94,7 +94,7 @@ class Manager
 
     boost::interprocess::named_condition fRegionEventsCV;
     std::thread fRegionEventThread;
-    std::atomic<bool> fRegionEventsSubscriptionActive;
+    bool fRegionEventsSubscriptionActive;
     std::function<void(fair::mq::RegionInfo)> fRegionEventCallback;
     std::unordered_map<uint64_t, RegionEvent> fObservedRegionEvents;
 

--- a/fairmq/shmem/TransportFactory.cxx
+++ b/fairmq/shmem/TransportFactory.cxx
@@ -174,6 +174,11 @@ void TransportFactory::SubscribeToRegionEvents(RegionEventCallback callback)
     fManager->SubscribeToRegionEvents(callback);
 }
 
+bool TransportFactory::SubscribedToRegionEvents()
+{
+    return fManager->SubscribedToRegionEvents();
+}
+
 void TransportFactory::UnsubscribeFromRegionEvents()
 {
     fManager->UnsubscribeFromRegionEvents();

--- a/fairmq/shmem/TransportFactory.cxx
+++ b/fairmq/shmem/TransportFactory.cxx
@@ -159,14 +159,14 @@ PollerPtr TransportFactory::CreatePoller(const unordered_map<string, vector<Fair
     return tools::make_unique<Poller>(channelsMap, channelList);
 }
 
-UnmanagedRegionPtr TransportFactory::CreateUnmanagedRegion(const size_t size, RegionCallback callback, const std::string& path /* = "" */, int flags /* = 0 */) const
+UnmanagedRegionPtr TransportFactory::CreateUnmanagedRegion(const size_t size, RegionCallback callback, const std::string& path /* = "" */, int flags /* = 0 */)
 {
-    return tools::make_unique<UnmanagedRegion>(*fManager, size, callback, path, flags);
+    return tools::make_unique<UnmanagedRegion>(*fManager, size, callback, path, flags, this);
 }
 
-UnmanagedRegionPtr TransportFactory::CreateUnmanagedRegion(const size_t size, const int64_t userFlags, RegionCallback callback, const std::string& path /* = "" */, int flags /* = 0 */) const
+UnmanagedRegionPtr TransportFactory::CreateUnmanagedRegion(const size_t size, const int64_t userFlags, RegionCallback callback, const std::string& path /* = "" */, int flags /* = 0 */)
 {
-    return tools::make_unique<UnmanagedRegion>(*fManager, size, userFlags, callback, path, flags);
+    return tools::make_unique<UnmanagedRegion>(*fManager, size, userFlags, callback, path, flags, this);
 }
 
 void TransportFactory::SubscribeToRegionEvents(RegionEventCallback callback)

--- a/fairmq/shmem/TransportFactory.h
+++ b/fairmq/shmem/TransportFactory.h
@@ -49,8 +49,8 @@ class TransportFactory final : public fair::mq::TransportFactory
     PollerPtr CreatePoller(const std::vector<FairMQChannel*>& channels) const override;
     PollerPtr CreatePoller(const std::unordered_map<std::string, std::vector<FairMQChannel>>& channelsMap, const std::vector<std::string>& channelList) const override;
 
-    UnmanagedRegionPtr CreateUnmanagedRegion(const size_t size, RegionCallback callback = nullptr, const std::string& path = "", int flags = 0) const override;
-    UnmanagedRegionPtr CreateUnmanagedRegion(const size_t size, int64_t userFlags, RegionCallback callback = nullptr, const std::string& path = "", int flags = 0) const override;
+    UnmanagedRegionPtr CreateUnmanagedRegion(const size_t size, RegionCallback callback = nullptr, const std::string& path = "", int flags = 0) override;
+    UnmanagedRegionPtr CreateUnmanagedRegion(const size_t size, int64_t userFlags, RegionCallback callback = nullptr, const std::string& path = "", int flags = 0) override;
 
     void SubscribeToRegionEvents(RegionEventCallback callback) override;
     void UnsubscribeFromRegionEvents() override;

--- a/fairmq/shmem/TransportFactory.h
+++ b/fairmq/shmem/TransportFactory.h
@@ -53,6 +53,7 @@ class TransportFactory final : public fair::mq::TransportFactory
     UnmanagedRegionPtr CreateUnmanagedRegion(const size_t size, int64_t userFlags, RegionCallback callback = nullptr, const std::string& path = "", int flags = 0) override;
 
     void SubscribeToRegionEvents(RegionEventCallback callback) override;
+    bool SubscribedToRegionEvents() override;
     void UnsubscribeFromRegionEvents() override;
     std::vector<fair::mq::RegionInfo> GetRegionInfo() override;
 

--- a/fairmq/shmem/UnmanagedRegion.h
+++ b/fairmq/shmem/UnmanagedRegion.h
@@ -53,6 +53,7 @@ class UnmanagedRegion final : public fair::mq::UnmanagedRegion
 
     void* GetData() const override { return fRegion->get_address(); }
     size_t GetSize() const override { return fRegion->get_size(); }
+    uint64_t GetId() const override { return fRegionId; }
 
     ~UnmanagedRegion() override { fManager.RemoveRegion(fRegionId); }
 

--- a/fairmq/shmem/UnmanagedRegion.h
+++ b/fairmq/shmem/UnmanagedRegion.h
@@ -36,12 +36,13 @@ class UnmanagedRegion final : public fair::mq::UnmanagedRegion
     friend class Socket;
 
   public:
-    UnmanagedRegion(Manager& manager, const size_t size, RegionCallback callback, const std::string& path = "", int flags = 0)
-        : UnmanagedRegion(manager, size, 0, callback, path, flags)
+    UnmanagedRegion(Manager& manager, const size_t size, RegionCallback callback, const std::string& path = "", int flags = 0, FairMQTransportFactory* factory = nullptr)
+        : UnmanagedRegion(manager, size, 0, callback, path, flags, factory)
     {}
 
-    UnmanagedRegion(Manager& manager, const size_t size, const int64_t userFlags, RegionCallback callback, const std::string& path = "", int flags = 0)
-        : fManager(manager)
+    UnmanagedRegion(Manager& manager, const size_t size, const int64_t userFlags, RegionCallback callback, const std::string& path = "", int flags = 0, FairMQTransportFactory* factory = nullptr)
+        : FairMQUnmanagedRegion(factory)
+        , fManager(manager)
         , fRegion(nullptr)
         , fRegionId(0)
     {

--- a/fairmq/zeromq/FairMQTransportFactoryZMQ.cxx
+++ b/fairmq/zeromq/FairMQTransportFactoryZMQ.cxx
@@ -132,6 +132,11 @@ void FairMQTransportFactoryZMQ::SubscribeToRegionEvents(FairMQRegionEventCallbac
     fRegionEventThread = thread(&FairMQTransportFactoryZMQ::RegionEventsSubscription, this);
 }
 
+bool FairMQTransportFactoryZMQ::SubscribedToRegionEvents()
+{
+    return fRegionEventThread.joinable();
+}
+
 void FairMQTransportFactoryZMQ::UnsubscribeFromRegionEvents()
 {
     if (fRegionEventThread.joinable()) {

--- a/fairmq/zeromq/FairMQTransportFactoryZMQ.cxx
+++ b/fairmq/zeromq/FairMQTransportFactoryZMQ.cxx
@@ -50,6 +50,7 @@ FairMQTransportFactoryZMQ::FairMQTransportFactoryZMQ(const string& id, const fai
         LOG(error) << "failed configuring context, reason: " << zmq_strerror(errno);
     }
 
+    fRegionEvents.emplace(0, nullptr, 0, 0, fair::mq::RegionEvent::local_only);
 }
 
 FairMQMessagePtr FairMQTransportFactoryZMQ::CreateMessage()

--- a/fairmq/zeromq/FairMQTransportFactoryZMQ.h
+++ b/fairmq/zeromq/FairMQTransportFactoryZMQ.h
@@ -52,6 +52,7 @@ class FairMQTransportFactoryZMQ final : public FairMQTransportFactory
     FairMQUnmanagedRegionPtr CreateUnmanagedRegion(const size_t size, const int64_t userFlags, FairMQRegionCallback callback, const std::string& path = "", int flags = 0) override;
 
     void SubscribeToRegionEvents(FairMQRegionEventCallback callback) override;
+    bool SubscribedToRegionEvents() override;
     void UnsubscribeFromRegionEvents() override;
     void RegionEventsSubscription();
     std::vector<fair::mq::RegionInfo> GetRegionInfo() override;

--- a/fairmq/zeromq/FairMQUnmanagedRegionZMQ.cxx
+++ b/fairmq/zeromq/FairMQUnmanagedRegionZMQ.cxx
@@ -7,23 +7,17 @@
  ********************************************************************************/
 
 #include "FairMQUnmanagedRegionZMQ.h"
+#include "FairMQTransportFactoryZMQ.h"
 #include "FairMQLogger.h"
 
-using namespace std;
-
-FairMQUnmanagedRegionZMQ::FairMQUnmanagedRegionZMQ(const size_t size, FairMQRegionCallback callback, const std::string& /* path = "" */, int /* flags = 0 */)
-    : fBuffer(malloc(size))
+FairMQUnmanagedRegionZMQ::FairMQUnmanagedRegionZMQ(uint64_t id, const size_t size, int64_t userFlags, FairMQRegionCallback callback, const std::string& /* path = "" */, int /* flags = 0 */, FairMQTransportFactory* factory /* = nullptr */)
+    : FairMQUnmanagedRegion(factory)
+    , fId(id)
+    , fBuffer(malloc(size))
     , fSize(size)
+    , fUserFlags(userFlags)
     , fCallback(callback)
-{
-}
-
-FairMQUnmanagedRegionZMQ::FairMQUnmanagedRegionZMQ(const size_t size, int64_t /* userFlags */, FairMQRegionCallback callback, const std::string& /* path = "" */, int /* flags = 0 */)
-    : fBuffer(malloc(size))
-    , fSize(size)
-    , fCallback(callback)
-{
-}
+{}
 
 void* FairMQUnmanagedRegionZMQ::GetData() const
 {
@@ -38,5 +32,6 @@ size_t FairMQUnmanagedRegionZMQ::GetSize() const
 FairMQUnmanagedRegionZMQ::~FairMQUnmanagedRegionZMQ()
 {
     LOG(debug) << "destroying region";
+    static_cast<FairMQTransportFactoryZMQ*>(GetTransport())->RemoveRegion(fId);
     free(fBuffer);
 }

--- a/fairmq/zeromq/FairMQUnmanagedRegionZMQ.h
+++ b/fairmq/zeromq/FairMQUnmanagedRegionZMQ.h
@@ -13,6 +13,7 @@
 
 #include <cstddef> // size_t
 #include <string>
+class FairMQTransportFactory;
 
 class FairMQUnmanagedRegionZMQ final : public FairMQUnmanagedRegion
 {
@@ -20,19 +21,23 @@ class FairMQUnmanagedRegionZMQ final : public FairMQUnmanagedRegion
     friend class FairMQMessageZMQ;
 
   public:
-    FairMQUnmanagedRegionZMQ(const size_t size, FairMQRegionCallback callback, const std::string& path = "", int flags = 0);
-    FairMQUnmanagedRegionZMQ(const size_t size, const int64_t userFlags, FairMQRegionCallback callback, const std::string& path = "", int flags = 0);
+    FairMQUnmanagedRegionZMQ(uint64_t id, const size_t size, int64_t userFlags, FairMQRegionCallback callback, const std::string& /* path = "" */, int /* flags = 0 */, FairMQTransportFactory* factory = nullptr);
+
     FairMQUnmanagedRegionZMQ(const FairMQUnmanagedRegionZMQ&) = delete;
     FairMQUnmanagedRegionZMQ operator=(const FairMQUnmanagedRegionZMQ&) = delete;
 
+    uint64_t GetId() const { return fId; }
     virtual void* GetData() const override;
     virtual size_t GetSize() const override;
+    int64_t GetUserFlags() const { return fUserFlags; }
 
     virtual ~FairMQUnmanagedRegionZMQ();
 
   private:
+    uint64_t fId;
     void* fBuffer;
     size_t fSize;
+    int64_t fUserFlags;
     FairMQRegionCallback fCallback;
 };
 

--- a/fairmq/zeromq/FairMQUnmanagedRegionZMQ.h
+++ b/fairmq/zeromq/FairMQUnmanagedRegionZMQ.h
@@ -26,9 +26,9 @@ class FairMQUnmanagedRegionZMQ final : public FairMQUnmanagedRegion
     FairMQUnmanagedRegionZMQ(const FairMQUnmanagedRegionZMQ&) = delete;
     FairMQUnmanagedRegionZMQ operator=(const FairMQUnmanagedRegionZMQ&) = delete;
 
-    uint64_t GetId() const { return fId; }
     virtual void* GetData() const override;
     virtual size_t GetSize() const override;
+    uint64_t GetId() const override { return fId; }
     int64_t GetUserFlags() const { return fUserFlags; }
 
     virtual ~FairMQUnmanagedRegionZMQ();

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -96,6 +96,19 @@ add_testsuite(Message
     ${definitions}
 )
 
+add_testsuite(Region
+    SOURCES
+    ${CMAKE_CURRENT_BINARY_DIR}/runner.cxx
+    region/_region.cxx
+
+    LINKS FairMQ
+    INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}
+             ${CMAKE_CURRENT_SOURCE_DIR}/region
+             ${CMAKE_CURRENT_BINARY_DIR}
+    TIMEOUT 5
+    ${definitions}
+)
+
 add_testsuite(Device
     SOURCES
     ${CMAKE_CURRENT_BINARY_DIR}/runner.cxx

--- a/test/region/_region.cxx
+++ b/test/region/_region.cxx
@@ -1,0 +1,103 @@
+/********************************************************************************
+ *    Copyright (C) 2017 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ *                                                                              *
+ *              This software is distributed under the terms of the             *
+ *              GNU Lesser General Public Licence (LGPL) version 3,             *
+ *                  copied verbatim in the file "LICENSE"                       *
+ ********************************************************************************/
+
+#include <FairMQLogger.h>
+#include <FairMQTransportFactory.h>
+#include <fairmq/ProgOptions.h>
+#include <fairmq/Tools.h>
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+namespace
+{
+
+using namespace std;
+
+void RegionEventSubscriptions(const string& transport)
+{
+    size_t session{fair::mq::tools::UuidHash()};
+
+    fair::mq::ProgOptions config;
+    config.SetProperty<string>("session", to_string(session));
+
+    auto factory = FairMQTransportFactory::CreateTransportFactory(transport, fair::mq::tools::Uuid(), &config);
+
+    constexpr int size1 = 1000000;
+    constexpr int size2 = 5000000;
+    constexpr int64_t userFlags = 12345;
+    fair::mq::tools::SharedSemaphore blocker;
+
+    {
+        auto region1 = factory->CreateUnmanagedRegion(size1, [](void*, size_t, void*) {});
+        void* ptr1 = region1->GetData();
+        uint64_t id1 = region1->GetId();
+        ASSERT_EQ(region1->GetSize(), size1);
+
+        auto region2 = factory->CreateUnmanagedRegion(size2, userFlags, [](void*, size_t, void*) {});
+        void* ptr2 = region2->GetData();
+        uint64_t id2 = region2->GetId();
+        ASSERT_EQ(region2->GetSize(), size2);
+
+        ASSERT_EQ(factory->SubscribedToRegionEvents(), false);
+        factory->SubscribeToRegionEvents([&](FairMQRegionInfo info) {
+            LOG(warn) << ">>>" << info.event;
+            LOG(warn) << "id: " << info.id;
+            LOG(warn) << "ptr: " << info.ptr;
+            LOG(warn) << "size: " << info.size;
+            LOG(warn) << "flags: " << info.flags;
+            if (info.event == FairMQRegionEvent::created) {
+                if (info.id == id1) {
+                    ASSERT_EQ(info.size, size1);
+                    ASSERT_EQ(info.ptr, ptr1);
+                    blocker.Signal();
+                } else if (info.id == id2) {
+                    ASSERT_EQ(info.size, size2);
+                    ASSERT_EQ(info.ptr, ptr2);
+                    ASSERT_EQ(info.flags, userFlags);
+                    blocker.Signal();
+                }
+            } else if (info.event == FairMQRegionEvent::destroyed) {
+                if (info.id == id1) {
+                    blocker.Signal();
+                } else if (info.id == id2) {
+                    blocker.Signal();
+                }
+            }
+        });
+        ASSERT_EQ(factory->SubscribedToRegionEvents(), true);
+
+        LOG(info) << "waiting for blockers...";
+        blocker.Wait();
+        LOG(info) << "1 done.";
+        blocker.Wait();
+        LOG(info) << "2 done.";
+    }
+
+    blocker.Wait();
+    LOG(info) << "3 done.";
+    blocker.Wait();
+    LOG(info) << "4 done.";
+    LOG(info) << "All done.";
+
+    factory->UnsubscribeFromRegionEvents();
+    ASSERT_EQ(factory->SubscribedToRegionEvents(), false);
+}
+
+TEST(EventSubscriptions, zeromq)
+{
+    RegionEventSubscriptions("zeromq");
+}
+
+TEST(EventSubscriptions, shmem)
+{
+    RegionEventSubscriptions("shmem");
+}
+
+} // namespace


### PR DESCRIPTION
- Implement subscriptions for region events and `GetRegionInfo()` for ZeroMQ transport. If subscribed, ZeroMQ transport will first call a region event with `FairMQRegionEvent::local_only` to notify that callbacks are only called for regions created by this transport.

- Add `bool FairMQTransportFactory::SubscribedToRegionEvents()` that returns true if a subscription is already active (currently only a single subscription at a time is allowed).

- Add `uint64_t FairMQUnmanagedRegion::GetId()` that returns the id of the region. This id corresponds to the one returned in the region info events (`FairMQRegionInfo::id`).

