### PR TITLE
Provide a better syntax for --channel-config

### DIFF
--- a/fairmq/SuboptParser.cxx
+++ b/fairmq/SuboptParser.cxx
@@ -17,8 +17,9 @@
 #include <fairlogger/Logger.h>
 
 #include <boost/property_tree/ptree.hpp>
-
-#include <utility> // make_pair
+#include <string_view>
+#include <utility>   // make_pair
+#include <cstring>
 
 using boost::property_tree::ptree;
 using namespace std;
@@ -83,6 +84,14 @@ Properties SuboptParser(const vector<string>& channelConfig, const string& devic
         string argString(token);
         char* subopts = &argString[0];
         char* value = nullptr;
+        // Find either a : or a =. If we find the former first, we consider what is before it
+        // the channel name
+        char* firstSep = strpbrk(subopts, ":=");
+        if (firstSep && *firstSep == ':') {
+            channelName = std::string_view(subopts, firstSep - subopts);
+            channelProperties.put("name", channelName);
+            subopts = firstSep + 1;
+        }
         while (subopts && *subopts != 0 && *subopts != ' ') {
             char* cur = subopts;
             int subopt = getsubopt(&subopts, (char**)channelOptionKeys, &value);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -217,6 +217,7 @@ add_testsuite(Properties
     SOURCES
     ${CMAKE_CURRENT_BINARY_DIR}/runner.cxx
     properties/_properties.cxx
+    properties/_suboptparser.cxx
 
     LINKS FairMQ
     INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}

--- a/test/properties/_suboptparser.cxx
+++ b/test/properties/_suboptparser.cxx
@@ -1,0 +1,36 @@
+/********************************************************************************
+ *    Copyright (C) 2021 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ *                                                                              *
+ *              This software is distributed under the terms of the             *
+ *              GNU Lesser General Public Licence (LGPL) version 3,             *
+ *                  copied verbatim in the file "LICENSE"                       *
+ ********************************************************************************/
+
+#include <fairmq/Properties.h>
+#include <fairmq/SuboptParser.h>
+#include <gtest/gtest.h>
+#include <string>
+#include <string_view>
+
+namespace {
+
+using namespace std;
+using namespace fair::mq;
+
+auto contains(Properties const& parsed, string_view key, string_view value) -> bool
+{
+    return PropertyHelper::ConvertPropertyToString(parsed.at(string(key))) == value;
+}
+
+TEST(SuboptParser, ChannelNameSelector)
+{
+    Properties parsed(SuboptParser({"name=foo-data,address=tcp://0.0.0.0:6000,type=push",
+                                    "bar-data:address=tcp://0.0.0.0:7000,type=pull"},
+                                   "foo"));
+    ASSERT_TRUE(contains(parsed, "chans.foo-data.0.address", "tcp://0.0.0.0:6000"));
+    ASSERT_TRUE(contains(parsed, "chans.foo-data.0.type", "push"));
+    ASSERT_TRUE(contains(parsed, "chans.bar-data.0.address", "tcp://0.0.0.0:7000"));
+    ASSERT_TRUE(contains(parsed, "chans.bar-data.0.type", "pull"));
+}
+
+}   // namespace


### PR DESCRIPTION
The current syntax is ambiguous because it treats assignments
(like address=127.0.0.1) and selectors (name=my-channel) using
the symbol equal `"`.

This allows:

my-channel:address=127.0.0.1

as alternative syntax, which clearly separates the role of my-channel
from the associated properties.

Describe your proposal.

Mention any issue this PR resolves or is related to.

---

Checklist:

* [x ] Rebased against `dev` branch
* [ x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [ x] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
