### PR TITLE
Shmmonitor updates

### DIFF
--- a/fairmq/shmem/Common.h
+++ b/fairmq/shmem/Common.h
@@ -195,14 +195,19 @@ struct RegionBlock
 
 // find id for unique shmem name:
 // a hash of user id + session id, truncated to 8 characters (to accommodate for name size limit on some systems (MacOS)).
-inline std::string makeShmIdStr(const std::string& sessionId)
+inline std::string makeShmIdStr(const std::string& sessionId, const std::string& userId)
 {
-    std::string seed((std::to_string(geteuid()) + sessionId));
+    std::string seed(userId + sessionId);
     // generate a 8-digit hex value out of sha256 hash
     std::vector<unsigned char> hash(4);
     picosha2::hash256(seed.begin(), seed.end(), hash.begin(), hash.end());
 
     return picosha2::bytes_to_hex_string(hash.begin(), hash.end());
+}
+
+inline std::string makeShmIdStr(const std::string& sessionId)
+{
+    return makeShmIdStr(sessionId, std::to_string(geteuid()));
 }
 
 inline uint64_t makeShmIdUint64(const std::string& sessionId)

--- a/fairmq/shmem/Common.h
+++ b/fairmq/shmem/Common.h
@@ -91,6 +91,17 @@ struct SegmentInfo
     AllocationAlgorithm fAllocationAlgorithm;
 };
 
+struct SessionInfo
+{
+    SessionInfo(const char* sessionName, int creatorId, const VoidAlloc& alloc)
+        : fSessionName(sessionName, alloc)
+        , fCreatorId(creatorId)
+    {}
+
+    Str fSessionName;
+    int fCreatorId;
+};
+
 using Uint16SegmentInfoPairAlloc = boost::interprocess::allocator<std::pair<const uint16_t, SegmentInfo>, SegmentManager>;
 using Uint16SegmentInfoHashMap = boost::unordered_map<uint16_t, SegmentInfo, boost::hash<uint16_t>, std::equal_to<uint16_t>, Uint16SegmentInfoPairAlloc>;
 // using Uint16SegmentInfoMap = boost::interprocess::map<uint16_t, SegmentInfo, std::less<uint16_t>, Uint16SegmentInfoPairAlloc>;

--- a/fairmq/shmem/Manager.h
+++ b/fairmq/shmem/Manager.h
@@ -105,6 +105,8 @@ class Manager
             StartMonitor(fShmId);
         }
 
+        fHeartbeatThread = std::thread(&Manager::SendHeartbeats, this);
+
         {
             std::stringstream ss;
             boost::interprocess::scoped_lock<boost::interprocess::named_mutex> lock(fShmMtx);
@@ -200,8 +202,6 @@ class Manager
             fShmMsgCounters = fManagementSegment.find_or_construct<Uint16MsgCounterHashMap>(unique_instance)(fShmVoidAlloc);
 #endif
         }
-
-        fHeartbeatThread = std::thread(&Manager::SendHeartbeats, this);
     }
 
     Manager() = delete;

--- a/fairmq/shmem/Manager.h
+++ b/fairmq/shmem/Manager.h
@@ -101,6 +101,7 @@ class Manager
         }
 
         if (autolaunchMonitor) {
+            boost::interprocess::scoped_lock<boost::interprocess::named_mutex> lock(fShmMtx);
             StartMonitor(fShmId);
         }
 

--- a/fairmq/shmem/Manager.h
+++ b/fairmq/shmem/Manager.h
@@ -215,7 +215,7 @@ class Manager
             boost::filesystem::path p = boost::process::search_path("fairmq-shmmonitor", ownPath);
 
             if (!p.empty()) {
-                boost::process::spawn(p, "-x", "--shmid", id, "-d", "-t", "2000", env);
+                boost::process::spawn(p, "-x", "-m", "--shmid", id, "-d", "-t", "2000", env);
                 int numTries = 0;
                 do {
                     try {

--- a/fairmq/shmem/Manager.h
+++ b/fairmq/shmem/Manager.h
@@ -227,8 +227,15 @@ class Manager
 
             boost::filesystem::path p = boost::process::search_path("fairmq-shmmonitor", ownPath);
 
+            bool verbose = false;
+            if (const char* verboseEnv = getenv("FAIRMQ_SHMMONITOR_VERBOSE")) {
+                if (std::string(verboseEnv) == "true") {
+                    verbose = true;
+                }
+            }
+
             if (!p.empty()) {
-                boost::process::spawn(p, "-x", "-m", "--shmid", id, "-d", "-t", "2000", env);
+                boost::process::spawn(p, "-x", "-m", "--shmid", id, "-d", "-t", "2000", verbose ? "--verbose" : "", env);
                 int numTries = 0;
                 do {
                     try {

--- a/fairmq/shmem/Monitor.cxx
+++ b/fairmq/shmem/Monitor.cxx
@@ -248,7 +248,7 @@ void Monitor::CheckSegment()
     using namespace boost::interprocess;
 
     try {
-        managed_shared_memory managementSegment(open_only, fManagementSegmentName.c_str());
+        managed_shared_memory managementSegment(open_read_only, fManagementSegmentName.c_str());
         VoidAlloc allocInstance(managementSegment.get_segment_manager());
 
         Uint16SegmentInfoHashMap* segmentInfos = managementSegment.find<Uint16SegmentInfoHashMap>(unique_instance).first;
@@ -261,9 +261,9 @@ void Monitor::CheckSegment()
 
         for (const auto& s : *segmentInfos) {
             if (s.second.fAllocationAlgorithm == AllocationAlgorithm::rbtree_best_fit) {
-                segments.emplace(s.first, RBTreeBestFitSegment(open_only, std::string("fmq_" + fShmId + "_m_" + to_string(s.first)).c_str()));
+                segments.emplace(s.first, RBTreeBestFitSegment(open_read_only, std::string("fmq_" + fShmId + "_m_" + to_string(s.first)).c_str()));
             } else {
-                segments.emplace(s.first, SimpleSeqFitSegment(open_only, std::string("fmq_" + fShmId + "_m_" + to_string(s.first)).c_str()));
+                segments.emplace(s.first, SimpleSeqFitSegment(open_read_only, std::string("fmq_" + fShmId + "_m_" + to_string(s.first)).c_str()));
             }
         }
 
@@ -280,7 +280,7 @@ void Monitor::CheckSegment()
                 numDevices = dc->fCount;
             }
 #ifdef FAIRMQ_DEBUG_MODE
-            msgCounters = managementSegment.find_or_construct<Uint16MsgCounterHashMap>(unique_instance)(allocInstance);
+            msgCounters = managementSegment.find<Uint16MsgCounterHashMap>(unique_instance).first;
 #endif
         }
 
@@ -313,7 +313,7 @@ void Monitor::CheckSegment()
                 ss << "   [" << s.first
                    << "]: total: " << total
 #ifdef FAIRMQ_DEBUG_MODE
-                   << ", msgs: " << (*msgCounters)[s.first].fCount
+                   << ", msgs: " << ( (msgCounters != nullptr) ? to_string((*msgCounters)[s.first].fCount) : "unknown")
 #else
                    << ", msgs: NODEBUG"
 #endif

--- a/fairmq/shmem/Monitor.h
+++ b/fairmq/shmem/Monitor.h
@@ -85,6 +85,7 @@ class Monitor
     static std::unordered_map<uint16_t, std::vector<BufferDebugInfo>> GetDebugInfo(const SessionId& shmId);
 
     static bool PrintShm(const ShmId& shmId);
+    static void ListAll(const std::string& path);
 
     static bool RemoveObject(const std::string& name);
     static bool RemoveFileMapping(const std::string& name);

--- a/fairmq/shmem/Monitor.h
+++ b/fairmq/shmem/Monitor.h
@@ -8,6 +8,8 @@
 #ifndef FAIR_MQ_SHMEM_MONITOR_H_
 #define FAIR_MQ_SHMEM_MONITOR_H_
 
+#include <fairlogger/Logger.h>
+
 #include <thread>
 #include <chrono>
 #include <atomic>
@@ -82,6 +84,8 @@ class Monitor
     static std::unordered_map<uint16_t, std::vector<BufferDebugInfo>> GetDebugInfo(const ShmId& shmId);
     static std::unordered_map<uint16_t, std::vector<BufferDebugInfo>> GetDebugInfo(const SessionId& shmId);
 
+    static bool PrintShm(const ShmId& shmId);
+
     static bool RemoveObject(const std::string& name);
     static bool RemoveFileMapping(const std::string& name);
     static bool RemoveQueue(const std::string& name);
@@ -92,7 +96,8 @@ class Monitor
 
   private:
     void PrintHelp();
-    void MonitorHeartbeats();
+    void Watch();
+    void ReceiveHeartbeats();
     void CheckSegment();
     void Interactive();
     void SignalMonitor();
@@ -106,8 +111,6 @@ class Monitor
     unsigned int fTimeoutInMS;
     unsigned int fIntervalInMS;
     std::string fShmId;
-    std::string fSegmentName;
-    std::string fManagementSegmentName;
     std::string fControlQueueName;
     std::atomic<bool> fTerminating;
     std::atomic<bool> fHeartbeatTriggered;

--- a/fairmq/shmem/Monitor.h
+++ b/fairmq/shmem/Monitor.h
@@ -100,7 +100,7 @@ class Monitor
     bool fSelfDestruct; // will self-destruct after the memory has been closed
     bool fInteractive; // running in interactive mode
     bool fViewOnly; // view only mode
-    bool fIsDaemon;
+    bool fMonitor;
     bool fSeenOnce; // true is segment has been opened successfully at least once
     bool fCleanOnExit;
     unsigned int fTimeoutInMS;

--- a/fairmq/shmem/TransportFactory.h
+++ b/fairmq/shmem/TransportFactory.h
@@ -68,9 +68,6 @@ class TransportFactory final : public fair::mq::TransportFactory
             throw SharedMemoryError(tools::ToString("Provided shared memory allocation algorithm '", allocationAlgorithm, "' is not supported. Supported are 'rbtree_best_fit'/'simple_seq_fit'"));
         }
 
-        std::string shmId = makeShmIdStr(sessionName);
-        LOG(debug) << "Generated shmid '" << shmId << "' out of session id '" << sessionName << "'.";
-
         try {
             if (zmq_ctx_set(fZmqCtx, ZMQ_IO_THREADS, numIoThreads) != 0) {
                 LOG(error) << "failed configuring context, reason: " << zmq_strerror(errno);
@@ -81,7 +78,7 @@ class TransportFactory final : public fair::mq::TransportFactory
                 LOG(error) << "failed configuring context, reason: " << zmq_strerror(errno);
             }
 
-            fManager = std::make_unique<Manager>(shmId, deviceId, segmentSize, config);
+            fManager = std::make_unique<Manager>(sessionName, deviceId, segmentSize, config);
         } catch (boost::interprocess::interprocess_exception& e) {
             LOG(error) << "Could not initialize shared memory transport: " << e.what();
             throw std::runtime_error(tools::ToString("Could not initialize shared memory transport: ", e.what()));

--- a/fairmq/shmem/runMonitor.cxx
+++ b/fairmq/shmem/runMonitor.cxx
@@ -86,6 +86,7 @@ int main(int argc, char** argv)
         bool debug = false;
         bool cleanOnExit = false;
         bool getShmId = false;
+        bool verbose = false;
         int userId = -1;
 
         options_description desc("Options");
@@ -103,6 +104,7 @@ int main(int argc, char** argv)
             ("clean-on-exit,e", value<bool>(&cleanOnExit)->implicit_value(true),        "Perform cleanup on exit")
             ("interval"       , value<unsigned int>(&intervalInMS)->default_value(100), "Output interval for interactive mode")
             ("get-shmid"      , value<bool>(&getShmId)->implicit_value(true),           "Translate given session id and user id to a shmem id (uses current user id if none provided)")
+            ("verbose"        , value<bool>(&verbose)->implicit_value(true),            "Verbose mode (daemon will output to a file 'fairmq-shmmonitor_log_<timestamp>')")
             ("user-id"        , value<int>(&userId)->default_value(-1),                 "User id (used with --get-shmid)")
             ("help,h",                                                                  "Print help");
 
@@ -117,6 +119,9 @@ int main(int argc, char** argv)
         notify(vm);
 
         if (runAsDaemon) {
+            if (verbose) {
+                fair::Logger::InitFileSink("trace", "fairmq-shmmonitor_log");
+            }
             daemonize();
         }
 

--- a/fairmq/shmem/runMonitor.cxx
+++ b/fairmq/shmem/runMonitor.cxx
@@ -80,6 +80,8 @@ int main(int argc, char** argv)
         bool runAsDaemon = false;
         bool debug = false;
         bool cleanOnExit = false;
+        bool getShmId = false;
+        int userId = -1;
 
         options_description desc("Options");
         desc.add_options()
@@ -91,9 +93,11 @@ int main(int argc, char** argv)
             ("view,v"         , value<bool>(&viewOnly)->implicit_value(true),           "Run in view only mode")
             ("timeout,t"      , value<unsigned int>(&timeoutInMS)->default_value(5000), "Heartbeat timeout in milliseconds")
             ("daemonize,d"    , value<bool>(&runAsDaemon)->implicit_value(true),        "Daemonize the monitor")
-            ("debug,b"        , value<bool>(&debug)->implicit_value(true),             "Debug - Print a list of messages)")
+            ("debug,b"        , value<bool>(&debug)->implicit_value(true),              "Debug - Print a list of messages)")
             ("clean-on-exit,e", value<bool>(&cleanOnExit)->implicit_value(true),        "Perform cleanup on exit")
             ("interval"       , value<unsigned int>(&intervalInMS)->default_value(100), "Output interval for interactive/view-only mode")
+            ("get-shmid"      , value<bool>(&getShmId)->implicit_value(true),           "Translate given session id and user id to a shmem id (uses current user id if none provided)")
+            ("user-id"        , value<int>(&userId)->default_value(-1),                  "User id")
             ("help,h", "Print help");
 
         variables_map vm;
@@ -110,7 +114,18 @@ int main(int argc, char** argv)
             daemonize();
         }
 
-        if (shmId == "") {
+        if (getShmId) {
+            if (userId == -1) {
+                cout << "shmem id for session '" << sessionName << "' and current user id " << geteuid()
+                     << " is: " << makeShmIdStr(sessionName) << endl;
+            } else {
+                cout << "shmem id for session '" << sessionName << "' and user id " << userId
+                     << " is: " << makeShmIdStr(sessionName, to_string(userId)) << endl;
+            }
+            return 0;
+        }
+
+        if (shmId.empty()) {
             shmId = makeShmIdStr(sessionName);
         }
 

--- a/fairmq/shmem/runMonitor.cxx
+++ b/fairmq/shmem/runMonitor.cxx
@@ -100,15 +100,15 @@ int main(int argc, char** argv)
             ("interactive,i"  , value<bool>(&interactive)->implicit_value(true),        "Interactive run")
             ("view,v"         , value<bool>(&viewOnly)->implicit_value(true),           "Run in view only mode")
             ("timeout,t"      , value<unsigned int>(&timeoutInMS)->default_value(5000), "Heartbeat timeout in milliseconds")
-            ("daemonize,d"    , value<bool>(&runAsDaemon)->implicit_value(true),        "Daemonize the monitor")
+            ("daemonize,d"    , value<bool>(&runAsDaemon)->implicit_value(true),        "Daemonize the monitor process (only in monitoring mode)")
             ("monitor,m"      , value<bool>(&monitor)->implicit_value(true),            "Run in monitoring mode")
             ("debug,b"        , value<bool>(&debug)->implicit_value(true),              "Debug - Print a list of messages)")
             ("clean-on-exit,e", value<bool>(&cleanOnExit)->implicit_value(true),        "Perform cleanup on exit")
-            ("interval"       , value<unsigned int>(&intervalInMS)->default_value(100), "Output interval for interactive mode")
+            ("interval"       , value<unsigned int>(&intervalInMS)->default_value(1000),"Output interval for interactive mode")
             ("get-shmid"      , value<bool>(&getShmId)->implicit_value(true),           "Translate given session id and user id to a shmem id (uses current user id if none provided)")
             ("list-all"       , value<bool>(&listAll)->implicit_value(true),            "List all sessions & segments")
             ("list-all-path"  , value<string>(&listAllPath)->default_value("/dev/shm/"),"Path for the --list-all command to search segments in")
-            ("verbose"        , value<bool>(&verbose)->implicit_value(true),            "Verbose mode (daemon will output to a file 'fairmq-shmmonitor_log_<timestamp>')")
+            ("verbose"        , value<bool>(&verbose)->implicit_value(true),            "Verbose mode (daemon will output to a file 'fairmq-shmmonitor_<timestamp>')")
             ("user-id"        , value<int>(&userId)->default_value(-1),                 "User id (used with --get-shmid)")
             ("help,h",                                                                  "Print help");
 
@@ -121,13 +121,6 @@ int main(int argc, char** argv)
         }
 
         notify(vm);
-
-        if (runAsDaemon) {
-            if (verbose) {
-                fair::Logger::InitFileSink("trace", "fairmq-shmmonitor_log");
-            }
-            daemonize();
-        }
 
         if (getShmId) {
             if (userId == -1) {
@@ -169,6 +162,13 @@ int main(int argc, char** argv)
                 LOG(info) << "No segments found.";
             }
             return 0;
+        }
+
+        if (runAsDaemon && monitor) {
+            if (verbose) {
+                fair::Logger::InitFileSink("trace", "fairmq-shmmonitor");
+            }
+            daemonize();
         }
 
         LOG(info) << "Starting shared memory monitor for session: \"" << sessionName << "\" (shm id: " << shmId << ")...";

--- a/fairmq/shmem/runMonitor.cxx
+++ b/fairmq/shmem/runMonitor.cxx
@@ -86,6 +86,8 @@ int main(int argc, char** argv)
         bool debug = false;
         bool cleanOnExit = false;
         bool getShmId = false;
+        bool listAll = false;
+        string listAllPath;
         bool verbose = false;
         int userId = -1;
 
@@ -104,6 +106,8 @@ int main(int argc, char** argv)
             ("clean-on-exit,e", value<bool>(&cleanOnExit)->implicit_value(true),        "Perform cleanup on exit")
             ("interval"       , value<unsigned int>(&intervalInMS)->default_value(100), "Output interval for interactive mode")
             ("get-shmid"      , value<bool>(&getShmId)->implicit_value(true),           "Translate given session id and user id to a shmem id (uses current user id if none provided)")
+            ("list-all"       , value<bool>(&listAll)->implicit_value(true),            "List all sessions & segments")
+            ("list-all-path"  , value<string>(&listAllPath)->default_value("/dev/shm/"),"Path for the --list-all command to search segments in")
             ("verbose"        , value<bool>(&verbose)->implicit_value(true),            "Verbose mode (daemon will output to a file 'fairmq-shmmonitor_log_<timestamp>')")
             ("user-id"        , value<int>(&userId)->default_value(-1),                 "User id (used with --get-shmid)")
             ("help,h",                                                                  "Print help");
@@ -147,6 +151,11 @@ int main(int argc, char** argv)
 
         if (debug) {
             Monitor::PrintDebugInfo(ShmId{shmId});
+            return 0;
+        }
+
+        if (listAll) {
+            Monitor::ListAll(listAllPath);
             return 0;
         }
 

--- a/fairmq/shmem/runMonitor.cxx
+++ b/fairmq/shmem/runMonitor.cxx
@@ -104,13 +104,13 @@ int main(int argc, char** argv)
             ("interval"       , value<unsigned int>(&intervalInMS)->default_value(100), "Output interval for interactive mode")
             ("get-shmid"      , value<bool>(&getShmId)->implicit_value(true),           "Translate given session id and user id to a shmem id (uses current user id if none provided)")
             ("user-id"        , value<int>(&userId)->default_value(-1),                 "User id (used with --get-shmid)")
-            ("help,h", "Print help");
+            ("help,h",                                                                  "Print help");
 
         variables_map vm;
         store(parse_command_line(argc, argv, desc), vm);
 
         if (vm.count("help")) {
-            cout << "FairMQ Shared Memory Monitor" << endl << desc << endl;
+            LOG(info) << "FairMQ Shared Memory Monitor" << "\n" << desc;
             return 0;
         }
 
@@ -122,11 +122,11 @@ int main(int argc, char** argv)
 
         if (getShmId) {
             if (userId == -1) {
-                cout << "shmem id for session '" << sessionName << "' and current user id " << geteuid()
-                     << " is: " << makeShmIdStr(sessionName) << endl;
+                LOG(info) << "shmem id for session '" << sessionName << "' and current user id " << geteuid()
+                          << " is: " << makeShmIdStr(sessionName);
             } else {
-                cout << "shmem id for session '" << sessionName << "' and user id " << userId
-                     << " is: " << makeShmIdStr(sessionName, to_string(userId)) << endl;
+                LOG(info) << "shmem id for session '" << sessionName << "' and user id " << userId
+                          << " is: " << makeShmIdStr(sessionName, to_string(userId));
             }
             return 0;
         }
@@ -152,12 +152,12 @@ int main(int argc, char** argv)
 
         if (viewOnly && !interactive) {
             if (!Monitor::PrintShm(ShmId{shmId})) {
-                cout << "No segments found." << endl;
+                LOG(info) << "No segments found.";
             }
             return 0;
         }
 
-        cout << "Starting shared memory monitor for session: \"" << sessionName << "\" (shm id: " << shmId << ")..." << endl;
+        LOG(info) << "Starting shared memory monitor for session: \"" << sessionName << "\" (shm id: " << shmId << ")...";
 
         Monitor shmmonitor(shmId, selfDestruct, interactive, viewOnly, timeoutInMS, intervalInMS, monitor, cleanOnExit);
         shmmonitor.CatchSignals();
@@ -165,7 +165,7 @@ int main(int argc, char** argv)
     } catch (Monitor::DaemonPresent& dp) {
         return 0;
     } catch (exception& e) {
-        cerr << "Unhandled Exception reached the top of main: " << e.what() << ", application will now exit" << endl;
+        LOG(error) << "Unhandled Exception reached the top of main: " << e.what() << ", application will now exit";
         return 2;
     }
 

--- a/fairmq/tools/Strings.h
+++ b/fairmq/tools/Strings.h
@@ -39,6 +39,24 @@ inline auto ToStrVector(const int argc, char*const* argv, const bool dropProgram
     }
 }
 
+inline bool StrStartsWith(std::string const& str, std::string const& start)
+{
+    if (str.length() >= start.length()) {
+        return (0 == str.compare(0, start.length(), start));
+    } else {
+        return false;
+    }
+}
+
+inline bool StrEndsWith(std::string const& str, std::string const& end)
+{
+    if (str.length() >= end.length()) {
+        return (0 == str.compare(str.length() - end.length(), end.length(), end));
+    } else {
+        return false;
+    }
+}
+
 } // namespace fair::mq::tools
 
 #endif /* FAIR_MQ_TOOLS_STRINGS_H */


### PR DESCRIPTION
- shmmonitor: update docs.
- shmmonitor: add --list-all.
- Add tools: StrStartsWith, StrEndsWith.
- shm: reduce delay between monitor daemon launch & HBs.
- shmmonitor: daemon output to file if FAIRMQ_SHMMONITOR_VERBOSE is true.
- shmmonitor: use fairlogger.
- shmmonitor: refactor to separate monitoring from output.
- shmmonitor: optimize startup to avoid repeated start.
- shmmonitor: add session name and creator id to the output.
- shmmonitor: enable read only access.
- shmmonitor: distinguish daemon from monitor mode (orthogonal).
- shmmonitor: allow getting shmids based on session/userid.
