### PR TITLE
Do not catch and rethrow exception from state handlers

### DIFF
--- a/examples/copypush/sampler.cxx
+++ b/examples/copypush/sampler.cxx
@@ -19,7 +19,7 @@ struct Sampler : fair::mq::Device
 {
     void InitTask() override
     {
-        fNumDataChannels = fChannels.at("data").size();
+        fNumDataChannels = GetNumSubChannels("data");
         fMaxIterations = fConfig->GetProperty<uint64_t>("max-iterations");
     }
 

--- a/examples/n-m/sender.cxx
+++ b/examples/n-m/sender.cxx
@@ -28,7 +28,7 @@ struct Sender : fair::mq::Device
 
     void Run() override
     {
-        FairMQChannel& dataInChannel = fChannels.at("sync").at(0);
+        FairMQChannel& dataInChannel = GetChannel("sync", 0);
 
         while (!NewStatePending()) {
             Header h;

--- a/examples/readout/receiver.cxx
+++ b/examples/readout/receiver.cxx
@@ -26,7 +26,7 @@ struct Receiver : Device
 
     void Run() override
     {
-        Channel& dataInChannel = fChannels.at("sr").at(0);
+        Channel& dataInChannel = GetChannel("sr", 0);
 
         while (!NewStatePending()) {
             auto msg(dataInChannel.NewMessage());

--- a/examples/region/sampler.cxx
+++ b/examples/region/sampler.cxx
@@ -23,7 +23,7 @@ struct Sampler : fair::mq::Device
         fLinger = fConfig->GetProperty<uint32_t>("region-linger");
         fMaxIterations = fConfig->GetProperty<uint64_t>("max-iterations");
 
-        fChannels.at("data").at(0).Transport()->SubscribeToRegionEvents([](FairMQRegionInfo info) {
+        GetChannel("data", 0).Transport()->SubscribeToRegionEvents([](FairMQRegionInfo info) {
             LOG(info) << "Region event: " << info.event << ": "
                     << (info.managed ? "managed" : "unmanaged")
                     << ", id: " << info.id
@@ -87,7 +87,7 @@ struct Sampler : fair::mq::Device
                 LOG(info) << "All acknowledgements received.";
             }
         }
-        fChannels.at("data").at(0).Transport()->UnsubscribeFromRegionEvents();
+        GetChannel("data", 0).Transport()->UnsubscribeFromRegionEvents();
     }
 
   private:

--- a/examples/region/sink.cxx
+++ b/examples/region/sink.cxx
@@ -22,7 +22,7 @@ struct Sink : Device
     {
         // Get the fMaxIterations value from the command line options (via fConfig)
         fMaxIterations = fConfig->GetProperty<uint64_t>("max-iterations");
-        fChannels.at("data").at(0).Transport()->SubscribeToRegionEvents([](RegionInfo info) {
+        GetChannel("data", 0).Transport()->SubscribeToRegionEvents([](RegionInfo info) {
             LOG(info) << "Region event: " << info.event << ": "
                       << (info.managed ? "managed" : "unmanaged") << ", id: " << info.id
                       << ", ptr: " << info.ptr << ", size: " << info.size
@@ -32,7 +32,7 @@ struct Sink : Device
 
     void Run() override
     {
-        Channel& dataInChannel = fChannels.at("data").at(0);
+        Channel& dataInChannel = GetChannel("data", 0);
 
         while (!NewStatePending()) {
             auto msg(dataInChannel.Transport()->CreateMessage());
@@ -51,7 +51,7 @@ struct Sink : Device
 
     void ResetTask() override
     {
-        fChannels.at("data").at(0).Transport()->UnsubscribeFromRegionEvents();
+        GetChannel("data", 0).Transport()->UnsubscribeFromRegionEvents();
     }
 
   private:

--- a/fairmq/Device.h
+++ b/fairmq/Device.h
@@ -320,10 +320,7 @@ class Device
     try {
         return fChannels.at(channelName).at(index);
     } catch (const std::out_of_range& oor) {
-        LOG(error)
-            << "requested channel has not been configured? check channel names/configuration.";
-        LOG(error) << "channel: " << channelName << ", index: " << index;
-        LOG(error) << "out of range: " << oor.what();
+        LOG(error) << "GetChannel(): '" << channelName << "[" << index << "]' does not exist.";
         throw;
     }
 

--- a/fairmq/Device.h
+++ b/fairmq/Device.h
@@ -324,6 +324,14 @@ class Device
         throw;
     }
 
+    size_t GetNumSubChannels(const std::string& channelName)
+    try {
+        return fChannels.at(channelName).size();
+    } catch (const std::out_of_range& oor) {
+        LOG(error) << "GetNumSubChannels(): '" << channelName << "' does not exist.";
+        throw;
+    }
+
     /// @brief Get numbers of connected peers for the given channel
     /// @param name channel name
     /// @param index sub-channel

--- a/fairmq/Tools.h
+++ b/fairmq/Tools.h
@@ -11,6 +11,7 @@
 
 // IWYU pragma: begin_exports
 #include <fairmq/tools/CppSTL.h>
+#include <fairmq/tools/Exceptions.h>
 #include <fairmq/tools/InstanceLimit.h>
 #include <fairmq/tools/Network.h>
 #include <fairmq/tools/Process.h>

--- a/fairmq/devices/BenchmarkSampler.h
+++ b/fairmq/devices/BenchmarkSampler.h
@@ -44,7 +44,7 @@ class BenchmarkSampler : public Device
     void Run() override
     {
         // store the channel reference to avoid traversing the map on every loop iteration
-        FairMQChannel& dataOutChannel = fChannels.at(fOutChannelName).at(0);
+        FairMQChannel& dataOutChannel = GetChannel(fOutChannelName, 0);
 
         LOG(info) << "Starting the benchmark with message size of " << fMsgSize << " and " << fMaxIterations << " iterations.";
         auto tStart = std::chrono::high_resolution_clock::now();

--- a/fairmq/devices/Merger.h
+++ b/fairmq/devices/Merger.h
@@ -43,7 +43,7 @@ class Merger : public Device
 
     void Run() override
     {
-        int numInputs = fChannels.at(fInChannelName).size();
+        int numInputs = GetNumSubChannels(fInChannelName);
 
         std::vector<FairMQChannel*> chans;
 

--- a/fairmq/devices/Multiplier.h
+++ b/fairmq/devices/Multiplier.h
@@ -30,7 +30,7 @@ class Multiplier : public Device
         fMultipart = fConfig->GetProperty<bool>("multipart");
         fInChannelName = fConfig->GetProperty<std::string>("in-channel");
         fOutChannelNames = fConfig->GetProperty<std::vector<std::string>>("out-channel");
-        fNumOutputs = fChannels.at(fOutChannelNames.at(0)).size();
+        fNumOutputs = GetNumSubChannels(fOutChannelNames.at(0));
 
         if (fMultipart) {
             OnData(fInChannelName, &Multiplier::HandleMultipartData);
@@ -43,7 +43,7 @@ class Multiplier : public Device
     bool HandleSingleData(std::unique_ptr<FairMQMessage>& payload, int)
     {
         for (unsigned int i = 0; i < fOutChannelNames.size() - 1; ++i) { // all except last channel
-            for (unsigned int j = 0; j < fChannels.at(fOutChannelNames.at(i)).size(); ++j) { // all subChannels in a channel
+            for (unsigned int j = 0; j < GetNumSubChannels(fOutChannelNames.at(i)); ++j) { // all subChannels in a channel
                 FairMQMessagePtr msgCopy(fTransportFactory->CreateMessage());
                 msgCopy->Copy(*payload);
 
@@ -51,7 +51,7 @@ class Multiplier : public Device
             }
         }
 
-        unsigned int lastChannelSize = fChannels.at(fOutChannelNames.back()).size();
+        unsigned int lastChannelSize = GetNumSubChannels(fOutChannelNames.back());
 
         for (unsigned int i = 0; i < lastChannelSize - 1; ++i) { // iterate over all except last subChannels of the last channel
             FairMQMessagePtr msgCopy(fTransportFactory->CreateMessage());
@@ -68,7 +68,7 @@ class Multiplier : public Device
     bool HandleMultipartData(FairMQParts& payload, int)
     {
         for (unsigned int i = 0; i < fOutChannelNames.size() - 1; ++i) { // all except last channel
-            for (unsigned int j = 0; j < fChannels.at(fOutChannelNames.at(i)).size(); ++j) { // all subChannels in a channel
+            for (unsigned int j = 0; j < GetNumSubChannels(fOutChannelNames.at(i)); ++j) { // all subChannels in a channel
                 FairMQParts parts;
 
                 for (int k = 0; k < payload.Size(); ++k) {
@@ -81,7 +81,7 @@ class Multiplier : public Device
             }
         }
 
-        unsigned int lastChannelSize = fChannels.at(fOutChannelNames.back()).size();
+        unsigned int lastChannelSize = GetNumSubChannels(fOutChannelNames.back());
 
         for (unsigned int i = 0; i < lastChannelSize - 1; ++i) { // iterate over all except last subChannels of the last channel
             FairMQParts parts;

--- a/fairmq/devices/Sink.h
+++ b/fairmq/devices/Sink.h
@@ -48,7 +48,7 @@ class Sink : public Device
     void Run() override
     {
         // store the channel reference to avoid traversing the map on every loop iteration
-        FairMQChannel& dataInChannel = fChannels.at(fInChannelName).at(0);
+        FairMQChannel& dataInChannel = GetChannel(fInChannelName, 0);
 
         LOG(info) << "Starting sink and expecting to receive " << fMaxIterations << " messages.";
         auto tStart = std::chrono::high_resolution_clock::now();

--- a/fairmq/devices/Splitter.h
+++ b/fairmq/devices/Splitter.h
@@ -30,7 +30,7 @@ class Splitter : public Device
         fMultipart = fConfig->GetProperty<bool>("multipart");
         fInChannelName = fConfig->GetProperty<std::string>("in-channel");
         fOutChannelName = fConfig->GetProperty<std::string>("out-channel");
-        fNumOutputs = fChannels.at(fOutChannelName).size();
+        fNumOutputs = GetNumSubChannels(fOutChannelName);
         fDirection = 0;
 
         if (fMultipart) {

--- a/fairmq/tools/Exceptions.h
+++ b/fairmq/tools/Exceptions.h
@@ -1,0 +1,54 @@
+/********************************************************************************
+ *    Copyright (C) 2021 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ *                                                                              *
+ *              This software is distributed under the terms of the             *
+ *              GNU Lesser General Public Licence (LGPL) version 3,             *
+ *                  copied verbatim in the file "LICENSE"                       *
+ ********************************************************************************/
+
+#ifndef FAIR_MQ_TOOLS_EXCEPTIONS_H
+#define FAIR_MQ_TOOLS_EXCEPTIONS_H
+
+#include <functional>
+
+namespace fair::mq::tools
+{
+
+/**
+ * Executes the given callback in the destructor.
+ * Can be used to execute something in case of an exception when catch is undesirable, e.g.:
+ *
+ * {
+ *    // callback will be executed only if f throws an exception
+ *    CallOnDestruction cod([](){ cout << "exception was thrown"; }, true);
+ *    f();
+ *    cod.disable();
+ * }
+ */
+
+class CallOnDestruction
+{
+  public:
+    CallOnDestruction(std::function<void()> c, bool enable = true)
+        : callback(c)
+        , enabled(enable)
+    {}
+
+    ~CallOnDestruction()
+    {
+        if (enabled) {
+            callback();
+        }
+    }
+
+    void enable() { enabled = true; }
+    void disable() { enabled = false; }
+
+  private:
+    std::function<void()> callback;
+    bool enabled;
+};
+
+} // namespace fair::mq::tools
+
+#endif /* FAIR_MQ_TOOLS_EXCEPTIONS_H */

--- a/test/helper/devices/TestPollIn.h
+++ b/test/helper/devices/TestPollIn.h
@@ -37,8 +37,8 @@ class PollIn : public FairMQDevice
     {
         vector<FairMQChannel*> chans;
 
-        chans.push_back(&fChannels.at("data1").at(0));
-        chans.push_back(&fChannels.at("data2").at(0));
+        chans.push_back(&GetChannel("data1", 0));
+        chans.push_back(&GetChannel("data2", 0));
 
         FairMQPollerPtr poller = nullptr;
 


### PR DESCRIPTION
Contributes to #372.

- Do not catch and re-throw exception from state handlers.
- feat: Add `Device::GetNumSubChannels(channel)`.
- Avoid accessing `Device::fChannels` directly, use getters.


