### PR TITLE
shmmonitor: non-interactive mode checks and quits

### DIFF
--- a/fairmq/shmem/runMonitor.cxx
+++ b/fairmq/shmem/runMonitor.cxx
@@ -125,13 +125,12 @@ int main(int argc, char** argv)
         }
 
         cout << "Starting shared memory monitor for session: \"" << sessionName << "\" (shmId: " << shmId << ")..." << endl;
-        if (viewOnly && !interactive) {
-            cout << "running in non-interactive view-only mode, outputting with interval of " << intervalInMS << "ms. (change with --interval), press ctrl+C to exit." << endl;
-        }
 
         Monitor monitor(shmId, selfDestruct, interactive, viewOnly, timeoutInMS, intervalInMS, runAsDaemon, cleanOnExit);
 
-        monitor.CatchSignals();
+        if (interactive || !viewOnly) {
+            monitor.CatchSignals();
+        }
         monitor.Run();
     } catch (Monitor::DaemonPresent& dp) {
         return 0;


### PR DESCRIPTION
With this change the `fairmq-shmmonitor` (when run with `-v` (view only)) will output the segment contents and exit immediately.
To get continuous output, use `-i` (interactive).
The output format is same for both.

@sawenzel This does what you requested.
@davidrohr FYI: with this you might have to modify your options if you have been using `-v` only, but want continuous output.