### PR TITLE
Bugfixes

### DIFF
--- a/examples/1-1/CMakeLists.txt
+++ b/examples/1-1/CMakeLists.txt
@@ -7,10 +7,10 @@
 ################################################################################
 
 add_library(Example11Lib STATIC
-    "Sampler.cxx"
-    "Sampler.h"
-    "Sink.cxx"
-    "Sink.h"
+  "Sampler.cxx"
+  "Sampler.h"
+  "Sink.cxx"
+  "Sink.h"
 )
 
 target_link_libraries(Example11Lib PUBLIC FairMQ)
@@ -40,12 +40,12 @@ set_tests_properties(Example.1-1.shmem PROPERTIES TIMEOUT "30" RUN_SERIAL true P
 # install
 
 install(
-    TARGETS
-    fairmq-ex-1-1-sampler
-    fairmq-ex-1-1-sink
+  TARGETS
+  fairmq-ex-1-1-sampler
+  fairmq-ex-1-1-sink
 
-    LIBRARY DESTINATION ${PROJECT_INSTALL_LIBDIR}
-    RUNTIME DESTINATION ${PROJECT_INSTALL_BINDIR}
+  LIBRARY DESTINATION ${PROJECT_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${PROJECT_INSTALL_BINDIR}
 )
 
 # configure run script with different executable paths for build and for install directories
@@ -54,7 +54,7 @@ set(FAIRMQ_BIN_DIR ${CMAKE_INSTALL_PREFIX}/${PROJECT_INSTALL_BINDIR}/fairmq)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/fairmq-start-ex-1-1.sh.in ${CMAKE_CURRENT_BINARY_DIR}/fairmq-start-ex-1-1.sh_install)
 
 install(
-    PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/fairmq-start-ex-1-1.sh_install
-    DESTINATION ${PROJECT_INSTALL_BINDIR}
-    RENAME fairmq-start-ex-1-1.sh
+  PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/fairmq-start-ex-1-1.sh_install
+  DESTINATION ${PROJECT_INSTALL_BINDIR}
+  RENAME fairmq-start-ex-1-1.sh
 )

--- a/examples/1-n-1/CMakeLists.txt
+++ b/examples/1-n-1/CMakeLists.txt
@@ -7,12 +7,12 @@
 ################################################################################
 
 add_library(Example1N1Lib STATIC
-    "Sampler.cxx"
-    "Sampler.h"
-    "Processor.cxx"
-    "Processor.h"
-    "Sink.cxx"
-    "Sink.h"
+  "Sampler.cxx"
+  "Sampler.h"
+  "Processor.cxx"
+  "Processor.h"
+  "Sink.cxx"
+  "Sink.h"
 )
 
 target_link_libraries(Example1N1Lib PUBLIC FairMQ)
@@ -48,13 +48,13 @@ set_tests_properties(Example.1-n-1.shmem PROPERTIES TIMEOUT "30" RUN_SERIAL true
 # install
 
 install(
-    TARGETS
-    fairmq-ex-1-n-1-sampler
-    fairmq-ex-1-n-1-processor
-    fairmq-ex-1-n-1-sink
+  TARGETS
+  fairmq-ex-1-n-1-sampler
+  fairmq-ex-1-n-1-processor
+  fairmq-ex-1-n-1-sink
 
-    LIBRARY DESTINATION ${PROJECT_INSTALL_LIBDIR}
-    RUNTIME DESTINATION ${PROJECT_INSTALL_BINDIR}
+  LIBRARY DESTINATION ${PROJECT_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${PROJECT_INSTALL_BINDIR}
 )
 
 # configure run script with different executable paths for build and for install directories
@@ -64,12 +64,12 @@ set(FAIRMQ_BIN_DIR ${CMAKE_INSTALL_PREFIX}/${PROJECT_INSTALL_BINDIR}/fairmq)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/fairmq-start-ex-1-n-1.sh.in ${CMAKE_CURRENT_BINARY_DIR}/fairmq-start-ex-1-n-1.sh_install)
 
 install(
-    PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/fairmq-start-ex-1-n-1.sh_install
-    DESTINATION ${PROJECT_INSTALL_BINDIR}
-    RENAME fairmq-start-ex-1-n-1.sh
+  PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/fairmq-start-ex-1-n-1.sh_install
+  DESTINATION ${PROJECT_INSTALL_BINDIR}
+  RENAME fairmq-start-ex-1-n-1.sh
 )
 
 install(
-    FILES ${CMAKE_CURRENT_BINARY_DIR}/ex-1-n-1.json
-    DESTINATION ${PROJECT_INSTALL_DATADIR}
+  FILES ${CMAKE_CURRENT_BINARY_DIR}/ex-1-n-1.json
+  DESTINATION ${PROJECT_INSTALL_DATADIR}
 )

--- a/examples/builtin-devices/CMakeLists.txt
+++ b/examples/builtin-devices/CMakeLists.txt
@@ -34,7 +34,7 @@ set(FAIRMQ_BIN_DIR ${CMAKE_INSTALL_PREFIX}/${PROJECT_INSTALL_BINDIR}/fairmq)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/fairmq-start-ex-builtin-devices.sh.in ${CMAKE_CURRENT_BINARY_DIR}/fairmq-start-ex-builtin-devices.sh_install)
 
 install(
-    PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/fairmq-start-ex-builtin-devices.sh_install
-    DESTINATION ${PROJECT_INSTALL_BINDIR}
-    RENAME fairmq-start-ex-builtin-devices.sh
+  PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/fairmq-start-ex-builtin-devices.sh_install
+  DESTINATION ${PROJECT_INSTALL_BINDIR}
+  RENAME fairmq-start-ex-builtin-devices.sh
 )

--- a/examples/copypush/CMakeLists.txt
+++ b/examples/copypush/CMakeLists.txt
@@ -7,10 +7,10 @@
 ################################################################################
 
 add_library(ExampleCopyPushLib STATIC
-    "Sampler.cxx"
-    "Sampler.h"
-    "Sink.cxx"
-    "Sink.h"
+  "Sampler.cxx"
+  "Sampler.h"
+  "Sink.cxx"
+  "Sink.h"
 )
 
 target_link_libraries(ExampleCopyPushLib PUBLIC FairMQ)
@@ -41,12 +41,12 @@ set_tests_properties(Example.CopyPush.shmem PROPERTIES TIMEOUT "30" RUN_SERIAL t
 # install
 
 install(
-    TARGETS
-    fairmq-ex-copypush-sampler
-    fairmq-ex-copypush-sink
+  TARGETS
+  fairmq-ex-copypush-sampler
+  fairmq-ex-copypush-sink
 
-    LIBRARY DESTINATION ${PROJECT_INSTALL_LIBDIR}
-    RUNTIME DESTINATION ${PROJECT_INSTALL_BINDIR}
+  LIBRARY DESTINATION ${PROJECT_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${PROJECT_INSTALL_BINDIR}
 )
 
 # configure run script with different executable paths for build and for install directories
@@ -55,7 +55,7 @@ set(FAIRMQ_BIN_DIR ${CMAKE_INSTALL_PREFIX}/${PROJECT_INSTALL_BINDIR}/fairmq)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/fairmq-start-ex-copypush.sh.in ${CMAKE_CURRENT_BINARY_DIR}/fairmq-start-ex-copypush.sh_install)
 
 install(
-    PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/fairmq-start-ex-copypush.sh_install
-    DESTINATION ${PROJECT_INSTALL_BINDIR}
-    RENAME fairmq-start-ex-copypush.sh
+  PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/fairmq-start-ex-copypush.sh_install
+  DESTINATION ${PROJECT_INSTALL_BINDIR}
+  RENAME fairmq-start-ex-copypush.sh
 )

--- a/examples/multipart/CMakeLists.txt
+++ b/examples/multipart/CMakeLists.txt
@@ -7,10 +7,10 @@
  ################################################################################
 
 add_library(ExampleMultipartLib STATIC
-    "Sampler.cxx"
-    "Sampler.h"
-    "Sink.cxx"
-    "Sink.h"
+  "Sampler.cxx"
+  "Sampler.h"
+  "Sink.cxx"
+  "Sink.h"
 )
 
 target_link_libraries(ExampleMultipartLib PUBLIC FairMQ)
@@ -45,12 +45,12 @@ endif()
 # install
 
 install(
-    TARGETS
-    fairmq-ex-multipart-sampler
-    fairmq-ex-multipart-sink
+  TARGETS
+  fairmq-ex-multipart-sampler
+  fairmq-ex-multipart-sink
 
-    LIBRARY DESTINATION ${PROJECT_INSTALL_LIBDIR}
-    RUNTIME DESTINATION ${PROJECT_INSTALL_BINDIR}
+  LIBRARY DESTINATION ${PROJECT_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${PROJECT_INSTALL_BINDIR}
 )
 
 # configure run script with different executable paths for build and for install directories
@@ -59,7 +59,7 @@ set(FAIRMQ_BIN_DIR ${CMAKE_INSTALL_PREFIX}/${PROJECT_INSTALL_BINDIR}/fairmq)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/fairmq-start-ex-multipart.sh.in ${CMAKE_CURRENT_BINARY_DIR}/fairmq-start-ex-multipart.sh_install)
 
 install(
-    PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/fairmq-start-ex-multipart.sh_install
-    DESTINATION ${PROJECT_INSTALL_BINDIR}
-    RENAME fairmq-start-ex-multipart.sh
+  PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/fairmq-start-ex-multipart.sh_install
+  DESTINATION ${PROJECT_INSTALL_BINDIR}
+  RENAME fairmq-start-ex-multipart.sh
 )

--- a/examples/multiple-channels/CMakeLists.txt
+++ b/examples/multiple-channels/CMakeLists.txt
@@ -7,12 +7,12 @@
  ################################################################################
 
 add_library(ExampleMultipleChannelsLib STATIC
-    "Sampler.cxx"
-    "Sampler.h"
-    "Broadcaster.cxx"
-    "Broadcaster.h"
-    "Sink.cxx"
-    "Sink.h"
+  "Sampler.cxx"
+  "Sampler.h"
+  "Broadcaster.cxx"
+  "Broadcaster.h"
+  "Sink.cxx"
+  "Sink.h"
 )
 
 target_link_libraries(ExampleMultipleChannelsLib PUBLIC FairMQ)
@@ -42,13 +42,13 @@ set_tests_properties(Example.MultipleChannels.zeromq PROPERTIES TIMEOUT "30" RUN
 # install
 
 install(
-    TARGETS
-    fairmq-ex-multiple-channels-sampler
-    fairmq-ex-multiple-channels-broadcaster
-    fairmq-ex-multiple-channels-sink
+  TARGETS
+  fairmq-ex-multiple-channels-sampler
+  fairmq-ex-multiple-channels-broadcaster
+  fairmq-ex-multiple-channels-sink
 
-    LIBRARY DESTINATION ${PROJECT_INSTALL_LIBDIR}
-    RUNTIME DESTINATION ${PROJECT_INSTALL_BINDIR}
+  LIBRARY DESTINATION ${PROJECT_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${PROJECT_INSTALL_BINDIR}
 )
 
 # configure run script with different executable paths for build and for install directories
@@ -57,7 +57,7 @@ set(FAIRMQ_BIN_DIR ${CMAKE_INSTALL_PREFIX}/${PROJECT_INSTALL_BINDIR}/fairmq)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/fairmq-start-ex-multiple-channels.sh.in ${CMAKE_CURRENT_BINARY_DIR}/fairmq-start-ex-multiple-channels.sh_install)
 
 install(
-    PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/fairmq-start-ex-multiple-channels.sh_install
-    DESTINATION ${PROJECT_INSTALL_BINDIR}
-    RENAME fairmq-start-ex-multiple-channels.sh
+  PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/fairmq-start-ex-multiple-channels.sh_install
+  DESTINATION ${PROJECT_INSTALL_BINDIR}
+  RENAME fairmq-start-ex-multiple-channels.sh
 )

--- a/examples/multiple-transports/CMakeLists.txt
+++ b/examples/multiple-transports/CMakeLists.txt
@@ -7,12 +7,12 @@
  ################################################################################
 
 add_library(ExampleMultipleTransportsLib STATIC
-    "Sampler1.cxx"
-    "Sampler1.h"
-    "Sampler2.cxx"
-    "Sampler2.h"
-    "Sink.cxx"
-    "Sink.h"
+  "Sampler1.cxx"
+  "Sampler1.h"
+  "Sampler2.cxx"
+  "Sampler2.h"
+  "Sink.cxx"
+  "Sink.h"
 )
 
 target_link_libraries(ExampleMultipleTransportsLib PUBLIC FairMQ)
@@ -41,13 +41,13 @@ set_tests_properties(Example.MultipleTransports PROPERTIES TIMEOUT "30" RUN_SERI
 # install
 
 install(
-    TARGETS
-    fairmq-ex-multiple-transports-sampler1
-    fairmq-ex-multiple-transports-sampler2
-    fairmq-ex-multiple-transports-sink
+  TARGETS
+  fairmq-ex-multiple-transports-sampler1
+  fairmq-ex-multiple-transports-sampler2
+  fairmq-ex-multiple-transports-sink
 
-    LIBRARY DESTINATION ${PROJECT_INSTALL_LIBDIR}
-    RUNTIME DESTINATION ${PROJECT_INSTALL_BINDIR}
+  LIBRARY DESTINATION ${PROJECT_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${PROJECT_INSTALL_BINDIR}
 )
 
 # configure run script with different executable paths for install directories
@@ -56,7 +56,7 @@ set(FAIRMQ_BIN_DIR ${CMAKE_INSTALL_PREFIX}/${PROJECT_INSTALL_BINDIR}/fairmq)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/fairmq-start-ex-multiple-transports.sh.in ${CMAKE_CURRENT_BINARY_DIR}/fairmq-start-ex-multiple-transports.sh_install)
 
 install(
-    PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/fairmq-start-ex-multiple-transports.sh_install
-    DESTINATION ${PROJECT_INSTALL_BINDIR}
-    RENAME fairmq-start-ex-multiple-transports.sh
+  PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/fairmq-start-ex-multiple-transports.sh_install
+  DESTINATION ${PROJECT_INSTALL_BINDIR}
+  RENAME fairmq-start-ex-multiple-transports.sh
 )

--- a/examples/readout/CMakeLists.txt
+++ b/examples/readout/CMakeLists.txt
@@ -29,15 +29,15 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/fairmq-start-ex-readout-processing.sh
 # install
 
 install(
-    TARGETS
-    fairmq-ex-readout-readout
-    fairmq-ex-readout-builder
-    fairmq-ex-readout-processor
-    fairmq-ex-readout-sender
-    fairmq-ex-readout-receiver
+  TARGETS
+  fairmq-ex-readout-readout
+  fairmq-ex-readout-builder
+  fairmq-ex-readout-processor
+  fairmq-ex-readout-sender
+  fairmq-ex-readout-receiver
 
-    LIBRARY DESTINATION ${PROJECT_INSTALL_LIBDIR}
-    RUNTIME DESTINATION ${PROJECT_INSTALL_BINDIR}
+  LIBRARY DESTINATION ${PROJECT_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${PROJECT_INSTALL_BINDIR}
 )
 
 # configure run script with different executable paths for build and for install directories
@@ -47,13 +47,13 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/fairmq-start-ex-readout.sh.in ${CMAKE
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/fairmq-start-ex-readout-processing.sh.in ${CMAKE_CURRENT_BINARY_DIR}/fairmq-start-ex-readout-processing.sh_install)
 
 install(
-    PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/fairmq-start-ex-readout.sh_install
-    DESTINATION ${PROJECT_INSTALL_BINDIR}
-    RENAME fairmq-start-ex-readout.sh
+  PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/fairmq-start-ex-readout.sh_install
+  DESTINATION ${PROJECT_INSTALL_BINDIR}
+  RENAME fairmq-start-ex-readout.sh
 )
 
 install(
-    PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/fairmq-start-ex-readout-processing.sh_install
-    DESTINATION ${PROJECT_INSTALL_BINDIR}
-    RENAME fairmq-start-ex-readout-processing.sh
+  PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/fairmq-start-ex-readout-processing.sh_install
+  DESTINATION ${PROJECT_INSTALL_BINDIR}
+  RENAME fairmq-start-ex-readout-processing.sh
 )

--- a/examples/region/CMakeLists.txt
+++ b/examples/region/CMakeLists.txt
@@ -7,10 +7,10 @@
  ################################################################################
 
 add_library(ExampleRegionLib STATIC
-    "Sampler.cxx"
-    "Sampler.h"
-    "Sink.cxx"
-    "Sink.h"
+  "Sampler.cxx"
+  "Sampler.h"
+  "Sink.cxx"
+  "Sink.h"
 )
 
 target_link_libraries(ExampleRegionLib PUBLIC FairMQ)
@@ -40,12 +40,12 @@ set_tests_properties(Example.Region.shmem PROPERTIES TIMEOUT "30" RUN_SERIAL tru
 # install
 
 install(
-    TARGETS
-    fairmq-ex-region-sampler
-    fairmq-ex-region-sink
+  TARGETS
+  fairmq-ex-region-sampler
+  fairmq-ex-region-sink
 
-    LIBRARY DESTINATION ${PROJECT_INSTALL_LIBDIR}
-    RUNTIME DESTINATION ${PROJECT_INSTALL_BINDIR}
+  LIBRARY DESTINATION ${PROJECT_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${PROJECT_INSTALL_BINDIR}
 )
 
 # configure run script with different executable paths for build and for install directories
@@ -54,7 +54,7 @@ set(FAIRMQ_BIN_DIR ${CMAKE_INSTALL_PREFIX}/${PROJECT_INSTALL_BINDIR}/fairmq)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/fairmq-start-ex-region.sh.in ${CMAKE_CURRENT_BINARY_DIR}/fairmq-start-ex-region.sh_install)
 
 install(
-    PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/fairmq-start-ex-region.sh_install
-    DESTINATION ${PROJECT_INSTALL_BINDIR}
-    RENAME fairmq-start-ex-region.sh
+  PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/fairmq-start-ex-region.sh_install
+  DESTINATION ${PROJECT_INSTALL_BINDIR}
+  RENAME fairmq-start-ex-region.sh
 )

--- a/examples/req-rep/CMakeLists.txt
+++ b/examples/req-rep/CMakeLists.txt
@@ -7,10 +7,10 @@
  ################################################################################
 
 add_library(ExampleReqRepLib STATIC
-    "Client.cxx"
-    "Client.h"
-    "Server.cxx"
-    "Server.h"
+  "Client.cxx"
+  "Client.h"
+  "Server.cxx"
+  "Server.h"
 )
 
 target_link_libraries(ExampleReqRepLib PUBLIC FairMQ)
@@ -41,12 +41,12 @@ set_tests_properties(Example.ReqRep.shmem PROPERTIES TIMEOUT "30" RUN_SERIAL tru
 # install
 
 install(
-    TARGETS
-    fairmq-ex-req-rep-client
-    fairmq-ex-req-rep-server
+  TARGETS
+  fairmq-ex-req-rep-client
+  fairmq-ex-req-rep-server
 
-    LIBRARY DESTINATION ${PROJECT_INSTALL_LIBDIR}
-    RUNTIME DESTINATION ${PROJECT_INSTALL_BINDIR}
+  LIBRARY DESTINATION ${PROJECT_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${PROJECT_INSTALL_BINDIR}
 )
 
 # configure run script with different executable paths for build and for install directories
@@ -55,7 +55,7 @@ set(FAIRMQ_BIN_DIR ${CMAKE_INSTALL_PREFIX}/${PROJECT_INSTALL_BINDIR}/fairmq)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/fairmq-start-ex-req-rep.sh.in ${CMAKE_CURRENT_BINARY_DIR}/fairmq-start-ex-req-rep.sh_install)
 
 install(
-    PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/fairmq-start-ex-req-rep.sh_install
-    DESTINATION ${PROJECT_INSTALL_BINDIR}
-    RENAME fairmq-start-ex-req-rep.sh
+  PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/fairmq-start-ex-req-rep.sh_install
+  DESTINATION ${PROJECT_INSTALL_BINDIR}
+  RENAME fairmq-start-ex-req-rep.sh
 )

--- a/fairmq/FairMQDevice.cxx
+++ b/fairmq/FairMQDevice.cxx
@@ -644,7 +644,7 @@ bool FairMQDevice::HandleMultipartInput(const string& chName, const InputMultipa
     FairMQParts input;
 
     if (Receive(input, chName, i) >= 0) {
-        return callback(input, 0);
+        return callback(input, i);
     } else {
         return false;
     }

--- a/fairmq/FairMQDevice.h
+++ b/fairmq/FairMQDevice.h
@@ -421,28 +421,64 @@ class FairMQDevice
     virtual void Reset() {}
 
   public:
+    /// @brief Request a device state transition
+    /// @param transition state transition
+    ///
+    /// The state transition may not happen immediately, but when the current state evaluates the
+    /// pending transition event and terminates. In other words, the device states are scheduled cooperatively.
     bool ChangeState(const fair::mq::Transition transition) { return fStateMachine.ChangeState(transition); }
+    /// @brief Request a device state transition
+    /// @param transition state transition
+    ///
+    /// The state transition may not happen immediately, but when the current state evaluates the
+    /// pending transition event and terminates. In other words, the device states are scheduled cooperatively.
     bool ChangeState(const std::string& transition) { return fStateMachine.ChangeState(fair::mq::GetTransition(transition)); }
 
+    /// @brief waits for the next state (any) to occur
     fair::mq::State WaitForNextState() { return fStateQueue.WaitForNext(); }
+    /// @brief waits for the specified state to occur
+    /// @param state state to wait for
     void WaitForState(fair::mq::State state) { fStateQueue.WaitForState(state); }
+    /// @brief waits for the specified state to occur
+    /// @param state state to wait for
     void WaitForState(const std::string& state) { WaitForState(fair::mq::GetState(state)); }
 
     void TransitionTo(const fair::mq::State state);
 
+    /// @brief Subscribe with a callback to state changes
+    /// @param key id to identify your subscription
+    /// @param callback callback (called with the new state as the parameter)
+    ///
+    /// The callback is called at the beginning of a new state.
+    /// The callback is called from the thread the state is running in.
     void SubscribeToStateChange(const std::string& key, std::function<void(const fair::mq::State)> callback) { fStateMachine.SubscribeToStateChange(key, callback); }
+    /// @brief Unsubscribe from state changes
+    /// @param key id (that was used when subscribing)
     void UnsubscribeFromStateChange(const std::string& key) { fStateMachine.UnsubscribeFromStateChange(key); }
 
+    /// @brief Subscribe with a callback to incoming state transitions
+    /// @param key id to identify your subscription
+    /// @param callback callback (called with the incoming transition as the parameter)
+    /// The callback is called when new transition is initiated.
+    /// The callback is called from the thread that initiates the transition (via ChangeState).
     void SubscribeToNewTransition(const std::string& key, std::function<void(const fair::mq::Transition)> callback) { fStateMachine.SubscribeToNewTransition(key, callback); }
+    /// @brief Unsubscribe from state transitions
+    /// @param key id (that was used when subscribing)
     void UnsubscribeFromNewTransition(const std::string& key) { fStateMachine.UnsubscribeFromNewTransition(key); }
 
-    /// Returns true is a new state has been requested, signaling the current handler to stop.
+    /// @brief Returns true if a new state has been requested, signaling the current handler to stop.
     bool NewStatePending() const { return fStateMachine.NewStatePending(); }
 
+    /// @brief Returns the current state
     fair::mq::State GetCurrentState() const { return fStateMachine.GetCurrentState(); }
+    /// @brief Returns the name of the current state as a string
     std::string GetCurrentStateName() const { return fStateMachine.GetCurrentStateName(); }
 
+    /// @brief Returns name of the given state as a string
+    /// @param state state
     static std::string GetStateName(const fair::mq::State state) { return fair::mq::GetStateName(state); }
+    /// @brief Returns name of the given transition as a string
+    /// @param transition transition
     static std::string GetTransitionName(const fair::mq::Transition transition) { return fair::mq::GetTransitionName(transition); }
 
     static constexpr const char* DefaultId = "";

--- a/fairmq/shmem/Common.h
+++ b/fairmq/shmem/Common.h
@@ -11,6 +11,7 @@
 #include <picosha2.h>
 
 #include <atomic>
+#include <sstream>
 #include <string>
 #include <functional> // std::equal_to
 
@@ -194,15 +195,25 @@ struct RegionBlock
 
 // find id for unique shmem name:
 // a hash of user id + session id, truncated to 8 characters (to accommodate for name size limit on some systems (MacOS)).
-inline std::string buildShmIdFromSessionIdAndUserId(const std::string& sessionId)
+inline std::string makeShmIdStr(const std::string& sessionId)
 {
     std::string seed((std::to_string(geteuid()) + sessionId));
     // generate a 8-digit hex value out of sha256 hash
     std::vector<unsigned char> hash(4);
     picosha2::hash256(seed.begin(), seed.end(), hash.begin(), hash.end());
-    std::string shmId = picosha2::bytes_to_hex_string(hash.begin(), hash.end());
 
-    return shmId;
+    return picosha2::bytes_to_hex_string(hash.begin(), hash.end());
+}
+
+inline uint64_t makeShmIdUint64(const std::string& sessionId)
+{
+    std::string shmId = makeShmIdStr(sessionId);
+    uint64_t id = 0;
+    std::stringstream ss;
+    ss << std::hex << shmId;
+    ss >> id;
+
+    return id;
 }
 
 struct SegmentSize : public boost::static_visitor<size_t>

--- a/fairmq/shmem/Common.h
+++ b/fairmq/shmem/Common.h
@@ -103,6 +103,15 @@ struct DeviceCounter
     std::atomic<unsigned int> fCount;
 };
 
+struct EventCounter
+{
+    EventCounter(uint64_t c)
+        : fCount(c)
+    {}
+
+    std::atomic<uint64_t> fCount;
+};
+
 struct RegionCounter
 {
     RegionCounter(uint16_t c)

--- a/fairmq/shmem/Manager.h
+++ b/fairmq/shmem/Manager.h
@@ -415,10 +415,10 @@ class Manager
         while (fRegionEventsSubscriptionActive) {
             auto infos = GetRegionInfoUnsafe();
             for (const auto& i : infos) {
-                auto el = fObservedRegionEvents.find(i.id);
+                auto el = fObservedRegionEvents.find({i.id, i.managed});
                 if (el == fObservedRegionEvents.end()) {
                     fRegionEventCallback(i);
-                    fObservedRegionEvents.emplace(i.id, i.event);
+                    fObservedRegionEvents.emplace(std::make_pair(i.id, i.managed), i.event);
                 } else {
                     if (el->second == RegionEvent::created && i.event == RegionEvent::destroyed) {
                         fRegionEventCallback(i);
@@ -617,7 +617,7 @@ class Manager
     std::thread fRegionEventThread;
     bool fRegionEventsSubscriptionActive;
     std::function<void(fair::mq::RegionInfo)> fRegionEventCallback;
-    std::unordered_map<uint16_t, RegionEvent> fObservedRegionEvents;
+    std::map<std::pair<uint16_t, bool>, RegionEvent> fObservedRegionEvents;
 
     DeviceCounter* fDeviceCounter;
     Uint16SegmentInfoHashMap* fShmSegments;

--- a/fairmq/shmem/Monitor.cxx
+++ b/fairmq/shmem/Monitor.cxx
@@ -393,7 +393,7 @@ void Monitor::PrintDebugInfo(const ShmId& shmId __attribute__((unused)))
 
 void Monitor::PrintDebugInfo(const SessionId& sessionId)
 {
-    ShmId shmId{buildShmIdFromSessionIdAndUserId(sessionId.sessionId)};
+    ShmId shmId{makeShmIdStr(sessionId.sessionId)};
     PrintDebugInfo(shmId);
 }
 
@@ -429,7 +429,7 @@ unordered_map<uint16_t, std::vector<BufferDebugInfo>> Monitor::GetDebugInfo(cons
 }
 unordered_map<uint16_t, std::vector<BufferDebugInfo>> Monitor::GetDebugInfo(const SessionId& sessionId)
 {
-    ShmId shmId{buildShmIdFromSessionIdAndUserId(sessionId.sessionId)};
+    ShmId shmId{makeShmIdStr(sessionId.sessionId)};
     return GetDebugInfo(shmId);
 }
 
@@ -536,7 +536,7 @@ std::vector<std::pair<std::string, bool>> Monitor::Cleanup(const ShmId& shmId, b
 
 std::vector<std::pair<std::string, bool>> Monitor::Cleanup(const SessionId& sessionId, bool verbose /* = true */)
 {
-    ShmId shmId{buildShmIdFromSessionIdAndUserId(sessionId.sessionId)};
+    ShmId shmId{makeShmIdStr(sessionId.sessionId)};
     if (verbose) {
         cout << "Cleanup called with session id '" << sessionId.sessionId << "', translating to shared memory id '" << shmId.shmId << "'" << endl;
     }
@@ -553,7 +553,7 @@ std::vector<std::pair<std::string, bool>> Monitor::CleanupFull(const ShmId& shmI
 
 std::vector<std::pair<std::string, bool>> Monitor::CleanupFull(const SessionId& sessionId, bool verbose /* = true */)
 {
-    ShmId shmId{buildShmIdFromSessionIdAndUserId(sessionId.sessionId)};
+    ShmId shmId{makeShmIdStr(sessionId.sessionId)};
     if (verbose) {
         cout << "Cleanup called with session id '" << sessionId.sessionId << "', translating to shared memory id '" << shmId.shmId << "'" << endl;
     }

--- a/fairmq/shmem/Region.h
+++ b/fairmq/shmem/Region.h
@@ -152,7 +152,7 @@ struct Region
             }
         }
 
-        LOG(debug) << "AcksSender for " << fName << " leaving " << "(blocks left to free: " << fBlocksToFree.size() << ", "
+        LOG(trace) << "AcksSender for " << fName << " leaving " << "(blocks left to free: " << fBlocksToFree.size() << ", "
                                                                 << " blocks left to send: " << blocksToSend << ").";
     }
 
@@ -195,7 +195,7 @@ struct Region
             }
         }
 
-        LOG(debug) << "AcksReceiver for " << fName << " leaving (remaining queue size: " << fQueue->get_num_msg() << ").";
+        LOG(trace) << "AcksReceiver for " << fName << " leaving (remaining queue size: " << fQueue->get_num_msg() << ").";
     }
 
     void ReleaseBlock(const RegionBlock& block)

--- a/fairmq/shmem/runMonitor.cxx
+++ b/fairmq/shmem/runMonitor.cxx
@@ -111,7 +111,7 @@ int main(int argc, char** argv)
         }
 
         if (shmId == "") {
-            shmId = buildShmIdFromSessionIdAndUserId(sessionName);
+            shmId = makeShmIdStr(sessionName);
         }
 
         if (cleanup) {

--- a/test/region/_region.cxx
+++ b/test/region/_region.cxx
@@ -50,12 +50,12 @@ void RegionEventSubscriptions(const string& transport)
 
         ASSERT_EQ(factory->SubscribedToRegionEvents(), false);
         factory->SubscribeToRegionEvents([&](FairMQRegionInfo info) {
-            LOG(warn) << ">>>" << info.event;
-            LOG(warn) << "managed: " << info.managed;
-            LOG(warn) << "id: " << info.id;
-            LOG(warn) << "ptr: " << info.ptr;
-            LOG(warn) << "size: " << info.size;
-            LOG(warn) << "flags: " << info.flags;
+            LOG(info) << ">>> " << info.event << ": "
+                      << (info.managed ? "managed" : "unmanaged")
+                      << ", id: " << info.id
+                      << ", ptr: " << info.ptr
+                      << ", size: " << info.size
+                      << ", flags: " << info.flags;
             if (info.event == FairMQRegionEvent::created) {
                 if (info.id == id1) {
                     ASSERT_EQ(info.size, size1);


### PR DESCRIPTION
- shm: Make sure all region events are fired. Before an event could be ignored when segment id clashes with region id. These ids are independent, at least for the moment, so whatever uses them has to account for that. The IDs are used internally, but the segment ids can be set by the user in the experimental `--shm-segment-id` feature. Further improvements possible here to avoid these kinds of conflicts. For now just fix the bug.
- shm: Make sure no event notification is missed. Theoretically notifier thread could miss a notify and go into wait without anything to wait for. While this was not observed anywhere afaik, still fixed to always have a condition check before waiting.
- shm: provide another internal method to get shmId as an uint64 in addition to string. This is not yet used anywhere.
- FairMQDevice: Fix a bug where OnData callback is always called with subchannel index 0, instead of the correct index.
- Minor formatting.
- Update device docs. Solves #341.
