### PR TITLE
Alignment part I - Interface and shmem send

### DIFF
--- a/fairmq/FairMQMessage.h
+++ b/fairmq/FairMQMessage.h
@@ -17,11 +17,26 @@
 using fairmq_free_fn = void(void* data, void* hint);
 class FairMQTransportFactory;
 
+namespace fair
+{
+namespace mq
+{
+
+struct Alignment
+{
+    size_t alignment;
+    explicit operator size_t() const { return alignment; }
+};
+
+} /* namespace mq */
+} /* namespace fair */
+
 class FairMQMessage
 {
   public:
     FairMQMessage() = default;
     FairMQMessage(FairMQTransportFactory* factory) : fTransport(factory) {}
+
     virtual void Rebuild() = 0;
     virtual void Rebuild(const size_t size) = 0;
     virtual void Rebuild(void* data, const size_t size, fairmq_free_fn* ffn, void* hint = nullptr) = 0;

--- a/fairmq/FairMQTransportFactory.h
+++ b/fairmq/FairMQTransportFactory.h
@@ -18,7 +18,7 @@
 #include <fairmq/Transports.h>
 
 #include <string>
-#include <memory>
+#include <memory> // shared_ptr
 #include <vector>
 #include <unordered_map>
 #include <stdexcept>
@@ -47,13 +47,22 @@ class FairMQTransportFactory
     fair::mq::ChannelResource* GetMemoryResource() { return &fMemoryResource; }
     operator fair::mq::ChannelResource*() { return &fMemoryResource; }
 
-    /// @brief Create empty FairMQMessage
+    /// @brief Create empty FairMQMessage (for receiving)
     /// @return pointer to FairMQMessage
     virtual FairMQMessagePtr CreateMessage() = 0;
+    /// @brief Create empty FairMQMessage (for receiving), align received buffer to specified alignment
+    /// @param alignment alignment to align received buffer to
+    /// @return pointer to FairMQMessage
+    virtual FairMQMessagePtr CreateMessage(fair::mq::Alignment alignment) = 0;
     /// @brief Create new FairMQMessage of specified size
     /// @param size message size
     /// @return pointer to FairMQMessage
     virtual FairMQMessagePtr CreateMessage(const size_t size) = 0;
+    /// @brief Create new FairMQMessage of specified size and alignment
+    /// @param size message size
+    /// @param alignment message alignment
+    /// @return pointer to FairMQMessage
+    virtual FairMQMessagePtr CreateMessage(const size_t size, fair::mq::Alignment alignment) = 0;
     /// @brief Create new FairMQMessage with user provided buffer and size
     /// @param data pointer to user provided buffer
     /// @param size size of the user provided buffer

--- a/fairmq/ofi/Message.cxx
+++ b/fairmq/ofi/Message.cxx
@@ -34,7 +34,31 @@ Message::Message(boost::container::pmr::memory_resource* pmr)
 {
 }
 
+Message::Message(boost::container::pmr::memory_resource* pmr, Alignment /* alignment */)
+    : fInitialSize(0)
+    , fSize(0)
+    , fData(nullptr)
+    , fFreeFunction(nullptr)
+    , fHint(nullptr)
+    , fPmr(pmr)
+{
+}
+
 Message::Message(boost::container::pmr::memory_resource* pmr, const size_t size)
+    : fInitialSize(size)
+    , fSize(size)
+    , fData(nullptr)
+    , fFreeFunction(nullptr)
+    , fHint(nullptr)
+    , fPmr(pmr)
+{
+    if (size) {
+        fData = fPmr->allocate(size);
+        assert(fData);
+    }
+}
+
+Message::Message(boost::container::pmr::memory_resource* pmr, const size_t size, Alignment /* alignment */)
     : fInitialSize(size)
     , fSize(size)
     , fData(nullptr)

--- a/fairmq/ofi/Message.h
+++ b/fairmq/ofi/Message.h
@@ -34,7 +34,9 @@ class Message final : public fair::mq::Message
 {
   public:
     Message(boost::container::pmr::memory_resource* pmr);
+    Message(boost::container::pmr::memory_resource* pmr, Alignment alignment);
     Message(boost::container::pmr::memory_resource* pmr, const size_t size);
+    Message(boost::container::pmr::memory_resource* pmr, const size_t size, Alignment alignment);
     Message(boost::container::pmr::memory_resource* pmr,
             void* data,
             const size_t size,

--- a/fairmq/ofi/TransportFactory.cxx
+++ b/fairmq/ofi/TransportFactory.cxx
@@ -41,8 +41,20 @@ auto TransportFactory::CreateMessage() -> MessagePtr
     return MessagePtr{new Message(&fMemoryResource)};
 }
 
+auto TransportFactory::CreateMessage(Alignment /* alignment */) -> MessagePtr
+{
+    // TODO Do not ignore alignment
+    return MessagePtr{new Message(&fMemoryResource)};
+}
+
 auto TransportFactory::CreateMessage(const size_t size) -> MessagePtr
 {
+    return MessagePtr{new Message(&fMemoryResource, size)};
+}
+
+auto TransportFactory::CreateMessage(const size_t size, Alignment /* alignment */) -> MessagePtr
+{
+    // TODO Do not ignore alignment
     return MessagePtr{new Message(&fMemoryResource, size)};
 }
 

--- a/fairmq/ofi/TransportFactory.h
+++ b/fairmq/ofi/TransportFactory.h
@@ -36,7 +36,9 @@ class TransportFactory final : public FairMQTransportFactory
     TransportFactory operator=(const TransportFactory&) = delete;
 
     auto CreateMessage() -> MessagePtr override;
+    auto CreateMessage(Alignment alignment) -> MessagePtr override;
     auto CreateMessage(const std::size_t size) -> MessagePtr override;
+    auto CreateMessage(const std::size_t size, Alignment alignment) -> MessagePtr override;
     auto CreateMessage(void* data, const std::size_t size, fairmq_free_fn* ffn, void* hint = nullptr) -> MessagePtr override;
     auto CreateMessage(UnmanagedRegionPtr& region, void* data, const std::size_t size, void* hint = nullptr) -> MessagePtr override;
 

--- a/fairmq/shmem/TransportFactory.h
+++ b/fairmq/shmem/TransportFactory.h
@@ -101,9 +101,19 @@ class TransportFactory final : public fair::mq::TransportFactory
         return tools::make_unique<Message>(*fManager, this);
     }
 
+    MessagePtr CreateMessage(Alignment alignment) override
+    {
+        return tools::make_unique<Message>(*fManager, alignment, this);
+    }
+
     MessagePtr CreateMessage(const size_t size) override
     {
         return tools::make_unique<Message>(*fManager, size, this);
+    }
+
+    MessagePtr CreateMessage(const size_t size, Alignment alignment) override
+    {
+        return tools::make_unique<Message>(*fManager, size, alignment, this);
     }
 
     MessagePtr CreateMessage(void* data, const size_t size, fairmq_free_fn* ffn, void* hint = nullptr) override

--- a/fairmq/zeromq/Message.h
+++ b/fairmq/zeromq/Message.h
@@ -47,8 +47,31 @@ class Message final : public fair::mq::Message
             LOG(error) << "failed initializing message, reason: " << zmq_strerror(errno);
         }
     }
+    Message(Alignment /* alignment */, FairMQTransportFactory* factory = nullptr)
+        : fair::mq::Message(factory)
+        , fUsedSizeModified(false)
+        , fUsedSize()
+        , fMsg(tools::make_unique<zmq_msg_t>())
+        , fViewMsg(nullptr)
+    {
+        if (zmq_msg_init(fMsg.get()) != 0) {
+            LOG(error) << "failed initializing message, reason: " << zmq_strerror(errno);
+        }
+    }
 
     Message(const size_t size, FairMQTransportFactory* factory = nullptr)
+        : fair::mq::Message(factory)
+        , fUsedSizeModified(false)
+        , fUsedSize(size)
+        , fMsg(tools::make_unique<zmq_msg_t>())
+        , fViewMsg(nullptr)
+    {
+        if (zmq_msg_init_size(fMsg.get(), size) != 0) {
+            LOG(error) << "failed initializing message with size, reason: " << zmq_strerror(errno);
+        }
+    }
+
+    Message(const size_t size, Alignment /* alignment */, FairMQTransportFactory* factory = nullptr)
         : fair::mq::Message(factory)
         , fUsedSizeModified(false)
         , fUsedSize(size)

--- a/fairmq/zeromq/TransportFactory.h
+++ b/fairmq/zeromq/TransportFactory.h
@@ -55,10 +55,20 @@ class TransportFactory final : public FairMQTransportFactory
     {
         return tools::make_unique<Message>(this);
     }
+    
+    MessagePtr CreateMessage(Alignment alignment) override
+    {
+        return tools::make_unique<Message>(alignment, this);
+    }
 
     MessagePtr CreateMessage(const size_t size) override
     {
         return tools::make_unique<Message>(size, this);
+    }
+
+    MessagePtr CreateMessage(const size_t size, Alignment alignment) override
+    {
+        return tools::make_unique<Message>(size, alignment, this);
     }
 
     MessagePtr CreateMessage(void* data, const size_t size, fairmq_free_fn* ffn, void* hint = nullptr) override


### PR DESCRIPTION
Adds the alignment interface, and implementation for shmem send case. Other cases (shm receive check, zmq send/recv) ignore the argument for now.
