### PR TITLE
Performance optimizations

### DIFF
--- a/fairmq/shmem/Manager.h
+++ b/fairmq/shmem/Manager.h
@@ -350,8 +350,8 @@ class Manager
         }
     }
 
-    void IncrementMsgCounter() { ++fMsgCounter; }
-    void DecrementMsgCounter() { --fMsgCounter; }
+    void IncrementMsgCounter() { fMsgCounter.fetch_add(1, std::memory_order_relaxed); }
+    void DecrementMsgCounter() { fMsgCounter.fetch_sub(1, std::memory_order_relaxed); }
 
     void SendHeartbeats()
     {


### PR DESCRIPTION
- Use relaxed memory ordering to keep the global atomic message counter. Final check uses acquire ordering for read serialization
- Move RateLimit constructor and call to clock::now() out of the fast path. 2x faster message allocation

![Screenshot 2020-08-11 at 15 15 33](https://user-images.githubusercontent.com/276684/89933122-e6ea7780-dc0e-11ea-9c65-602e792186c9.png)

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [ ] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
