### PR TITLE
Improve Events API

### DIFF
--- a/fairmq/FairMQSocket.h
+++ b/fairmq/FairMQSocket.h
@@ -56,7 +56,7 @@ class FairMQSocket
     /// If the backend supports it, fills the unsigned integer @a events with the ZMQ_EVENTS value
     /// DISCLAIMER: this API is experimental and unsupported and might be dropped / refactored in
     /// the future.
-    virtual void Events(uint32_t* events) = 0;
+    virtual int Events(uint32_t* events) = 0;
     virtual void SetLinger(const int value) = 0;
     virtual int GetLinger() const = 0;
     virtual void SetSndBufSize(const int value) = 0;

--- a/fairmq/shmem/Socket.h
+++ b/fairmq/shmem/Socket.h
@@ -378,12 +378,10 @@ class Socket final : public fair::mq::Socket
         }
     }
 
-    void Events(uint32_t* events) override
+    int Events(uint32_t* events) override
     {
         size_t eventsSize = sizeof(uint32_t);
-        if (zmq_getsockopt(fSocket, ZMQ_EVENTS, events, &eventsSize) < 0) {
-            throw SocketError(tools::ToString("failed setting ZMQ_EVENTS, reason: ", zmq_strerror(errno)));
-        }
+        return zmq_getsockopt(fSocket, ZMQ_EVENTS, events, &eventsSize);
     }
 
     int GetLinger() const override

--- a/fairmq/zeromq/Socket.h
+++ b/fairmq/zeromq/Socket.h
@@ -323,12 +323,10 @@ class Socket final : public fair::mq::Socket
         }
     }
 
-    void Events(uint32_t* events) override
+    int Events(uint32_t* events) override
     {
         size_t eventsSize = sizeof(uint32_t);
-        if (zmq_getsockopt(fSocket, ZMQ_EVENTS, events, &eventsSize) < 0) {
-            throw SocketError(tools::ToString("failed setting ZMQ_EVENTS, reason: ", zmq_strerror(errno)));
-        }
+        return zmq_getsockopt(fSocket, ZMQ_EVENTS, events, &eventsSize);
     }
 
     void SetLinger(const int value) override


### PR DESCRIPTION
If the call is interrupted by a signal, this will throw, which we clearly do not want. Simplifying the API to let the user decide what to do on error is probably the best option.

See also https://alice.its.cern.ch/jira/browse/O2-2257.

---