### PR TITLE
Do not attemp to find random port for non-TCP protocols

### DIFF
--- a/fairmq/FairMQChannel.cxx
+++ b/fairmq/FairMQChannel.cxx
@@ -671,7 +671,6 @@ void FairMQChannel::Init()
 bool FairMQChannel::ConnectEndpoint(const string& endpoint)
 {
     lock_guard<mutex> lock(fMtx);
-
     return fSocket->Connect(endpoint);
 }
 
@@ -683,6 +682,13 @@ bool FairMQChannel::BindEndpoint(string& endpoint)
     if (fSocket->Bind(endpoint)) {
         return true;
     } else {
+        // auto-bind only implemented for TCP
+        size_t protocolPos = endpoint.find(':');
+        string protocol = endpoint.substr(0, protocolPos);
+        if (protocol != "tcp") {
+            return false;
+        }
+
         if (fAutoBind) {
             // number of attempts when choosing a random port
             int numAttempts = 0;

--- a/fairmq/devices/FairMQBenchmarkSampler.h
+++ b/fairmq/devices/FairMQBenchmarkSampler.h
@@ -54,8 +54,6 @@ class FairMQBenchmarkSampler : public FairMQDevice
         // store the channel reference to avoid traversing the map on every loop iteration
         FairMQChannel& dataOutChannel = fChannels.at(fOutChannelName).at(0);
 
-        FairMQMessagePtr baseMsg(dataOutChannel.NewMessage(fMsgSize));
-
         LOG(info) << "Starting the benchmark with message size of " << fMsgSize << " and " << fMaxIterations << " iterations.";
         auto tStart = std::chrono::high_resolution_clock::now();
 

--- a/fairmq/shmem/Manager.h
+++ b/fairmq/shmem/Manager.h
@@ -73,7 +73,7 @@ class Manager
         , fThrowOnBadAlloc(throwOnBadAlloc)
     {
         using namespace boost::interprocess;
-        LOG(debug) << "created/opened shared memory segment '" << "fmq_" << fShmId << "_main" << "' of " << size << " bytes. Available are " << fSegment.get_free_memory() << " bytes.";
+        LOG(debug) << "created/opened shared memory segment '" << "fmq_" << fShmId << "_main" << "' of " << fSegment.get_size() << " bytes. Available are " << fSegment.get_free_memory() << " bytes.";
 
         fRegionInfos = fManagementSegment.find_or_construct<Uint64RegionInfoMap>(unique_instance)(fShmVoidAlloc);
         // store info about the managed segment as region with id 0

--- a/fairmq/shmem/Message.h
+++ b/fairmq/shmem/Message.h
@@ -251,6 +251,10 @@ class Message final : public fair::mq::Message
                 // boost::interprocess::managed_shared_memory::size_type actualSize = size;
                 // char* hint = 0; // unused for boost::interprocess::allocate_new
                 // fLocalPtr = fManager.Segment().allocation_command<char>(boost::interprocess::allocate_new, size, actualSize, hint);
+                size_t segmentSize = fManager.Segment().get_size();
+                if (size > segmentSize) {
+                    throw MessageBadAlloc(tools::ToString("Requested message size (", size, ") exceeds segment size (", segmentSize, ")"));
+                }
                 if (alignment == 0) {
                     fLocalPtr = reinterpret_cast<char*>(fManager.Segment().allocate(size));
                 } else {


### PR DESCRIPTION
- When autobind is enabled, do not try to find a new port for non-TCP protocols.
- Shm: throw if requested message size exceeds total segment size
- BenchmarkSampler: remove unused variable.
- Shm: when opening segment created by another device, report the actual size of the opened segment, and not the one configured on this device.