### PR TITLE
shmem fixes and improvements, misc

### DIFF
--- a/examples/region/Sampler.cxx
+++ b/examples/region/Sampler.cxx
@@ -37,8 +37,8 @@ void Sampler::InitTask()
     fMaxIterations = fConfig->GetProperty<uint64_t>("max-iterations");
 
     fChannels.at("data").at(0).Transport()->SubscribeToRegionEvents([](FairMQRegionInfo info) {
-        LOG(info) << "Region event: " << info.event
-                  << ", managed: " << info.managed
+        LOG(info) << "Region event: " << info.event << ": "
+                  << (info.managed ? "managed" : "unmanaged")
                   << ", id: " << info.id
                   << ", ptr: " << info.ptr
                   << ", size: " << info.size

--- a/examples/region/Sampler.cxx
+++ b/examples/region/Sampler.cxx
@@ -5,12 +5,6 @@
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
  *                  copied verbatim in the file "LICENSE"                       *
  ********************************************************************************/
-/**
- * Sampler.cpp
- *
- * @since 2014-10-10
- * @author A. Rybalchenko
- */
 
 #include "Sampler.h"
 
@@ -75,20 +69,19 @@ bool Sampler::ConditionalRun()
     // std::this_thread::sleep_for(std::chrono::seconds(1));
 
     lock_guard<mutex> lock(fMtx);
+    ++fNumUnackedMsgs;
     if (Send(msg, "data", 0) > 0) {
         if (fMaxIterations > 0 && ++fNumIterations >= fMaxIterations) {
             LOG(info) << "Configured maximum number of iterations reached. Leaving RUNNING state.";
             return false;
         }
     }
-    ++fNumUnackedMsgs;
 
     return true;
 }
 
 void Sampler::ResetTask()
 {
-    // On destruction UnmanagedRegion will try to TODO
     fRegion.reset();
     {
         lock_guard<mutex> lock(fMtx);

--- a/examples/region/Sink.cxx
+++ b/examples/region/Sink.cxx
@@ -30,8 +30,8 @@ void Sink::InitTask()
     // Get the fMaxIterations value from the command line options (via fConfig)
     fMaxIterations = fConfig->GetProperty<uint64_t>("max-iterations");
     fChannels.at("data").at(0).Transport()->SubscribeToRegionEvents([](FairMQRegionInfo info) {
-        LOG(info) << "Region event: " << info.event
-                  << ", managed: " << info.managed
+        LOG(info) << "Region event: " << info.event << ": "
+                  << (info.managed ? "managed" : "unmanaged")
                   << ", id: " << info.id
                   << ", ptr: " << info.ptr
                   << ", size: " << info.size

--- a/examples/region/fairmq-start-ex-region.sh.in
+++ b/examples/region/fairmq-start-ex-region.sh.in
@@ -15,11 +15,11 @@ SAMPLER+=" --msg-size $msgSize"
 # SAMPLER+=" --rate 10"
 SAMPLER+=" --transport shmem"
 SAMPLER+=" --channel-config name=data,type=push,method=bind,address=tcp://127.0.0.1:7777,sndKernelSize=212992"
-xterm -geometry 80x23+0+0 -hold -e @EX_BIN_DIR@/$SAMPLER &
+xterm -geometry 120x60+0+0 -hold -e @EX_BIN_DIR@/$SAMPLER &
 
 SINK="fairmq-ex-region-sink"
 SINK+=" --id sink1"
 SINK+=" --severity debug"
 SINK+=" --transport shmem"
 SINK+=" --channel-config name=data,type=pull,method=connect,address=tcp://127.0.0.1:7777,rcvKernelSize=212992"
-xterm -geometry 80x23+500+0 -hold -e @EX_BIN_DIR@/$SINK &
+xterm -geometry 120x60+750+0 -hold -e @EX_BIN_DIR@/$SINK &

--- a/examples/region/fairmq-start-ex-region.sh.in
+++ b/examples/region/fairmq-start-ex-region.sh.in
@@ -2,9 +2,14 @@
 
 export FAIRMQ_PATH=@FAIRMQ_BIN_DIR@
 
+transport="shmem"
 msgSize="1000000"
 
-if [[ $1 =~ ^[0-9]+$ ]]; then
+if [[ $1 =~ ^[a-z]+$ ]]; then
+    transport=$1
+fi
+
+if [[ $2 =~ ^[0-9]+$ ]]; then
     msgSize=$1
 fi
 
@@ -13,13 +18,13 @@ SAMPLER+=" --id sampler1"
 SAMPLER+=" --severity debug"
 SAMPLER+=" --msg-size $msgSize"
 # SAMPLER+=" --rate 10"
-SAMPLER+=" --transport shmem"
+SAMPLER+=" --transport $transport"
 SAMPLER+=" --channel-config name=data,type=push,method=bind,address=tcp://127.0.0.1:7777,sndKernelSize=212992"
 xterm -geometry 120x60+0+0 -hold -e @EX_BIN_DIR@/$SAMPLER &
 
 SINK="fairmq-ex-region-sink"
 SINK+=" --id sink1"
 SINK+=" --severity debug"
-SINK+=" --transport shmem"
+SINK+=" --transport $transport"
 SINK+=" --channel-config name=data,type=pull,method=connect,address=tcp://127.0.0.1:7777,rcvKernelSize=212992"
 xterm -geometry 120x60+750+0 -hold -e @EX_BIN_DIR@/$SINK &

--- a/examples/region/test-ex-region.sh.in
+++ b/examples/region/test-ex-region.sh.in
@@ -31,6 +31,7 @@ SAMPLER_PID=$!
 SINK="fairmq-ex-region-sink"
 SINK+=" --id sink1"
 SINK+=" --transport $transport"
+SINK+=" --severity debug"
 SINK+=" --session $SESSION"
 SINK+=" --verbosity veryhigh"
 SINK+=" --control static --color false"

--- a/fairmq/FairMQTransportFactory.h
+++ b/fairmq/FairMQTransportFactory.h
@@ -92,8 +92,8 @@ class FairMQTransportFactory
     /// @param path optional parameter to pass to the underlying transport
     /// @param flags optional parameter to pass to the underlying transport
     /// @return pointer to UnmanagedRegion
-    virtual FairMQUnmanagedRegionPtr CreateUnmanagedRegion(const size_t size, FairMQRegionCallback callback = nullptr, const std::string& path = "", int flags = 0) = 0;
-    virtual FairMQUnmanagedRegionPtr CreateUnmanagedRegion(const size_t size, FairMQRegionBulkCallback callback = nullptr, const std::string& path = "", int flags = 0) = 0;
+    virtual FairMQUnmanagedRegionPtr CreateUnmanagedRegion(const size_t size, FairMQRegionCallback callback = nullptr, const std::string& path = "", int flags = 0, fair::mq::RegionConfig cfg = fair::mq::RegionConfig()) = 0;
+    virtual FairMQUnmanagedRegionPtr CreateUnmanagedRegion(const size_t size, FairMQRegionBulkCallback callback = nullptr, const std::string& path = "", int flags = 0, fair::mq::RegionConfig cfg = fair::mq::RegionConfig()) = 0;
     /// @brief Create new UnmanagedRegion
     /// @param size size of the region
     /// @param userFlags flags to be stored with the region, have no effect on the transport, but can be retrieved from the region by the user
@@ -101,8 +101,8 @@ class FairMQTransportFactory
     /// @param path optional parameter to pass to the underlying transport
     /// @param flags optional parameter to pass to the underlying transport
     /// @return pointer to UnmanagedRegion
-    virtual FairMQUnmanagedRegionPtr CreateUnmanagedRegion(const size_t size, const int64_t userFlags, FairMQRegionCallback callback = nullptr, const std::string& path = "", int flags = 0) = 0;
-    virtual FairMQUnmanagedRegionPtr CreateUnmanagedRegion(const size_t size, const int64_t userFlags, FairMQRegionBulkCallback callback = nullptr, const std::string& path = "", int flags = 0) = 0;
+    virtual FairMQUnmanagedRegionPtr CreateUnmanagedRegion(const size_t size, const int64_t userFlags, FairMQRegionCallback callback = nullptr, const std::string& path = "", int flags = 0, fair::mq::RegionConfig cfg = fair::mq::RegionConfig()) = 0;
+    virtual FairMQUnmanagedRegionPtr CreateUnmanagedRegion(const size_t size, const int64_t userFlags, FairMQRegionBulkCallback callback = nullptr, const std::string& path = "", int flags = 0, fair::mq::RegionConfig cfg = fair::mq::RegionConfig()) = 0;
 
     /// @brief Subscribe to region events (creation, destruction, ...)
     /// @param callback the callback that is called when a region event occurs

--- a/fairmq/FairMQUnmanagedRegion.h
+++ b/fairmq/FairMQUnmanagedRegion.h
@@ -108,6 +108,19 @@ inline std::ostream& operator<<(std::ostream& os, const FairMQRegionEvent& event
 namespace fair::mq
 {
 
+struct RegionConfig {
+    bool lock;
+    bool zero;
+
+    RegionConfig()
+        : lock(false), zero(false)
+    {}
+
+    RegionConfig(bool l, bool z)
+        : lock(l), zero(z)
+    {}
+};
+
 using RegionCallback = FairMQRegionCallback;
 using RegionBulkCallback = FairMQRegionBulkCallback;
 using RegionEventCallback = FairMQRegionEventCallback;

--- a/fairmq/FairMQUnmanagedRegion.h
+++ b/fairmq/FairMQUnmanagedRegion.h
@@ -79,6 +79,7 @@ class FairMQUnmanagedRegion
     virtual void SetLinger(uint32_t linger) = 0;
     virtual uint32_t GetLinger() const = 0;
 
+    virtual fair::mq::Transport GetType() const = 0;
     FairMQTransportFactory* GetTransport() { return fTransport; }
     void SetTransport(FairMQTransportFactory* transport) { fTransport = transport; }
 

--- a/fairmq/Transports.h
+++ b/fairmq/Transports.h
@@ -12,6 +12,7 @@
 #include <fairmq/tools/Strings.h>
 
 #include <memory>
+#include <ostream>
 #include <stdexcept>
 #include <string>
 #include <unordered_map>
@@ -58,6 +59,11 @@ try {
     return TransportTypes.at(transport);
 } catch (std::out_of_range&) {
     throw TransportError(tools::ToString("Unknown transport provided: ", transport));
+}
+
+inline std::ostream& operator<<(std::ostream& os, const Transport& transport)
+{
+    return os << TransportName(transport);
 }
 
 } // namespace fair::mq

--- a/fairmq/ofi/Socket.h
+++ b/fairmq/ofi/Socket.h
@@ -41,7 +41,7 @@ class Socket final : public fair::mq::Socket
 
     auto GetId() const -> std::string override { return fId; }
 
-    auto Events(uint32_t *events) -> void override { *events = 0; }
+    auto Events(uint32_t *events) -> int override { *events = 0; }
     auto Bind(const std::string& address) -> bool override;
     auto Connect(const std::string& address) -> bool override;
 

--- a/fairmq/ofi/TransportFactory.cxx
+++ b/fairmq/ofi/TransportFactory.cxx
@@ -92,22 +92,22 @@ auto TransportFactory::CreatePoller(const unordered_map<string, vector<FairMQCha
     // return PollerPtr{new Poller(channelsMap, channelList)};
 }
 
-auto TransportFactory::CreateUnmanagedRegion(const size_t /*size*/, FairMQRegionCallback /*callback*/, const std::string& /* path = "" */, int /* flags = 0 */) -> UnmanagedRegionPtr
+auto TransportFactory::CreateUnmanagedRegion(const size_t /*size*/, FairMQRegionCallback /*callback*/, const std::string& /* path = "" */, int /* flags = 0 */, fair::mq::RegionConfig /* cfg = fair::mq::RegionConfig() */) -> UnmanagedRegionPtr
 {
     throw runtime_error{"Not yet implemented UMR."};
 }
 
-auto TransportFactory::CreateUnmanagedRegion(const size_t /*size*/, FairMQRegionBulkCallback /*callback*/, const std::string& /* path = "" */, int /* flags = 0 */) -> UnmanagedRegionPtr
+auto TransportFactory::CreateUnmanagedRegion(const size_t /*size*/, FairMQRegionBulkCallback /*callback*/, const std::string& /* path = "" */, int /* flags = 0 */, fair::mq::RegionConfig /* cfg = fair::mq::RegionConfig() */) -> UnmanagedRegionPtr
 {
     throw runtime_error{"Not yet implemented UMR."};
 }
 
-auto TransportFactory::CreateUnmanagedRegion(const size_t /*size*/, const int64_t /*userFlags*/, FairMQRegionCallback /*callback*/, const std::string& /* path = "" */, int /* flags = 0 */) -> UnmanagedRegionPtr
+auto TransportFactory::CreateUnmanagedRegion(const size_t /*size*/, const int64_t /*userFlags*/, FairMQRegionCallback /*callback*/, const std::string& /* path = "" */, int /* flags = 0 */, fair::mq::RegionConfig /* cfg = fair::mq::RegionConfig() */) -> UnmanagedRegionPtr
 {
     throw runtime_error{"Not yet implemented UMR."};
 }
 
-auto TransportFactory::CreateUnmanagedRegion(const size_t /*size*/, const int64_t /*userFlags*/, FairMQRegionBulkCallback /*callback*/, const std::string& /* path = "" */, int /* flags = 0 */) -> UnmanagedRegionPtr
+auto TransportFactory::CreateUnmanagedRegion(const size_t /*size*/, const int64_t /*userFlags*/, FairMQRegionBulkCallback /*callback*/, const std::string& /* path = "" */, int /* flags = 0 */, fair::mq::RegionConfig /* cfg = fair::mq::RegionConfig() */) -> UnmanagedRegionPtr
 {
     throw runtime_error{"Not yet implemented UMR."};
 }

--- a/fairmq/shmem/Manager.h
+++ b/fairmq/shmem/Manager.h
@@ -410,7 +410,7 @@ class Manager
             }
             fRegionEventsShmCV.notify_all();
         } catch(std::out_of_range& oor) {
-            LOG(debug) << "RemoveRegion() could not locate region with id'" << id << "'";
+            LOG(debug) << "RemoveRegion() could not locate region with id '" << id << "'";
         }
         fRegionsGen += 1; // signal TL cache invalidation
     }

--- a/fairmq/shmem/Manager.h
+++ b/fairmq/shmem/Manager.h
@@ -238,7 +238,7 @@ class Manager
             }
 
             if (!p.empty()) {
-                boost::process::spawn(p, "-x", "-m", "--shmid", id, "-d", "-t", "2000", verbose ? "--verbose" : "", env);
+                boost::process::spawn(p, "-x", "-m", "--shmid", id, "-d", "-t", "2000", (verbose ? "--verbose" : ""), env);
                 int numTries = 0;
                 do {
                     try {

--- a/fairmq/shmem/Message.h
+++ b/fairmq/shmem/Message.h
@@ -309,6 +309,8 @@ class Message final : public fair::mq::Message
                 }
 
                 if (fRegionPtr) {
+                    fRegionPtr->InitializeQueues();
+                    fRegionPtr->StartSendingAcks();
                     fRegionPtr->ReleaseBlock({fMeta.fHandle, fMeta.fSize, fMeta.fHint});
                 } else {
                     LOG(warn) << "region ack queue for id " << fMeta.fRegionId << " no longer exist. Not sending ack";
@@ -324,7 +326,7 @@ class Message final : public fair::mq::Message
         Deallocate();
         fAlignment = 0;
 
-        fManager.DecrementMsgCounter(); // TODO: put this to debug mode
+        fManager.DecrementMsgCounter();
     }
 };
 

--- a/fairmq/shmem/Monitor.cxx
+++ b/fairmq/shmem/Monitor.cxx
@@ -497,7 +497,7 @@ std::pair<std::string, bool> RunRemoval(std::function<bool(const std::string&)> 
         return {name, true};
     } else {
         if (verbose) {
-            LOG(info) << "Did not remove '" << name << "'. Already removed?";
+            LOG(debug) << "Did not remove '" << name << "'. Already removed?";
         }
         return {name, false};
     }
@@ -525,7 +525,7 @@ std::vector<std::pair<std::string, bool>> Monitor::Cleanup(const ShmId& shmId, b
             RegionCounter* rc = managementSegment.find<RegionCounter>(bipc::unique_instance).first;
             if (rc) {
                 if (verbose) {
-                    LOG(info) << "Region counter found: " << rc->fCount;
+                    LOG(debug) << "Region counter found: " << rc->fCount;
                 }
                 uint16_t regionCount = rc->fCount;
 

--- a/fairmq/shmem/README.md
+++ b/fairmq/shmem/README.md
@@ -1,4 +1,4 @@
-# Shared Memory transport
+## Shared Memory transport
 
 Shared memory transport for FairMQ. To try with existing devices, run the devices with `--transport shmem` option or configure channel transport in JSON (see examples/MQ/multiple-transports).
 
@@ -6,7 +6,7 @@ The transport manages shared memory via boost::interprocess library. The transfe
 
 Devices track and cleanup shared memory on shutdown. For more information on the current shared memory segment and additional cleanup options, see following section.
 
-# Shared Memory objects / files
+## Shared Memory objects / files
 
 FairMQ Shared Memory currently uses the following names to register shared memory on the system:
 
@@ -53,3 +53,7 @@ Additional cmd options:
 For full option details, run with `-h`.
 
 The Monitor class can also be used independently from the supplied executable, allowing integration on any level.
+
+## Troubleshooting
+
+Bus Error (SIGBUS) can occur if the transport tries to access shared memory that is not accessible. One reason could be because the used memory in the segment exceeds the capacity or available memory of the shmem filesystem (capacity is by default set to half of RAM on Linux).

--- a/fairmq/shmem/Region.h
+++ b/fairmq/shmem/Region.h
@@ -106,7 +106,7 @@ struct Region
 
         InitializeQueues();
         StartSendingAcks();
-        LOG(debug) << "shmem: initialized region: " << fName;
+        LOG(trace) << "shmem: initialized region: " << fName << " (" << (fRemote ? "remote" : "local") << ")";
     }
 
     Region() = delete;
@@ -123,7 +123,7 @@ struct Region
         } else {
             fQueue = std::make_unique<message_queue>(create_only, fQueueName.c_str(), 1024, fAckBunchSize * sizeof(RegionBlock));
         }
-        LOG(debug) << "shmem: initialized region queue: " << fQueueName;
+        LOG(trace) << "shmem: initialized region queue: " << fQueueName << " (" << (fRemote ? "remote" : "local") << ")";
     }
 
     void StartSendingAcks() { fAcksSender = std::thread(&Region::SendAcks, this); }
@@ -238,11 +238,11 @@ struct Region
             }
 
             if (boost::interprocess::shared_memory_object::remove(fName.c_str())) {
-                LOG(debug) << "Region '" << fName << "' destroyed.";
+                LOG(trace) << "Region '" << fName << "' destroyed.";
             }
 
             if (boost::interprocess::file_mapping::remove(fName.c_str())) {
-                LOG(debug) << "File mapping '" << fName << "' destroyed.";
+                LOG(trace) << "File mapping '" << fName << "' destroyed.";
             }
 
             if (fFile) {
@@ -250,14 +250,13 @@ struct Region
             }
 
             if (boost::interprocess::message_queue::remove(fQueueName.c_str())) {
-                LOG(debug) << "Region queue '" << fQueueName << "' destroyed.";
+                LOG(trace) << "Region queue '" << fQueueName << "' destroyed.";
             }
         } else {
-            // LOG(debug) << "shmem: region '" << fName << "' is remote, no cleanup necessary.";
-            LOG(debug) << "Region queue '" << fQueueName << "' is remote, no cleanup necessary";
+            // LOG(debug) << "Region queue '" << fQueueName << "' is remote, no cleanup necessary";
         }
 
-        LOG(debug) << "Region '" << fName << "' (" << (fRemote ? "remote" : "local") << ") destructed.";
+        // LOG(debug) << "Region '" << fName << "' (" << (fRemote ? "remote" : "local") << ") destructed.";
     }
 
     bool fRemote;

--- a/fairmq/shmem/TransportFactory.h
+++ b/fairmq/shmem/TransportFactory.h
@@ -141,29 +141,29 @@ class TransportFactory final : public fair::mq::TransportFactory
         return std::make_unique<Poller>(channelsMap, channelList);
     }
 
-    UnmanagedRegionPtr CreateUnmanagedRegion(const size_t size, RegionCallback callback = nullptr, const std::string& path = "", int flags = 0) override
+    UnmanagedRegionPtr CreateUnmanagedRegion(const size_t size, RegionCallback callback = nullptr, const std::string& path = "", int flags = 0, fair::mq::RegionConfig cfg = fair::mq::RegionConfig()) override
     {
-        return CreateUnmanagedRegion(size, 0, callback, nullptr, path, flags);
+        return CreateUnmanagedRegion(size, 0, callback, nullptr, path, flags, cfg);
     }
 
-    UnmanagedRegionPtr CreateUnmanagedRegion(const size_t size, RegionBulkCallback bulkCallback = nullptr, const std::string& path = "", int flags = 0) override
+    UnmanagedRegionPtr CreateUnmanagedRegion(const size_t size, RegionBulkCallback bulkCallback = nullptr, const std::string& path = "", int flags = 0, fair::mq::RegionConfig cfg = fair::mq::RegionConfig()) override
     {
-        return CreateUnmanagedRegion(size, 0, nullptr, bulkCallback, path, flags);
+        return CreateUnmanagedRegion(size, 0, nullptr, bulkCallback, path, flags, cfg);
     }
 
-    UnmanagedRegionPtr CreateUnmanagedRegion(const size_t size, int64_t userFlags, RegionCallback callback = nullptr, const std::string& path = "", int flags = 0) override
+    UnmanagedRegionPtr CreateUnmanagedRegion(const size_t size, int64_t userFlags, RegionCallback callback = nullptr, const std::string& path = "", int flags = 0, fair::mq::RegionConfig cfg = fair::mq::RegionConfig()) override
     {
-        return CreateUnmanagedRegion(size, userFlags, callback, nullptr, path, flags);
+        return CreateUnmanagedRegion(size, userFlags, callback, nullptr, path, flags, cfg);
     }
 
-    UnmanagedRegionPtr CreateUnmanagedRegion(const size_t size, int64_t userFlags, RegionBulkCallback bulkCallback = nullptr, const std::string& path = "", int flags = 0) override
+    UnmanagedRegionPtr CreateUnmanagedRegion(const size_t size, int64_t userFlags, RegionBulkCallback bulkCallback = nullptr, const std::string& path = "", int flags = 0, fair::mq::RegionConfig cfg = fair::mq::RegionConfig()) override
     {
-        return CreateUnmanagedRegion(size, userFlags, nullptr, bulkCallback, path, flags);
+        return CreateUnmanagedRegion(size, userFlags, nullptr, bulkCallback, path, flags, cfg);
     }
 
-    UnmanagedRegionPtr CreateUnmanagedRegion(const size_t size, int64_t userFlags, RegionCallback callback, RegionBulkCallback bulkCallback, const std::string& path, int flags)
+    UnmanagedRegionPtr CreateUnmanagedRegion(const size_t size, int64_t userFlags, RegionCallback callback, RegionBulkCallback bulkCallback, const std::string& path, int flags, fair::mq::RegionConfig cfg)
     {
-        return std::make_unique<UnmanagedRegion>(*fManager, size, userFlags, callback, bulkCallback, path, flags, this);
+        return std::make_unique<UnmanagedRegion>(*fManager, size, userFlags, callback, bulkCallback, path, flags, this, cfg);
     }
 
     void SubscribeToRegionEvents(RegionEventCallback callback) override { fManager->SubscribeToRegionEvents(callback); }

--- a/fairmq/shmem/UnmanagedRegion.h
+++ b/fairmq/shmem/UnmanagedRegion.h
@@ -37,15 +37,16 @@ class UnmanagedRegion final : public fair::mq::UnmanagedRegion
                     const int64_t userFlags,
                     RegionCallback callback,
                     RegionBulkCallback bulkCallback,
-                    const std::string& path = "",
-                    int flags = 0,
-                    FairMQTransportFactory* factory = nullptr)
+                    const std::string& path,
+                    int flags,
+                    FairMQTransportFactory* factory,
+                    fair::mq::RegionConfig cfg)
         : FairMQUnmanagedRegion(factory)
         , fManager(manager)
         , fRegion(nullptr)
         , fRegionId(0)
     {
-        auto result = fManager.CreateRegion(size, userFlags, callback, bulkCallback, path, flags);
+        auto result = fManager.CreateRegion(size, userFlags, callback, bulkCallback, path, flags, cfg);
         fRegion = result.first;
         fRegionId = result.second;
     }

--- a/fairmq/shmem/UnmanagedRegion.h
+++ b/fairmq/shmem/UnmanagedRegion.h
@@ -56,6 +56,8 @@ class UnmanagedRegion final : public fair::mq::UnmanagedRegion
     void SetLinger(uint32_t linger) override { fManager.GetRegion(fRegionId)->SetLinger(linger); }
     uint32_t GetLinger() const override { return fManager.GetRegion(fRegionId)->GetLinger(); }
 
+    Transport GetType() const override { return fair::mq::Transport::SHM; }
+
     ~UnmanagedRegion() override { fManager.RemoveRegion(fRegionId); }
 
   private:

--- a/fairmq/shmem/runMonitor.cxx
+++ b/fairmq/shmem/runMonitor.cxx
@@ -89,6 +89,7 @@ int main(int argc, char** argv)
         bool listAll = false;
         string listAllPath;
         bool verbose = false;
+        string severity;
         int userId = -1;
 
         options_description desc("Options");
@@ -109,6 +110,7 @@ int main(int argc, char** argv)
             ("list-all"       , value<bool>(&listAll)->implicit_value(true),            "List all sessions & segments")
             ("list-all-path"  , value<string>(&listAllPath)->default_value("/dev/shm/"),"Path for the --list-all command to search segments in")
             ("verbose"        , value<bool>(&verbose)->implicit_value(true),            "Verbose mode (daemon will output to a file 'fairmq-shmmonitor_<timestamp>')")
+            ("severity"       , value<string>(&severity)->default_value("info"),        "Log severity")
             ("user-id"        , value<int>(&userId)->default_value(-1),                 "User id (used with --get-shmid)")
             ("help,h",                                                                  "Print help");
 
@@ -121,6 +123,8 @@ int main(int argc, char** argv)
         }
 
         notify(vm);
+
+        fair::Logger::SetConsoleSeverity(severity);
 
         if (getShmId) {
             if (userId == -1) {

--- a/fairmq/zeromq/Message.h
+++ b/fairmq/zeromq/Message.h
@@ -109,6 +109,11 @@ class Message final : public fair::mq::Message
         , fAlignment(0)
         , fMsg(std::make_unique<zmq_msg_t>())
     {
+        if (region->GetType() != GetType()) {
+            LOG(error) << "region type (" << region->GetType() << ") does not match message type (" << GetType() << ")";
+            throw TransportError(tools::ToString("region type (", region->GetType(), ") does not match message type (", GetType(), ")"));
+        }
+
         // FIXME: make this zero-copy:
         // simply taking over the provided buffer can casue premature delete, since region could be
         // destroyed before the message is sent out. Needs lifetime extension for the ZMQ region.

--- a/fairmq/zeromq/TransportFactory.h
+++ b/fairmq/zeromq/TransportFactory.h
@@ -96,29 +96,29 @@ class TransportFactory final : public FairMQTransportFactory
         return std::make_unique<Poller>(channelsMap, channelList);
     }
 
-    UnmanagedRegionPtr CreateUnmanagedRegion(const size_t size, RegionCallback callback, const std::string& path = "", int flags = 0) override
+    UnmanagedRegionPtr CreateUnmanagedRegion(const size_t size, RegionCallback callback, const std::string& path = "", int flags = 0, fair::mq::RegionConfig cfg = fair::mq::RegionConfig()) override
     {
-        return CreateUnmanagedRegion(size, 0, callback, nullptr, path, flags);
+        return CreateUnmanagedRegion(size, 0, callback, nullptr, path, flags, cfg);
     }
 
-    UnmanagedRegionPtr CreateUnmanagedRegion(const size_t size, RegionBulkCallback bulkCallback, const std::string& path = "", int flags = 0) override
+    UnmanagedRegionPtr CreateUnmanagedRegion(const size_t size, RegionBulkCallback bulkCallback, const std::string& path = "", int flags = 0, fair::mq::RegionConfig cfg = fair::mq::RegionConfig()) override
     {
-        return CreateUnmanagedRegion(size, 0, nullptr, bulkCallback, path, flags);
+        return CreateUnmanagedRegion(size, 0, nullptr, bulkCallback, path, flags, cfg);
     }
 
-    UnmanagedRegionPtr CreateUnmanagedRegion(const size_t size, const int64_t userFlags, RegionCallback callback, const std::string& path = "", int flags = 0) override
+    UnmanagedRegionPtr CreateUnmanagedRegion(const size_t size, const int64_t userFlags, RegionCallback callback, const std::string& path = "", int flags = 0, fair::mq::RegionConfig cfg = fair::mq::RegionConfig()) override
     {
-        return CreateUnmanagedRegion(size, userFlags, callback, nullptr, path, flags);
+        return CreateUnmanagedRegion(size, userFlags, callback, nullptr, path, flags, cfg);
     }
 
-    UnmanagedRegionPtr CreateUnmanagedRegion(const size_t size, const int64_t userFlags, RegionBulkCallback bulkCallback, const std::string& path = "", int flags = 0) override
+    UnmanagedRegionPtr CreateUnmanagedRegion(const size_t size, const int64_t userFlags, RegionBulkCallback bulkCallback, const std::string& path = "", int flags = 0, fair::mq::RegionConfig cfg = fair::mq::RegionConfig()) override
     {
-        return CreateUnmanagedRegion(size, userFlags, nullptr, bulkCallback, path, flags);
+        return CreateUnmanagedRegion(size, userFlags, nullptr, bulkCallback, path, flags, cfg);
     }
 
-    UnmanagedRegionPtr CreateUnmanagedRegion(const size_t size, const int64_t userFlags, RegionCallback callback, RegionBulkCallback bulkCallback, const std::string&, int)
+    UnmanagedRegionPtr CreateUnmanagedRegion(const size_t size, const int64_t userFlags, RegionCallback callback, RegionBulkCallback bulkCallback, const std::string&, int /* flags */, fair::mq::RegionConfig cfg)
     {
-        UnmanagedRegionPtr ptr = std::make_unique<UnmanagedRegion>(*fCtx, size, userFlags, callback, bulkCallback, this);
+        UnmanagedRegionPtr ptr = std::make_unique<UnmanagedRegion>(*fCtx, size, userFlags, callback, bulkCallback, this, cfg);
         auto zPtr = static_cast<UnmanagedRegion*>(ptr.get());
         fCtx->AddRegion(false, zPtr->GetId(), zPtr->GetData(), zPtr->GetSize(), zPtr->GetUserFlags(), RegionEvent::created);
         return ptr;

--- a/fairmq/zeromq/UnmanagedRegion.h
+++ b/fairmq/zeromq/UnmanagedRegion.h
@@ -51,6 +51,8 @@ class UnmanagedRegion final : public fair::mq::UnmanagedRegion
     void SetLinger(uint32_t /* linger */) override { LOG(debug) << "ZeroMQ UnmanagedRegion linger option not implemented. Acknowledgements are local."; }
     uint32_t GetLinger() const override { LOG(debug) << "ZeroMQ UnmanagedRegion linger option not implemented. Acknowledgements are local."; return 0; }
 
+    Transport GetType() const override { return Transport::ZMQ; }
+
     virtual ~UnmanagedRegion()
     {
         LOG(debug) << "destroying region " << fId;

--- a/test/device/_error_state.cxx
+++ b/test/device/_error_state.cxx
@@ -153,9 +153,11 @@ TEST(ErrorState, interactive_InReset)
     EXPECT_EXIT(RunErrorStateIn("Reset", "interactive", "q"), ::testing::ExitedWithCode(1), "");
 }
 
+#ifdef FAIRMQ_DEBUG_MODE
 TEST(ErrorState, OrphanMessages)
 {
     BadDevice badDevice;
 }
+#endif
 
 } // namespace


### PR DESCRIPTION
- Shm: check result of region acquisition.
- Configurable transport for region example script.
- Add operator<< for fair::mq::Transport.
- Add GetType() to UnmanagedRegion.
- Check transport type of msg and corresponding region.
- Shm: eliminate race/deadlock in region subscriptions.
- Shmmonitor: add severity setting.
- Update docs.
- Region example: fix msg counter.
- Shm: reduce shm contention when dealing with ack queues.
- Add mlock/zero options to unmanaged region.
- ofi: fix Events() signature.