### PR TITLE
Adjust transfer methods behaviour when interrupted

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,11 +8,15 @@ def jobMatrix(String prefix, List specs, Closure callback) {
   def nodes = [:]
   for (spec in specs) {
     def label = specToLabel(spec)
+    def node_tag = label
+    if (spec.os =~ /macOS/) {
+      node_tag = spec.os
+    }
     def fairsoft = spec.fairsoft
     def os = spec.os
     def compiler = spec.compiler
     nodes["${prefix}/${label}"] = {
-      node(label) {
+      node(node_tag) {
         githubNotify(context: "${prefix}/${label}", description: 'Building ...', status: 'PENDING')
         try {
           deleteDir()
@@ -29,7 +33,7 @@ def jobMatrix(String prefix, List specs, Closure callback) {
               echo "module load compiler/gcc/9.1.0" >> Dart.cfg
             '''
           }
-          if (os =~ /MacOS/) {
+          if (os =~ /[Mm]acOS/) {
             sh "echo \"export EXTRA_FLAGS='-DCMAKE_CXX_COMPILER=clang++'\" >> Dart.cfg"
           } else {
             sh "echo \"export EXTRA_FLAGS='-DCMAKE_CXX_COMPILER=g++'\" >> Dart.cfg"
@@ -71,8 +75,7 @@ pipeline{
         script {
           def build_jobs = jobMatrix('build', [
             [os: 'Debian8',    arch: 'x86_64', compiler: 'gcc9.1.0',        fairsoft: 'fairmq_dev'],
-            [os: 'MacOS10.13', arch: 'x86_64', compiler: 'AppleLLVM10.0.0', fairsoft: 'fairmq_dev'],
-            [os: 'MacOS10.14', arch: 'x86_64', compiler: 'AppleLLVM10.0.0', fairsoft: 'fairmq_dev'],
+            [os: 'macOS10.15', arch: 'x86_64', compiler: 'AppleLLVM11.0.3', fairsoft: 'fairmq_dev'],
           ]) { spec, label ->
             sh './Dart.sh alfa_ci Dart.cfg'
           }

--- a/fairmq/FairMQChannel.h
+++ b/fairmq/FairMQChannel.h
@@ -250,7 +250,7 @@ class FairMQChannel
     /// Sends a message to the socket queue.
     /// @param msg Constant reference of unique_ptr to a FairMQMessage
     /// @param sndTimeoutInMs send timeout in ms. -1 will wait forever (or until interrupt (e.g. via state change)), 0 will not wait (return immediately if cannot send)
-    /// @return Number of bytes that have been queued. -2 If queueing was not possible or timed out. -1 if there was an error.
+    /// @return Number of bytes that have been queued, TransferResult::timeout if timed out, TransferResult::error if there was an error, TransferResult::interrupted if interrupted (e.g. by requested state change)
     int Send(FairMQMessagePtr& msg, int sndTimeoutInMs = -1)
     {
         CheckSendCompatibility(msg);
@@ -260,7 +260,7 @@ class FairMQChannel
     /// Receives a message from the socket queue.
     /// @param msg Constant reference of unique_ptr to a FairMQMessage
     /// @param rcvTimeoutInMs receive timeout in ms. -1 will wait forever (or until interrupt (e.g. via state change)), 0 will not wait (return immediately if cannot receive)
-    /// @return Number of bytes that have been received. -2 if reading from the queue was not possible or timed out. -1 if there was an error.
+    /// @return Number of bytes that have been received, TransferResult::timeout if timed out, TransferResult::error if there was an error, TransferResult::interrupted if interrupted (e.g. by requested state change)
     int Receive(FairMQMessagePtr& msg, int rcvTimeoutInMs = -1)
     {
         CheckReceiveCompatibility(msg);
@@ -270,7 +270,7 @@ class FairMQChannel
     /// Send a vector of messages
     /// @param msgVec message vector reference
     /// @param sndTimeoutInMs send timeout in ms. -1 will wait forever (or until interrupt (e.g. via state change)), 0 will not wait (return immediately if cannot send)
-    /// @return Number of bytes that have been queued. -2 If queueing was not possible or timed out. -1 if there was an error.
+    /// @return Number of bytes that have been queued, TransferResult::timeout if timed out, TransferResult::error if there was an error, TransferResult::interrupted if interrupted (e.g. by requested state change)
     int64_t Send(std::vector<FairMQMessagePtr>& msgVec, int sndTimeoutInMs = -1)
     {
         CheckSendCompatibility(msgVec);
@@ -280,7 +280,7 @@ class FairMQChannel
     /// Receive a vector of messages
     /// @param msgVec message vector reference
     /// @param rcvTimeoutInMs receive timeout in ms. -1 will wait forever (or until interrupt (e.g. via state change)), 0 will not wait (return immediately if cannot receive)
-    /// @return Number of bytes that have been received. -2 if reading from the queue was not possible or timed out. -1 if there was an error.
+    /// @return Number of bytes that have been received, TransferResult::timeout if timed out, TransferResult::error if there was an error, TransferResult::interrupted if interrupted (e.g. by requested state change)
     int64_t Receive(std::vector<FairMQMessagePtr>& msgVec, int rcvTimeoutInMs = -1)
     {
         CheckReceiveCompatibility(msgVec);
@@ -290,7 +290,7 @@ class FairMQChannel
     /// Send FairMQParts
     /// @param parts FairMQParts reference
     /// @param sndTimeoutInMs send timeout in ms. -1 will wait forever (or until interrupt (e.g. via state change)), 0 will not wait (return immediately if cannot send)
-    /// @return Number of bytes that have been queued. -2 If queueing was not possible or timed out. -1 if there was an error.
+    /// @return Number of bytes that have been queued, TransferResult::timeout if timed out, TransferResult::error if there was an error, TransferResult::interrupted if interrupted (e.g. by requested state change)
     int64_t Send(FairMQParts& parts, int sndTimeoutInMs = -1)
     {
         return Send(parts.fParts, sndTimeoutInMs);
@@ -299,7 +299,7 @@ class FairMQChannel
     /// Receive FairMQParts
     /// @param parts FairMQParts reference
     /// @param rcvTimeoutInMs receive timeout in ms. -1 will wait forever (or until interrupt (e.g. via state change)), 0 will not wait (return immediately if cannot receive)
-    /// @return Number of bytes that have been received. -2 if reading from the queue was not possible or timed out. -1 if there was an error.
+    /// @return Number of bytes that have been received, TransferResult::timeout if timed out, TransferResult::error if there was an error, TransferResult::interrupted if interrupted (e.g. by requested state change)
     int64_t Receive(FairMQParts& parts, int rcvTimeoutInMs = -1)
     {
         return Receive(parts.fParts, rcvTimeoutInMs);

--- a/fairmq/FairMQDevice.h
+++ b/fairmq/FairMQDevice.h
@@ -129,7 +129,7 @@ class FairMQDevice
     /// @param chan channel name
     /// @param i channel index
     /// @param sndTimeoutInMs send timeout in ms, -1 will wait forever (or until interrupt (e.g. via state change)), 0 will not wait (return immediately if cannot send)
-    /// @return Number of bytes that have been queued. -2 If queueing was not possible or timed out. -1 if there was an error.
+    /// @return Number of bytes that have been queued, TransferResult::timeout if timed out, TransferResult::error if there was an error, TransferResult::interrupted if interrupted (e.g. by requested state change)
     int Send(FairMQMessagePtr& msg, const std::string& channel, const int index = 0, int sndTimeoutInMs = -1)
     {
         return GetChannel(channel, index).Send(msg, sndTimeoutInMs);
@@ -140,7 +140,7 @@ class FairMQDevice
     /// @param chan channel name
     /// @param i channel index
     /// @param rcvTimeoutInMs receive timeout in ms, -1 will wait forever (or until interrupt (e.g. via state change)), 0 will not wait (return immediately if cannot receive)
-    /// @return Number of bytes that have been received. -2 if reading from the queue was not possible or timed out. -1 if there was an error.
+    /// @return Number of bytes that have been received, TransferResult::timeout if timed out, TransferResult::error if there was an error, TransferResult::interrupted if interrupted (e.g. by requested state change)
     int Receive(FairMQMessagePtr& msg, const std::string& channel, const int index = 0, int rcvTimeoutInMs = -1)
     {
         return GetChannel(channel, index).Receive(msg, rcvTimeoutInMs);
@@ -151,7 +151,7 @@ class FairMQDevice
     /// @param chan channel name
     /// @param i channel index
     /// @param sndTimeoutInMs send timeout in ms, -1 will wait forever (or until interrupt (e.g. via state change)), 0 will not wait (return immediately if cannot send)
-    /// @return Number of bytes that have been queued. -2 If queueing was not possible or timed out. -1 if there was an error.
+    /// @return Number of bytes that have been queued, TransferResult::timeout if timed out, TransferResult::error if there was an error, TransferResult::interrupted if interrupted (e.g. by requested state change)
     int64_t Send(FairMQParts& parts, const std::string& channel, const int index = 0, int sndTimeoutInMs = -1)
     {
         return GetChannel(channel, index).Send(parts.fParts, sndTimeoutInMs);
@@ -162,7 +162,7 @@ class FairMQDevice
     /// @param chan channel name
     /// @param i channel index
     /// @param rcvTimeoutInMs receive timeout in ms, -1 will wait forever (or until interrupt (e.g. via state change)), 0 will not wait (return immediately if cannot receive)
-    /// @return Number of bytes that have been received. -2 if reading from the queue was not possible or timed out. -1 if there was an error.
+    /// @return Number of bytes that have been received, TransferResult::timeout if timed out, TransferResult::error if there was an error, TransferResult::interrupted if interrupted (e.g. by requested state change)
     int64_t Receive(FairMQParts& parts, const std::string& channel, const int index = 0, int rcvTimeoutInMs = -1)
     {
         return GetChannel(channel, index).Receive(parts.fParts, rcvTimeoutInMs);

--- a/fairmq/FairMQSocket.h
+++ b/fairmq/FairMQSocket.h
@@ -9,13 +9,30 @@
 #ifndef FAIRMQSOCKET_H_
 #define FAIRMQSOCKET_H_
 
+#include "FairMQMessage.h"
+
 #include <memory>
+#include <ostream>
 #include <stdexcept>
 #include <string>
 #include <vector>
 
-#include "FairMQMessage.h"
 class FairMQTransportFactory;
+
+namespace fair
+{
+namespace mq
+{
+
+enum class TransferResult : int
+{
+    error = -1,
+    timeout = -2,
+    interrupted = -3
+};
+
+} // namespace mq
+} // namespace fair
 
 class FairMQSocket
 {

--- a/fairmq/ofi/Socket.cxx
+++ b/fairmq/ofi/Socket.cxx
@@ -272,7 +272,7 @@ try {
     int size(0);
     for (auto& msg : msgVec) {
         size += msg->GetSize();
-    } 
+    }
 
     fSendPushSem.wait();
     {
@@ -284,7 +284,7 @@ try {
     return size;
 } catch (const std::exception& e) {
     LOG(error) << e.what();
-    return -1;
+    return TransferResult::error;
 }
 
 auto Socket::SendQueueReader() -> void
@@ -431,7 +431,7 @@ try {
     return size;
 } catch (const std::exception& e) {
     LOG(error) << e.what();
-    return -1;
+    return TransferResult::error;
 }
 
 auto Socket::Receive(std::vector<MessagePtr>& msgVec, const int /*timeout*/) -> int64_t
@@ -449,14 +449,14 @@ try {
     int64_t size(0);
     for (auto& msg : msgVec) {
         size += msg->GetSize();
-    } 
+    }
     fBytesRx += size;
     ++fMessagesRx;
 
-    return size; 
+    return size;
 } catch (const std::exception& e) {
     LOG(error) << e.what();
-    return -1;
+    return TransferResult::error;
 }
 
 auto Socket::RecvControlQueueReader() -> void

--- a/fairmq/sdk/Topology.h
+++ b/fairmq/sdk/Topology.h
@@ -464,7 +464,7 @@ class BasicTopology : public AsioBase<Executor, Allocator>
         }
     }
 
-    using Duration = std::chrono::milliseconds;
+    using Duration = std::chrono::microseconds;
     using ChangeStateCompletionSignature = void(std::error_code, TopologyState);
 
   private:

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,6 +12,18 @@ include(GTestHelper)
 # FairMQ Testsuites/helpers #
 #############################
 
+if(FairLogger_VERSION VERSION_LESS 1.9.0 AND FairLogger_VERSION VERSION_GREATER_EQUAL 1.7.0)
+  LIST(APPEND definitions FAIR_MIN_SEVERITY=trace)
+endif()
+
+if(BUILD_OFI_TRANSPORT)
+  LIST(APPEND definitions BUILD_OFI_TRANSPORT)
+endif()
+
+if(definitions)
+  set(definitions DEFINITIONS ${definitions})
+endif()
+
 add_testhelper(runTestDevice
     SOURCES
     helper/runTestDevice.cxx
@@ -30,15 +42,8 @@ add_testhelper(runTestDevice
     helper/devices/TestExceptions.h
 
     LINKS FairMQ
+    ${definitions}
 )
-
-if(BUILD_OFI_TRANSPORT)
-  LIST(APPEND definitions BUILD_OFI_TRANSPORT)
-endif()
-
-if(definitions)
-  set(definitions DEFINITIONS ${definitions})
-endif()
 
 set(MQ_CONFIG "${CMAKE_BINARY_DIR}/test/testsuite_FairMQ.IOPatterns_config.json")
 set(RUN_TEST_DEVICE "${CMAKE_BINARY_DIR}/test/testhelper_runTestDevice")

--- a/test/helper/devices/TestTransferTimeout.h
+++ b/test/helper/devices/TestTransferTimeout.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2015-2017 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2015static_cast<int>(TransferResult::timeout017 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH ) *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -24,20 +24,20 @@ class TransferTimeout : public FairMQDevice
   protected:
     auto Run() -> void override
     {
-        bool sendMsgCancelingAfter100ms = false;
-        bool receiveMsgCancelingAfter100ms = false;
+        bool sendMsgCancelingAfter200ms = false;
+        bool receiveMsgCancelingAfter200ms = false;
 
         bool sendMsgCancelingAfter0ms = false;
         bool receiveMsgCancelingAfter0ms = false;
 
-        bool send1PartCancelingAfter100ms = false;
-        bool receive1PartCancelingAfter100ms = false;
+        bool send1PartCancelingAfter200ms = false;
+        bool receive1PartCancelingAfter200ms = false;
 
         bool send1PartCancelingAfter0ms = false;
         bool receive1PartCancelingAfter0ms = false;
 
-        bool send2PartsCancelingAfter100ms = false;
-        bool receive2PartsCancelingAfter100ms = false;
+        bool send2PartsCancelingAfter200ms = false;
+        bool receive2PartsCancelingAfter200ms = false;
 
         bool send2PartsCancelingAfter0ms = false;
         bool receive2PartsCancelingAfter0ms = false;
@@ -45,28 +45,28 @@ class TransferTimeout : public FairMQDevice
         FairMQMessagePtr msg1(NewMessage());
         FairMQMessagePtr msg2(NewMessage());
 
-        if (Send(msg1, "data-out", 0, 100) == -2) {
-            LOG(info) << "send msg canceled (100ms)";
-            sendMsgCancelingAfter100ms = true;
+        if (Send(msg1, "data-out", 0, 200) == static_cast<int>(TransferResult::timeout)) {
+            LOG(info) << "send msg canceled (200ms)";
+            sendMsgCancelingAfter200ms = true;
         } else {
-            LOG(error) << "send msg did not cancel (100ms)";
+            LOG(error) << "send msg did not cancel (200ms)";
         }
 
-        if (Receive(msg2, "data-in", 0, 100) == -2) {
-            LOG(info) << "receive msg canceled (100ms)";
-            receiveMsgCancelingAfter100ms = true;
+        if (Receive(msg2, "data-in", 0, 200) == static_cast<int>(TransferResult::timeout)) {
+            LOG(info) << "receive msg canceled (200ms)";
+            receiveMsgCancelingAfter200ms = true;
         } else {
-            LOG(error) << "receive msg did not cancel (100ms)";
+            LOG(error) << "receive msg did not cancel (200ms)";
         }
 
-        if (Send(msg1, "data-out", 0, 0) == -2) {
+        if (Send(msg1, "data-out", 0, 0) == static_cast<int>(TransferResult::timeout)) {
             LOG(info) << "send msg canceled (0ms)";
             sendMsgCancelingAfter0ms = true;
         } else {
             LOG(error) << "send msg did not cancel (0ms)";
         }
 
-        if (Receive(msg2, "data-in", 0, 0) == -2) {
+        if (Receive(msg2, "data-in", 0, 0) == static_cast<int>(TransferResult::timeout)) {
             LOG(info) << "receive msg canceled (0ms)";
             receiveMsgCancelingAfter0ms = true;
         } else {
@@ -77,28 +77,28 @@ class TransferTimeout : public FairMQDevice
         parts1.AddPart(NewMessage(10));
         FairMQParts parts2;
 
-        if (Send(parts1, "data-out", 0, 100) == -2) {
-            LOG(info) << "send 1 part canceled (100ms)";
-            send1PartCancelingAfter100ms = true;
+        if (Send(parts1, "data-out", 0, 200) == static_cast<int>(TransferResult::timeout)) {
+            LOG(info) << "send 1 part canceled (200ms)";
+            send1PartCancelingAfter200ms = true;
         } else {
-            LOG(error) << "send 1 part did not cancel (100ms)";
+            LOG(error) << "send 1 part did not cancel (200ms)";
         }
 
-        if (Receive(parts2, "data-in", 0, 100) == -2) {
-            LOG(info) << "receive 1 part canceled (100ms)";
-            receive1PartCancelingAfter100ms = true;
+        if (Receive(parts2, "data-in", 0, 200) == static_cast<int>(TransferResult::timeout)) {
+            LOG(info) << "receive 1 part canceled (200ms)";
+            receive1PartCancelingAfter200ms = true;
         } else {
-            LOG(error) << "receive 1 part did not cancel (100ms)";
+            LOG(error) << "receive 1 part did not cancel (200ms)";
         }
 
-        if (Send(parts1, "data-out", 0, 0) == -2) {
+        if (Send(parts1, "data-out", 0, 0) == static_cast<int>(TransferResult::timeout)) {
             LOG(info) << "send 1 part canceled (0ms)";
             send1PartCancelingAfter0ms = true;
         } else {
             LOG(error) << "send 1 part did not cancel (0ms)";
         }
 
-        if (Receive(parts2, "data-in", 0, 0) == -2) {
+        if (Receive(parts2, "data-in", 0, 0) == static_cast<int>(TransferResult::timeout)) {
             LOG(info) << "receive 1 part canceled (0ms)";
             receive1PartCancelingAfter0ms = true;
         } else {
@@ -110,44 +110,44 @@ class TransferTimeout : public FairMQDevice
         parts3.AddPart(NewMessage(10));
         FairMQParts parts4;
 
-        if (Send(parts3, "data-out", 0, 100) == -2) {
-            LOG(info) << "send 2 parts canceled (100ms)";
-            send2PartsCancelingAfter100ms = true;
+        if (Send(parts3, "data-out", 0, 200) == static_cast<int>(TransferResult::timeout)) {
+            LOG(info) << "send 2 parts canceled (200ms)";
+            send2PartsCancelingAfter200ms = true;
         } else {
-            LOG(error) << "send 2 parts did not cancel (100ms)";
+            LOG(error) << "send 2 parts did not cancel (200ms)";
         }
 
-        if (Receive(parts4, "data-in", 0, 100) == -2) {
-            LOG(info) << "receive 2 parts canceled (100ms)";
-            receive2PartsCancelingAfter100ms = true;
+        if (Receive(parts4, "data-in", 0, 200) == static_cast<int>(TransferResult::timeout)) {
+            LOG(info) << "receive 2 parts canceled (200ms)";
+            receive2PartsCancelingAfter200ms = true;
         } else {
-            LOG(error) << "receive 2 parts did not cancel (100ms)";
+            LOG(error) << "receive 2 parts did not cancel (200ms)";
         }
 
-        if (Send(parts3, "data-out", 0, 0) == -2) {
+        if (Send(parts3, "data-out", 0, 0) == static_cast<int>(TransferResult::timeout)) {
             LOG(info) << "send 2 parts canceled (0ms)";
             send2PartsCancelingAfter0ms = true;
         } else {
             LOG(error) << "send 2 parts did not cancel (0ms)";
         }
 
-        if (Receive(parts4, "data-in", 0, 0) == -2) {
+        if (Receive(parts4, "data-in", 0, 0) == static_cast<int>(TransferResult::timeout)) {
             LOG(info) << "receive 2 parts canceled (0ms)";
             receive2PartsCancelingAfter0ms = true;
         } else {
             LOG(error) << "receive 2 parts did not cancel (0ms)";
         }
 
-        if (sendMsgCancelingAfter100ms &&
-            receiveMsgCancelingAfter100ms &&
+        if (sendMsgCancelingAfter200ms &&
+            receiveMsgCancelingAfter200ms &&
             sendMsgCancelingAfter0ms &&
             receiveMsgCancelingAfter0ms &&
-            send1PartCancelingAfter100ms &&
-            receive1PartCancelingAfter100ms &&
+            send1PartCancelingAfter200ms &&
+            receive1PartCancelingAfter200ms &&
             send1PartCancelingAfter0ms &&
             receive1PartCancelingAfter0ms &&
-            send2PartsCancelingAfter100ms &&
-            receive2PartsCancelingAfter100ms &&
+            send2PartsCancelingAfter200ms &&
+            receive2PartsCancelingAfter200ms &&
             send2PartsCancelingAfter0ms &&
             receive2PartsCancelingAfter0ms)
         {

--- a/test/sdk/_topology.cxx
+++ b/test/sdk/_topology.cxx
@@ -361,7 +361,7 @@ TEST_F(Topology, AsyncSetPropertiesTimeout)
 
     topo.AsyncSetProperties({{"key1", "val1"}},
                             "",
-                            std::chrono::milliseconds(1),
+                            std::chrono::microseconds(1),
                             [=](std::error_code ec, sdk::FailedDevices) mutable {
                                 LOG(info) << ec;
                                 EXPECT_EQ(ec, MakeErrorCode(ErrorCode::OperationTimeout));


### PR DESCRIPTION
Currently, a `Stop` transition during the `Running` state will interrupt the transfers. Blocking transfer calls (`Send`/`Receive`) will return `-2` (timeout). If another transfer is attempted before transitioning to Ready state, the behaviour of zmq/shmem transport is inconsistent. Another call to zmq transfer will attempt to complete the transfer with a certain timeout, while shmem transfer will not attempt any transfer and immediately return `-2` again.

There are scenarios when doing another transfer can be useful. One such scenario is to send an `end-of-stream` message when `Stop` happens. See some discussion of such a use case here: https://alice.its.cern.ch/jira/browse/O2-1499

This PR:
- gives names to different return values of the transfer methods: `TransferResult::error`, `TransferResult::timeout`, `TransferResult::interrupted`.
- makes the behaviour of zmq/shmem transport consistent - they will attempt a transfer with a timeout even if transport has been interrupted. If such timeout occurs, they will return `TransferResult::interrupted`.


