### PR TITLE
Update return types in ofi::Socket

### DIFF
--- a/fairmq/ofi/Socket.cxx
+++ b/fairmq/ofi/Socket.cxx
@@ -284,7 +284,7 @@ try {
     return size;
 } catch (const std::exception& e) {
     LOG(error) << e.what();
-    return TransferResult::error;
+    return static_cast<int64_t>(TransferResult::error);
 }
 
 auto Socket::SendQueueReader() -> void
@@ -431,7 +431,7 @@ try {
     return size;
 } catch (const std::exception& e) {
     LOG(error) << e.what();
-    return TransferResult::error;
+    return static_cast<int>(TransferResult::error);
 }
 
 auto Socket::Receive(std::vector<MessagePtr>& msgVec, const int /*timeout*/) -> int64_t
@@ -456,7 +456,7 @@ try {
     return size;
 } catch (const std::exception& e) {
     LOG(error) << e.what();
-    return TransferResult::error;
+    return static_cast<int64_t>(TransferResult::error);
 }
 
 auto Socket::RecvControlQueueReader() -> void


### PR DESCRIPTION
Update return types in ofi::Socket.
alisw/alidist/pull/2494.

@dennisklein we need to include ofi transport in some of the test environments.