### PR TITLE
Update algorithm to generate hash for shmem id 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "extern/asio"]
 	path = extern/asio
 	url = https://github.com/chriskohlhoff/asio
+[submodule "extern/PicoSHA2"]
+	path = extern/PicoSHA2
+	url = https://github.com/okdshin/PicoSHA2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,6 +146,8 @@ if(BUILD_FAIRMQ)
   find_package2(PRIVATE ZeroMQ REQUIRED
     VERSION 4.1.4
   )
+  build_bundled(PicoSHA2 extern/PicoSHA2)
+  find_package2(PRIVATE PicoSHA2 REQUIRED)
 endif()
 
 if(BUILD_TESTING)

--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -23,6 +23,10 @@ Files: extern/asio
 Copyright: 2003-2019, Christopher M. Kohlhoff (chris at kohlhoff dot com)
 License: BSL-1.0
 
+Files: extern/PicoSHA2
+Copyright: 2017 okdshin
+License: MIT
+
 License: LGPL-3.0-only
   [see LICENSE file]
 
@@ -102,3 +106,22 @@ License: BSL-1.0
   FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,
   ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
   DEALINGS IN THE SOFTWARE.
+
+License: MIT
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.

--- a/cmake/FairMQLib.cmake
+++ b/cmake/FairMQLib.cmake
@@ -498,6 +498,8 @@ function(build_bundled package bundle)
     set(${package}_BUILD_INCLUDE_DIR ${${package}_SOURCE_DIR}/asio/include CACHE PATH "Bundled ${package} build-interface include dir")
     set(${package}_INSTALL_INCLUDE_DIR ${PROJECT_INSTALL_INCDIR}/bundled CACHE PATH "Bundled ${package} install-interface include dir")
     set(${package}_ROOT ${${package}_SOURCE_DIR}/asio)
+  elseif(${package} STREQUAL PicoSHA2)
+    set(${package}_ROOT ${${package}_SOURCE_DIR})
   endif()
 
   string(TOUPPER ${package} package_upper)

--- a/cmake/FindPicoSHA2.cmake
+++ b/cmake/FindPicoSHA2.cmake
@@ -1,0 +1,21 @@
+################################################################################
+#    Copyright (C) 2020 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    #
+#                                                                              #
+#              This software is distributed under the terms of the             #
+#              GNU Lesser General Public Licence (LGPL) version 3,             #
+#                  copied verbatim in the file "LICENSE"                       #
+################################################################################
+
+find_path(PicoSHA2_INCLUDE_DIR NAMES picosha2.h)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(PicoSHA2
+  REQUIRED_VARS PicoSHA2_INCLUDE_DIR
+)
+
+if(PicoSHA2_FOUND)
+  add_library(PicoSHA2 INTERFACE IMPORTED)
+  set_target_properties(PicoSHA2 PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${PicoSHA2_INCLUDE_DIR}"
+  )
+endif()

--- a/fairmq/CMakeLists.txt
+++ b/fairmq/CMakeLists.txt
@@ -325,6 +325,7 @@ if(BUILD_FAIRMQ)
 
     PRIVATE # only libFairMQ links against private dependencies
     libzmq
+    PicoSHA2
     ${OFI_DEPS}
   )
   set_target_properties(${_target} PROPERTIES
@@ -377,6 +378,7 @@ if(BUILD_FAIRMQ)
     Boost::boost
     Boost::date_time
     Boost::program_options
+    PicoSHA2
   )
   target_include_directories(fairmq-shmmonitor PUBLIC
     $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>

--- a/fairmq/shmem/Common.h
+++ b/fairmq/shmem/Common.h
@@ -8,6 +8,8 @@
 #ifndef FAIR_MQ_SHMEM_COMMON_H_
 #define FAIR_MQ_SHMEM_COMMON_H_
 
+#include <picosha2.h>
+
 #include <atomic>
 #include <string>
 #include <unordered_map>
@@ -110,9 +112,9 @@ struct RegionBlock
 // a hash of user id + session id, truncated to 8 characters (to accommodate for name size limit on some systems (MacOS)).
 inline std::string buildShmIdFromSessionIdAndUserId(const std::string& sessionId)
 {
-    boost::hash<std::string> stringHash;
-    std::string shmId(std::to_string(stringHash(std::string((std::to_string(geteuid()) + sessionId)))));
-    shmId.resize(8, '_');
+    std::string seed((std::to_string(geteuid()) + sessionId));
+    std::string shmId = picosha2::hash256_hex_string(seed);
+    shmId.resize(10, '_');
     return shmId;
 }
 

--- a/fairmq/zeromq/Message.h
+++ b/fairmq/zeromq/Message.h
@@ -155,9 +155,17 @@ class Message final : public fair::mq::Message
     void* GetData() const override
     {
         if (!fViewMsg) {
-            return zmq_msg_data(fMsg.get());
+            if (zmq_msg_size(fMsg.get()) > 0) {
+                return zmq_msg_data(fMsg.get());
+            } else {
+                return nullptr;
+            }
         } else {
-            return zmq_msg_data(fViewMsg.get());
+            if (zmq_msg_size(fViewMsg.get()) > 0) {
+                return zmq_msg_data(fViewMsg.get());
+            } else {
+                return nullptr;
+            }
         }
     }
 


### PR DESCRIPTION
- Add bundled dependency on PicoSHA2.
- Update hash algorithm that generates hash for shmem id from boost::hash to SHA-2. Former can result in collisions on MacOS, primarily because we have to truncate the hash value to accommodate for the name length limit.

Also:
- Update ZeroMQ transport's GetData() to return `nullptr` for empty messages.
