### PR TITLE
Add configurable default snd/rcv timeout

### DIFF
--- a/fairmq/Channel.cxx
+++ b/fairmq/Channel.cxx
@@ -39,6 +39,8 @@ constexpr int Channel::DefaultSndBufSize;
 constexpr int Channel::DefaultRcvBufSize;
 constexpr int Channel::DefaultSndKernelSize;
 constexpr int Channel::DefaultRcvKernelSize;
+constexpr int Channel::DefaultSndTimeoutMs;
+constexpr int Channel::DefaultRcvTimeoutMs;
 constexpr int Channel::DefaultLinger;
 constexpr int Channel::DefaultRateLogging;
 constexpr int Channel::DefaultPortRangeMin;
@@ -73,6 +75,8 @@ Channel::Channel(string name, string type, string method, string address, shared
     , fRcvBufSize(DefaultRcvBufSize)
     , fSndKernelSize(DefaultSndKernelSize)
     , fRcvKernelSize(DefaultRcvKernelSize)
+    , fSndTimeoutMs(DefaultSndTimeoutMs)
+    , fRcvTimeoutMs(DefaultRcvTimeoutMs)
     , fLinger(DefaultLinger)
     , fRateLogging(DefaultRateLogging)
     , fPortRangeMin(DefaultPortRangeMin)
@@ -97,6 +101,8 @@ Channel::Channel(const string& name, int index, const Properties& properties)
     fRcvBufSize = GetPropertyOrDefault(properties, string(prefix + "rcvBufSize"), DefaultRcvBufSize);
     fSndKernelSize = GetPropertyOrDefault(properties, string(prefix + "sndKernelSize"), DefaultSndKernelSize);
     fRcvKernelSize = GetPropertyOrDefault(properties, string(prefix + "rcvKernelSize"), DefaultRcvKernelSize);
+    fSndTimeoutMs = GetPropertyOrDefault(properties, string(prefix + "sndTimeoutMs"), DefaultSndTimeoutMs);
+    fRcvTimeoutMs = GetPropertyOrDefault(properties, string(prefix + "rcvTimeoutMs"), DefaultRcvTimeoutMs);
     fLinger = GetPropertyOrDefault(properties, string(prefix + "linger"), DefaultLinger);
     fRateLogging = GetPropertyOrDefault(properties, string(prefix + "rateLogging"), DefaultRateLogging);
     fPortRangeMin = GetPropertyOrDefault(properties, string(prefix + "portRangeMin"), DefaultPortRangeMin);
@@ -120,6 +126,8 @@ Channel::Channel(const Channel& chan, string newName)
     , fRcvBufSize(chan.fRcvBufSize)
     , fSndKernelSize(chan.fSndKernelSize)
     , fRcvKernelSize(chan.fRcvKernelSize)
+    , fSndTimeoutMs(chan.fSndTimeoutMs)
+    , fRcvTimeoutMs(chan.fRcvTimeoutMs)
     , fLinger(chan.fLinger)
     , fRateLogging(chan.fRateLogging)
     , fPortRangeMin(chan.fPortRangeMin)
@@ -146,6 +154,8 @@ Channel& Channel::operator=(const Channel& chan)
     fRcvBufSize = chan.fRcvBufSize;
     fSndKernelSize = chan.fSndKernelSize;
     fRcvKernelSize = chan.fRcvKernelSize;
+    fSndTimeoutMs = chan.fSndTimeoutMs;
+    fRcvTimeoutMs = chan.fRcvTimeoutMs;
     fLinger = chan.fLinger;
     fRateLogging = chan.fRateLogging;
     fPortRangeMin = chan.fPortRangeMin;

--- a/fairmq/Device.h
+++ b/fairmq/Device.h
@@ -81,72 +81,70 @@ class Device
         Deserializer().Deserialize(msg, std::forward<DataType>(data), std::forward<Args>(args)...);
     }
 
-    /// Shorthand method to send `msg` on `chan` at index `i`
-    /// @param msg message reference
+    /// Send `m` on `chan` at index `i`
+    /// @param m reference to MessagePtr/Parts/vector<MessagePtr>
     /// @param chan channel name
     /// @param i channel index
-    /// @param sndTimeoutInMs send timeout in ms, -1 will wait forever (or until interrupt (e.g. via
-    /// state change)), 0 will not wait (return immediately if cannot send)
-    /// @return Number of bytes that have been queued, TransferCode::timeout if timed out,
-    /// TransferCode::error if there was an error, TransferCode::interrupted if interrupted (e.g. by
-    /// requested state change)
-    int64_t Send(MessagePtr& msg,
-                 const std::string& channel,
-                 const int index = 0,
-                 int sndTimeoutInMs = -1)
+    /// @return Number of queued bytes,
+    /// TransferCode::timeout if timed out,
+    /// TransferCode::error if there was an error,
+    /// TransferCode::interrupted if interrupted (e.g. by requested state change)
+    template<typename M>
+    std::enable_if_t<is_transferrable<M>::value, int64_t>
+    Send(M& m, const std::string& channel, const int index = 0)
     {
-        return GetChannel(channel, index).Send(msg, sndTimeoutInMs);
+        return GetChannel(channel, index).Send(m);
     }
 
-    /// Shorthand method to receive `msg` on `chan` at index `i`
-    /// @param msg message reference
+    /// Receive `m` on `chan` at index `i`
+    /// @param m reference to MessagePtr/Parts/vector<MessagePtr>
     /// @param chan channel name
     /// @param i channel index
-    /// @param rcvTimeoutInMs receive timeout in ms, -1 will wait forever (or until interrupt (e.g.
-    /// via state change)), 0 will not wait (return immediately if cannot receive)
-    /// @return Number of bytes that have been received, TransferCode::timeout if timed out,
-    /// TransferCode::error if there was an error, TransferCode::interrupted if interrupted (e.g. by
-    /// requested state change)
-    int64_t Receive(MessagePtr& msg,
-                    const std::string& channel,
-                    const int index = 0,
-                    int rcvTimeoutInMs = -1)
+    /// @return Number of received bytes,
+    /// TransferCode::timeout if timed out,
+    /// TransferCode::error if there was an error,
+    /// TransferCode::interrupted if interrupted (e.g. by requested state change)
+    template<typename M>
+    std::enable_if_t<is_transferrable<M>::value, int64_t>
+    Receive(M& m, const std::string& channel, const int index = 0)
     {
-        return GetChannel(channel, index).Receive(msg, rcvTimeoutInMs);
+        return GetChannel(channel, index).Receive(m);
     }
 
-    /// Shorthand method to send Parts on `chan` at index `i`
-    /// @param parts parts reference
+    /// Send `m` on `chan` at index `i`
+    /// @param m reference to MessagePtr/Parts/vector<MessagePtr>
     /// @param chan channel name
     /// @param i channel index
-    /// @param sndTimeoutInMs send timeout in ms, -1 will wait forever (or until interrupt (e.g. via
-    /// state change)), 0 will not wait (return immediately if cannot send)
-    /// @return Number of bytes that have been queued, TransferCode::timeout if timed out,
-    /// TransferCode::error if there was an error, TransferCode::interrupted if interrupted (e.g. by
-    /// requested state change)
-    int64_t Send(Parts& parts,
-                 const std::string& channel,
-                 const int index = 0,
-                 int sndTimeoutInMs = -1)
+    /// @param sndTimeoutMs send timeout in ms,
+    /// -1 will wait forever (or until interrupt (e.g. via state change)),
+    /// 0 will not wait (return immediately if cannot send)
+    /// @return Number of queued bytes,
+    /// TransferCode::timeout if timed out,
+    /// TransferCode::error if there was an error,
+    /// TransferCode::interrupted if interrupted (e.g. by requested state change)
+    template<typename M>
+    std::enable_if_t<is_transferrable<M>::value, int64_t>
+    Send(M& m, const std::string& channel, const int index, int sndTimeoutMs)
     {
-        return GetChannel(channel, index).Send(parts.fParts, sndTimeoutInMs);
+        return GetChannel(channel, index).Send(m, sndTimeoutMs);
     }
 
-    /// Shorthand method to receive Parts on `chan` at index `i`
-    /// @param parts parts reference
+    /// Receive `m` on `chan` at index `i`
+    /// @param m reference to MessagePtr/Parts/vector<MessagePtr>
     /// @param chan channel name
     /// @param i channel index
-    /// @param rcvTimeoutInMs receive timeout in ms, -1 will wait forever (or until interrupt (e.g.
-    /// via state change)), 0 will not wait (return immediately if cannot receive)
-    /// @return Number of bytes that have been received, TransferCode::timeout if timed out,
-    /// TransferCode::error if there was an error, TransferCode::interrupted if interrupted (e.g. by
-    /// requested state change)
-    int64_t Receive(Parts& parts,
-                    const std::string& channel,
-                    const int index = 0,
-                    int rcvTimeoutInMs = -1)
+    /// @param rcvTimeoutMs receive timeout in ms,
+    /// -1 will wait forever (or until interrupt (e.g. via state change),
+    /// 0 will not wait (return immediately if cannot receive)
+    /// @return Number of received bytes,
+    /// TransferCode::timeout if timed out,
+    /// TransferCode::error if there was an error,
+    /// TransferCode::interrupted if interrupted (e.g. by requested state change)
+    template<typename M>
+    std::enable_if_t<is_transferrable<M>::value, int64_t>
+    Receive(M& m, const std::string& channel, const int index, int rcvTimeoutMs)
     {
-        return GetChannel(channel, index).Receive(parts.fParts, rcvTimeoutInMs);
+        return GetChannel(channel, index).Receive(m, rcvTimeoutMs);
     }
 
     /// @brief Getter for default transport factory

--- a/fairmq/JSONParser.cxx
+++ b/fairmq/JSONParser.cxx
@@ -96,6 +96,8 @@ void ChannelParser(const ptree& tree, fair::mq::Properties& properties)
                 commonProperties.emplace("rcvBufSize", cn.second.get<int>("rcvBufSize", FairMQChannel::DefaultRcvBufSize));
                 commonProperties.emplace("sndKernelSize", cn.second.get<int>("sndKernelSize", FairMQChannel::DefaultSndKernelSize));
                 commonProperties.emplace("rcvKernelSize", cn.second.get<int>("rcvKernelSize", FairMQChannel::DefaultRcvKernelSize));
+                commonProperties.emplace("sndTimeoutMs", cn.second.get<int>("sndTimeoutMs", FairMQChannel::DefaultSndTimeoutMs));
+                commonProperties.emplace("rcvTimeoutMs", cn.second.get<int>("rcvTimeoutMs", FairMQChannel::DefaultRcvTimeoutMs));
                 commonProperties.emplace("linger", cn.second.get<int>("linger", FairMQChannel::DefaultLinger));
                 commonProperties.emplace("rateLogging", cn.second.get<int>("rateLogging", FairMQChannel::DefaultRateLogging));
                 commonProperties.emplace("portRangeMin", cn.second.get<int>("portRangeMin", FairMQChannel::DefaultPortRangeMin));
@@ -146,6 +148,8 @@ void SubChannelParser(const ptree& channelTree, fair::mq::Properties& properties
                 newProperties["rcvBufSize"] = sn.second.get<int>("rcvBufSize", boost::any_cast<int>(commonProperties.at("rcvBufSize")));
                 newProperties["sndKernelSize"] = sn.second.get<int>("sndKernelSize", boost::any_cast<int>(commonProperties.at("sndKernelSize")));
                 newProperties["rcvKernelSize"] = sn.second.get<int>("rcvKernelSize", boost::any_cast<int>(commonProperties.at("rcvKernelSize")));
+                newProperties["sndTimeoutMs"] = sn.second.get<int>("sndTimeoutMs", boost::any_cast<int>(commonProperties.at("sndTimeoutMs")));
+                newProperties["rcvTimeoutMs"] = sn.second.get<int>("rcvTimeoutMs", boost::any_cast<int>(commonProperties.at("rcvTimeoutMs")));
                 newProperties["linger"] = sn.second.get<int>("linger", boost::any_cast<int>(commonProperties.at("linger")));
                 newProperties["rateLogging"] = sn.second.get<int>("rateLogging", boost::any_cast<int>(commonProperties.at("rateLogging")));
                 newProperties["portRangeMin"] = sn.second.get<int>("portRangeMin", boost::any_cast<int>(commonProperties.at("portRangeMin")));

--- a/fairmq/Socket.h
+++ b/fairmq/Socket.h
@@ -10,9 +10,12 @@
 #define FAIR_MQ_SOCKET_H
 
 #include <fairmq/Message.h>
+#include <fairmq/Parts.h>
+
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 namespace fair::mq {
@@ -26,6 +29,12 @@ enum class TransferCode : int
     timeout = -2,
     interrupted = -3
 };
+
+template <typename T>
+struct is_transferrable : std::disjunction<std::is_same<T, MessagePtr>,
+                                           std::is_same<T, std::vector<MessagePtr>>,
+                                           std::is_same<T, fair::mq::Parts>>
+{};
 
 struct Socket
 {
@@ -45,6 +54,8 @@ struct Socket
     virtual int64_t Receive(MessagePtr& msg, int timeout = -1) = 0;
     virtual int64_t Send(std::vector<std::unique_ptr<Message>>& msgVec, int timeout = -1) = 0;
     virtual int64_t Receive(std::vector<std::unique_ptr<Message>>& msgVec, int timeout = -1) = 0;
+    virtual int64_t Send(Parts& parts, int timeout = -1) { return Send(parts.fParts, timeout); }
+    virtual int64_t Receive(Parts& parts, int timeout = -1) { return Receive(parts.fParts, timeout); }
 
     [[deprecated("Use Socket::~Socket() instead.")]]
     virtual void Close() = 0;

--- a/fairmq/SuboptParser.cxx
+++ b/fairmq/SuboptParser.cxx
@@ -38,6 +38,8 @@ enum channelOptionKeyIds
     RCVBUFSIZE,     // size of the receive queue
     SNDKERNELSIZE,
     RCVKERNELSIZE,
+    SNDTIMEOUTMS,
+    RCVTIMEOUTMS,
     LINGER,
     RATELOGGING,    // logging rate
     PORTRANGEMIN,
@@ -57,6 +59,8 @@ constexpr static const char* channelOptionKeys[] = {
     /*[RCVBUFSIZE]    = */ "rcvBufSize",
     /*[SNDKERNELSIZE] = */ "sndKernelSize",
     /*[RCVKERNELSIZE] = */ "rcvKernelSize",
+    /*[SNDTIMEOUTMS]  = */ "sndTimeoutMs",
+    /*[RCVTIMEOUTMS]  = */ "rcvTimeoutMs",
     /*[LINGER]        = */ "linger",
     /*[RATELOGGING]   = */ "rateLogging",
     /*[PORTRANGEMIN]  = */ "portRangeMin",

--- a/fairmq/shmem/Socket.h
+++ b/fairmq/shmem/Socket.h
@@ -117,52 +117,12 @@ class Socket final : public fair::mq::Socket
 
     bool Bind(const std::string& address) override
     {
-        // LOG(info) << "binding socket " << fId << " on " << address;
-        if (zmq_bind(fSocket, address.c_str()) != 0) {
-            if (errno == EADDRINUSE) {
-                // do not print error in this case, this is handled by FairMQDevice in case no connection could be established after trying a number of random ports from a range.
-                return false;
-            }
-            LOG(error) << "Failed binding socket " << fId << ", reason: " << zmq_strerror(errno);
-            return false;
-        }
-        return true;
+        return zmq::Bind(fSocket, address, fId);
     }
 
     bool Connect(const std::string& address) override
     {
-        // LOG(info) << "connecting socket " << fId << " on " << address;
-        if (zmq_connect(fSocket, address.c_str()) != 0) {
-            LOG(error) << "Failed connecting socket " << fId << ", reason: " << zmq_strerror(errno);
-            return false;
-        }
-        return true;
-    }
-
-    bool ShouldRetry(int flags, int timeout, int& elapsed) const
-    {
-        if ((flags & ZMQ_DONTWAIT) == 0) {
-            if (timeout > 0) {
-                elapsed += fTimeout;
-                if (elapsed >= timeout) {
-                    return false;
-                }
-            }
-            return true;
-        } else {
-            return false;
-        }
-    }
-
-    int HandleErrors() const
-    {
-        if (zmq_errno() == ETERM) {
-            LOG(debug) << "Terminating socket " << fId;
-            return static_cast<int>(TransferCode::error);
-        } else {
-            LOG(error) << "Failed transfer on socket " << fId << ", reason: " << zmq_strerror(errno);
-            return static_cast<int>(TransferCode::error);
-        }
+        return zmq::Connect(fSocket, address, fId);
     }
 
     int64_t Send(MessagePtr& msg, int timeout = -1) override
@@ -186,13 +146,13 @@ class Socket final : public fair::mq::Socket
             } else if (zmq_errno() == EAGAIN || zmq_errno() == EINTR) {
                 if (fManager.Interrupted()) {
                     return static_cast<int>(TransferCode::interrupted);
-                } else if (ShouldRetry(flags, timeout, elapsed)) {
+                } else if (zmq::ShouldRetry(flags, fTimeout, timeout, elapsed)) {
                     continue;
                 } else {
                     return static_cast<int>(TransferCode::timeout);
                 }
             } else {
-                return HandleErrors();
+                return zmq::HandleErrors(fId);
             }
         }
 
@@ -226,13 +186,13 @@ class Socket final : public fair::mq::Socket
             } else if (zmq_errno() == EAGAIN || zmq_errno() == EINTR) {
                 if (fManager.Interrupted()) {
                     return static_cast<int>(TransferCode::interrupted);
-                } else if (ShouldRetry(flags, timeout, elapsed)) {
+                } else if (zmq::ShouldRetry(flags, fTimeout, timeout, elapsed)) {
                     continue;
                 } else {
                     return static_cast<int>(TransferCode::timeout);
                 }
             } else {
-                return HandleErrors();
+                return zmq::HandleErrors(fId);
             }
         }
     }
@@ -277,13 +237,13 @@ class Socket final : public fair::mq::Socket
             } else if (zmq_errno() == EAGAIN || zmq_errno() == EINTR) {
                 if (fManager.Interrupted()) {
                     return static_cast<int>(TransferCode::interrupted);
-                } else if (ShouldRetry(flags, timeout, elapsed)) {
+                } else if (zmq::ShouldRetry(flags, fTimeout, timeout, elapsed)) {
                     continue;
                 } else {
                     return static_cast<int>(TransferCode::timeout);
                 }
             } else {
-                return HandleErrors();
+                return zmq::HandleErrors(fId);
             }
         }
 
@@ -333,13 +293,13 @@ class Socket final : public fair::mq::Socket
             } else if (zmq_errno() == EAGAIN || zmq_errno() == EINTR) {
                 if (fManager.Interrupted()) {
                     return static_cast<int>(TransferCode::interrupted);
-                } else if (ShouldRetry(flags, timeout, elapsed)) {
+                } else if (zmq::ShouldRetry(flags, fTimeout, timeout, elapsed)) {
                     continue;
                 } else {
                     return static_cast<int>(TransferCode::timeout);
                 }
             } else {
-                return HandleErrors();
+                return zmq::HandleErrors(fId);
             }
         }
 


### PR DESCRIPTION
- Add default send/receive timeout, configurable via `--channel-config` keys `sndTimeoutMs` and `rcvTimeoutMs`. Only affects default value (which is `-1` - no timeout - by default), when no explicit timeout argument is provided to Send/Receive.


