### PR TITLE
Workaround Cpp17MoveInsertable issue on xcode 12

### DIFF
--- a/fairmq/FairMQChannel.h
+++ b/fairmq/FairMQChannel.h
@@ -66,13 +66,13 @@ class FairMQChannel
     FairMQChannel(const FairMQChannel&, const std::string& name);
 
     /// Move constructor
-    FairMQChannel(FairMQChannel&&) = delete;
+    // FairMQChannel(FairMQChannel&&) = delete;
 
     /// Assignment operator
     FairMQChannel& operator=(const FairMQChannel&);
 
     /// Move assignment operator
-    FairMQChannel& operator=(FairMQChannel&&) = delete;
+    // FairMQChannel& operator=(FairMQChannel&&) = delete;
 
     /// Destructor
     virtual ~FairMQChannel()


### PR DESCRIPTION
Fixes #298.
`std::vector` wants FairMQChannel to be movable. When the move ctor is explicitly deleted, it fails, at least on xcode 12, but also on linux clang 10.0.1: https://godbolt.org/z/z3rY6n
Removing the `FairMQChannel(FairMQChannel&&) = delete` from the code causes the vector's move attempt to fall back to copy, which is fine for this case.