### PR TITLE
Retry on EINTR in blocking zmq calls

### DIFF
--- a/fairmq/shmem/Socket.h
+++ b/fairmq/shmem/Socket.h
@@ -148,9 +148,6 @@ class Socket final : public fair::mq::Socket
         if (zmq_errno() == ETERM) {
             LOG(debug) << "Terminating socket " << fId;
             return -1;
-        } else if (zmq_errno() == EINTR) {
-            LOG(debug) << "Transfer interrupted by system call";
-            return -1;
         } else {
             LOG(error) << "Failed transfer on socket " << fId << ", reason: " << zmq_strerror(errno);
             return -1;
@@ -177,7 +174,7 @@ class Socket final : public fair::mq::Socket
                 size_t size = msg->GetSize();
                 fBytesTx += size;
                 return size;
-            } else if (zmq_errno() == EAGAIN) {
+            } else if (zmq_errno() == EAGAIN || zmq_errno() == EINTR) {
                 if (ShouldRetry(flags, timeout, elapsed)) {
                     continue;
                 } else {
@@ -220,7 +217,7 @@ class Socket final : public fair::mq::Socket
                 fBytesRx += size;
                 ++fMessagesRx;
                 return size;
-            } else if (zmq_errno() == EAGAIN) {
+            } else if (zmq_errno() == EAGAIN || zmq_errno() == EINTR) {
                 if (ShouldRetry(flags, timeout, elapsed)) {
                     continue;
                 } else {
@@ -269,7 +266,7 @@ class Socket final : public fair::mq::Socket
                 fBytesTx += totalSize;
 
                 return totalSize;
-            } else if (zmq_errno() == EAGAIN) {
+            } else if (zmq_errno() == EAGAIN || zmq_errno() == EINTR) {
                 if (ShouldRetry(flags, timeout, elapsed)) {
                     continue;
                 } else {
@@ -323,7 +320,7 @@ class Socket final : public fair::mq::Socket
                 fBytesRx += totalSize;
 
                 return totalSize;
-            } else if (zmq_errno() == EAGAIN) {
+            } else if (zmq_errno() == EAGAIN || zmq_errno() == EINTR) {
                 if (ShouldRetry(flags, timeout, elapsed)) {
                     continue;
                 } else {

--- a/fairmq/zeromq/Context.h
+++ b/fairmq/zeromq/Context.h
@@ -161,13 +161,16 @@ class Context
         UnsubscribeFromRegionEvents();
 
         if (fZmqCtx) {
-            if (zmq_ctx_term(fZmqCtx) != 0) {
-                if (errno == EINTR) {
-                    LOG(error) << " failed closing context, reason: " << zmq_strerror(errno);
-                } else {
-                    fZmqCtx = nullptr;
-                    return;
+            while (true) {
+                if (zmq_ctx_term(fZmqCtx) != 0) {
+                    if (errno == EINTR) {
+                        LOG(debug) << "zmq_ctx_term interrupted by system call, retrying";
+                        continue;
+                    } else {
+                        fZmqCtx = nullptr;
+                    }
                 }
+                break;
             }
         } else {
             LOG(error) << "context not available for shutdown";

--- a/fairmq/zeromq/Poller.h
+++ b/fairmq/zeromq/Poller.h
@@ -130,13 +130,20 @@ class Poller final : public fair::mq::Poller
 
     void Poll(const int timeout) override
     {
-        if (zmq_poll(fItems, fNumItems, timeout) < 0) {
-            if (errno == ETERM) {
-                LOG(debug) << "polling exited, reason: " << zmq_strerror(errno);
-            } else {
-                LOG(error) << "polling failed, reason: " << zmq_strerror(errno);
-                throw fair::mq::PollerError(fair::mq::tools::ToString("Polling failed, reason: ", zmq_strerror(errno)));
+        while (true) {
+            if (zmq_poll(fItems, fNumItems, timeout) < 0) {
+                if (errno == ETERM) {
+                    LOG(debug) << "polling exited, reason: " << zmq_strerror(errno);
+                    return;
+                } else if (errno == EINTR) {
+                    LOG(debug) << "polling interrupted by system call";
+                    continue;
+                } else {
+                    LOG(error) << "polling failed, reason: " << zmq_strerror(errno);
+                    throw fair::mq::PollerError(fair::mq::tools::ToString("Polling failed, reason: ", zmq_strerror(errno)));
+                }
             }
+            break;
         }
     }
 


### PR DESCRIPTION
Retry when a blocking ZeroMQ call returns `EINTR`.
The relevant signals are picked up by the controller plugin and propagated in their own way to unblock the calls.

