### PR TITLE
Fix regression in region events handler

### DIFF
--- a/fairmq/shmem/Manager.h
+++ b/fairmq/shmem/Manager.h
@@ -466,6 +466,7 @@ class Manager
                 auto r = fRegions.emplace(id, std::make_unique<UnmanagedRegion>(fShmId, 0, true, std::move(cfg)));
                 r.first->second->InitializeQueues();
                 r.first->second->StartAckSender();
+                lockedShmLock.lock();
                 return r.first->second.get();
             } catch (std::out_of_range& oor) {
                 LOG(error) << "Could not get remote region with id '" << id << "'. Does the region creator run with the same session id?";

--- a/fairmq/shmem/Manager.h
+++ b/fairmq/shmem/Manager.h
@@ -777,8 +777,6 @@ class Manager
         if (lastRemoved) {
             if (!fNoCleanup) {
                 Monitor::Cleanup(ShmId{fShmId});
-            } else {
-                Monitor::RemoveObject("fmq_" + fShmId + "_mng");
             }
         }
     }


### PR DESCRIPTION
- Fix regression in region events handler (double unlock).
- shm: keep also the mng segment around when skipping cleanup.
- expand keep-alive example exe a bit.
