### PR TITLE
Fix a couple of issues

### DIFF
--- a/fairmq/plugins/PMIx/PMIxPlugin.cxx
+++ b/fairmq/plugins/PMIx/PMIxPlugin.cxx
@@ -148,12 +148,12 @@ auto PMIxPlugin::SubscribeForCommands() -> void
                     Transition transition = static_cast<ChangeState&>(*cmd).GetTransition();
                     if (ChangeDeviceState(transition)) {
                         fCommands.Send(
-                            Cmds(make<TransitionStatus>(fDeviceId, 0, Result::Ok, transition))
+                            Cmds(make<TransitionStatus>(fDeviceId, 0, Result::Ok, transition, GetCurrentDeviceState()))
                                 .Serialize(Format::JSON),
                             {sender});
                     } else {
                         fCommands.Send(
-                            Cmds(make<TransitionStatus>(fDeviceId, 0, Result::Failure, transition))
+                            Cmds(make<TransitionStatus>(fDeviceId, 0, Result::Failure, transition, GetCurrentDeviceState()))
                                 .Serialize(Format::JSON),
                             {sender});
                     }


### PR DESCRIPTION
- Avoid default session id in shmem tests. Should fix these types of failures: https://cdash.gsi.de/testDetails.php?test=7170379&build=246945. Also refactored the test a bit to avoid global objects and capitalize the type names.
- Update command format in PMIx plugin. Fixes #307.
