### PR TITLE
Let single message methods also return int64_t

### DIFF
--- a/fairmq/FairMQChannel.h
+++ b/fairmq/FairMQChannel.h
@@ -257,7 +257,7 @@ class FairMQChannel
     /// @param msg Constant reference of unique_ptr to a FairMQMessage
     /// @param sndTimeoutInMs send timeout in ms. -1 will wait forever (or until interrupt (e.g. via state change)), 0 will not wait (return immediately if cannot send)
     /// @return Number of bytes that have been queued, TransferResult::timeout if timed out, TransferResult::error if there was an error, TransferResult::interrupted if interrupted (e.g. by requested state change)
-    int Send(FairMQMessagePtr& msg, int sndTimeoutInMs = -1)
+    int64_t Send(FairMQMessagePtr& msg, int sndTimeoutInMs = -1)
     {
         CheckSendCompatibility(msg);
         return fSocket->Send(msg, sndTimeoutInMs);
@@ -267,7 +267,7 @@ class FairMQChannel
     /// @param msg Constant reference of unique_ptr to a FairMQMessage
     /// @param rcvTimeoutInMs receive timeout in ms. -1 will wait forever (or until interrupt (e.g. via state change)), 0 will not wait (return immediately if cannot receive)
     /// @return Number of bytes that have been received, TransferResult::timeout if timed out, TransferResult::error if there was an error, TransferResult::interrupted if interrupted (e.g. by requested state change)
-    int Receive(FairMQMessagePtr& msg, int rcvTimeoutInMs = -1)
+    int64_t Receive(FairMQMessagePtr& msg, int rcvTimeoutInMs = -1)
     {
         CheckReceiveCompatibility(msg);
         return fSocket->Receive(msg, rcvTimeoutInMs);

--- a/fairmq/FairMQDevice.h
+++ b/fairmq/FairMQDevice.h
@@ -129,7 +129,7 @@ class FairMQDevice
     /// @param i channel index
     /// @param sndTimeoutInMs send timeout in ms, -1 will wait forever (or until interrupt (e.g. via state change)), 0 will not wait (return immediately if cannot send)
     /// @return Number of bytes that have been queued, TransferResult::timeout if timed out, TransferResult::error if there was an error, TransferResult::interrupted if interrupted (e.g. by requested state change)
-    int Send(FairMQMessagePtr& msg, const std::string& channel, const int index = 0, int sndTimeoutInMs = -1)
+    int64_t Send(FairMQMessagePtr& msg, const std::string& channel, const int index = 0, int sndTimeoutInMs = -1)
     {
         return GetChannel(channel, index).Send(msg, sndTimeoutInMs);
     }
@@ -140,7 +140,7 @@ class FairMQDevice
     /// @param i channel index
     /// @param rcvTimeoutInMs receive timeout in ms, -1 will wait forever (or until interrupt (e.g. via state change)), 0 will not wait (return immediately if cannot receive)
     /// @return Number of bytes that have been received, TransferResult::timeout if timed out, TransferResult::error if there was an error, TransferResult::interrupted if interrupted (e.g. by requested state change)
-    int Receive(FairMQMessagePtr& msg, const std::string& channel, const int index = 0, int rcvTimeoutInMs = -1)
+    int64_t Receive(FairMQMessagePtr& msg, const std::string& channel, const int index = 0, int rcvTimeoutInMs = -1)
     {
         return GetChannel(channel, index).Receive(msg, rcvTimeoutInMs);
     }

--- a/fairmq/FairMQSocket.h
+++ b/fairmq/FairMQSocket.h
@@ -45,8 +45,8 @@ class FairMQSocket
     virtual bool Bind(const std::string& address) = 0;
     virtual bool Connect(const std::string& address) = 0;
 
-    virtual int Send(FairMQMessagePtr& msg, int timeout = -1) = 0;
-    virtual int Receive(FairMQMessagePtr& msg, int timeout = -1) = 0;
+    virtual int64_t Send(FairMQMessagePtr& msg, int timeout = -1) = 0;
+    virtual int64_t Receive(FairMQMessagePtr& msg, int timeout = -1) = 0;
     virtual int64_t Send(std::vector<std::unique_ptr<FairMQMessage>>& msgVec, int timeout = -1) = 0;
     virtual int64_t Receive(std::vector<std::unique_ptr<FairMQMessage>>& msgVec, int timeout = -1) = 0;
 

--- a/fairmq/ofi/Socket.cxx
+++ b/fairmq/ofi/Socket.cxx
@@ -254,7 +254,7 @@ auto Socket::ConnectEndpoint(std::unique_ptr<asiofi::connected_endpoint>& endpoi
     }
 }
 
-auto Socket::Send(MessagePtr& msg, const int /*timeout*/) -> int
+auto Socket::Send(MessagePtr& msg, const int /*timeout*/) -> int64_t
 {
     // timeout argument not yet implemented
 
@@ -412,7 +412,7 @@ auto Socket::SendQueueReaderStatic() -> void
     });
 }
 
-auto Socket::Receive(MessagePtr& msg, const int /*timeout*/) -> int
+auto Socket::Receive(MessagePtr& msg, const int /*timeout*/) -> int64_t
 try {
     // timeout argument not yet implemented
 

--- a/fairmq/ofi/Socket.h
+++ b/fairmq/ofi/Socket.h
@@ -49,8 +49,8 @@ class Socket final : public fair::mq::Socket
     auto Bind(const std::string& address) -> bool override;
     auto Connect(const std::string& address) -> bool override;
 
-    auto Send(MessagePtr& msg, int timeout = 0) -> int override;
-    auto Receive(MessagePtr& msg, int timeout = 0) -> int override;
+    auto Send(MessagePtr& msg, int timeout = 0) -> int64_t override;
+    auto Receive(MessagePtr& msg, int timeout = 0) -> int64_t override;
     auto Send(std::vector<MessagePtr>& msgVec, int timeout = 0) -> int64_t override;
     auto Receive(std::vector<MessagePtr>& msgVec, int timeout = 0) -> int64_t override;
 

--- a/fairmq/shmem/Socket.h
+++ b/fairmq/shmem/Socket.h
@@ -155,7 +155,7 @@ class Socket final : public fair::mq::Socket
         }
     }
 
-    int Send(MessagePtr& msg, const int timeout = -1) override
+    int64_t Send(MessagePtr& msg, const int timeout = -1) override
     {
         int flags = 0;
         if (timeout == 0) {
@@ -191,7 +191,7 @@ class Socket final : public fair::mq::Socket
         return static_cast<int>(TransferResult::error);
     }
 
-    int Receive(MessagePtr& msg, const int timeout = -1) override
+    int64_t Receive(MessagePtr& msg, const int timeout = -1) override
     {
         int flags = 0;
         if (timeout == 0) {

--- a/fairmq/zeromq/Socket.h
+++ b/fairmq/zeromq/Socket.h
@@ -132,7 +132,7 @@ class Socket final : public fair::mq::Socket
         }
     }
 
-    int Send(MessagePtr& msg, const int timeout = -1) override
+    int64_t Send(MessagePtr& msg, const int timeout = -1) override
     {
         int flags = 0;
         if (timeout == 0) {
@@ -162,7 +162,7 @@ class Socket final : public fair::mq::Socket
         }
     }
 
-    int Receive(MessagePtr& msg, const int timeout = -1) override
+    int64_t Receive(MessagePtr& msg, const int timeout = -1) override
     {
         int flags = 0;
         if (timeout == 0) {


### PR DESCRIPTION
Due to historical reasons (ZeroMQ transfer methods return int) all single-message transfer methods return `int`. While this is fine for ZeroMQ, other transports are capable of transferring larger data sizes in a single message. This PR changes all transfer methods return types to int64_t.

Triggered by AliceO2Group/AliceO2/pull/4804 (although not the cause for any trouble in that case).


