### PR TITLE
Get rid of obsolete names

### DIFF
--- a/examples/1-1/sampler.cxx
+++ b/examples/1-1/sampler.cxx
@@ -30,7 +30,7 @@ struct Sampler : fair::mq::Device
         // create message object with a pointer to the data buffer, its size,
         // custom deletion function (called when transfer is done),
         // and pointer to the object managing the data buffer
-        FairMQMessagePtr msg(NewMessage(
+        fair::mq::MessagePtr msg(NewMessage(
             const_cast<char*>(text->c_str()),
             text->length(),
             [](void* /*data*/, void* object) { delete static_cast<std::string*>(object); },

--- a/examples/1-1/sink.cxx
+++ b/examples/1-1/sink.cxx
@@ -27,7 +27,7 @@ struct Sink : fair::mq::Device
         fMaxIterations = fConfig->GetProperty<uint64_t>("max-iterations");
     }
 
-    bool HandleData(FairMQMessagePtr& msg, int)
+    bool HandleData(fair::mq::MessagePtr& msg, int)
     {
         LOG(info) << "Received: \"" << std::string(static_cast<char*>(msg->GetData()), msg->GetSize()) << "\"";
 

--- a/examples/1-n-1/processor.cxx
+++ b/examples/1-n-1/processor.cxx
@@ -20,7 +20,7 @@ struct Processor : fair::mq::Device
         OnData("data1", &Processor::HandleData);
     }
 
-    bool HandleData(FairMQMessagePtr& msg, int)
+    bool HandleData(fair::mq::MessagePtr& msg, int)
     {
         LOG(info) << "Received data, processing...";
 
@@ -32,7 +32,7 @@ struct Processor : fair::mq::Device
         // its size,
         // custom deletion function (called when transfer is done),
         // and pointer to the object managing the data buffer
-        FairMQMessagePtr msg2(NewMessage(const_cast<char*>(text->c_str()),
+        fair::mq::MessagePtr msg2(NewMessage(const_cast<char*>(text->c_str()),
                                         text->length(),
                                         [](void* /*data*/, void* object) { delete static_cast<std::string*>(object); },
                                         text));

--- a/examples/1-n-1/sampler.cxx
+++ b/examples/1-n-1/sampler.cxx
@@ -28,7 +28,7 @@ struct Sampler : fair::mq::Device
     {
         // Initializing message with NewStaticMessage will avoid copy
         // but won't delete the data after the sending is completed.
-        FairMQMessagePtr msg(NewStaticMessage(fText));
+        fair::mq::MessagePtr msg(NewStaticMessage(fText));
 
         LOG(info) << "Sending \"" << fText << "\"";
 

--- a/examples/1-n-1/sink.cxx
+++ b/examples/1-n-1/sink.cxx
@@ -27,7 +27,7 @@ struct Sink : fair::mq::Device
         fMaxIterations = fConfig->GetProperty<uint64_t>("max-iterations");
     }
 
-    bool HandleData(FairMQMessagePtr& msg, int)
+    bool HandleData(fair::mq::MessagePtr& msg, int)
     {
         LOG(info) << "Received: \"" << std::string(static_cast<char*>(msg->GetData()), msg->GetSize()) << "\"";
 

--- a/examples/copypush/sampler.cxx
+++ b/examples/copypush/sampler.cxx
@@ -27,10 +27,10 @@ struct Sampler : fair::mq::Device
     {
         // NewSimpleMessage creates a copy of the data and takes care of its destruction (after the transfer takes place).
         // Should only be used for small data because of the cost of an additional copy
-        FairMQMessagePtr msg(NewSimpleMessage(fCounter++));
+        fair::mq::MessagePtr msg(NewSimpleMessage(fCounter++));
 
         for (int i = 0; i < fNumDataChannels - 1; ++i) {
-            FairMQMessagePtr msgCopy(NewMessage());
+            fair::mq::MessagePtr msgCopy(NewMessage());
             msgCopy->Copy(*msg);
             Send(msgCopy, "data", i);
         }

--- a/examples/copypush/sink.cxx
+++ b/examples/copypush/sink.cxx
@@ -27,7 +27,7 @@ struct Sink : fair::mq::Device
         fMaxIterations = fConfig->GetProperty<uint64_t>("max-iterations");
     }
 
-    bool HandleData(FairMQMessagePtr& msg, int)
+    bool HandleData(fair::mq::MessagePtr& msg, int)
     {
         LOG(info) << "Received message: \"" << *(static_cast<uint64_t*>(msg->GetData())) << "\"";
 

--- a/examples/dds/processor.cxx
+++ b/examples/dds/processor.cxx
@@ -20,7 +20,7 @@ struct Processor : fair::mq::Device
         OnData("data1", &Processor::HandleData);
     }
 
-    bool HandleData(FairMQMessagePtr& msg, int)
+    bool HandleData(fair::mq::MessagePtr& msg, int)
     {
         LOG(info) << "Received data, processing...";
 
@@ -32,7 +32,7 @@ struct Processor : fair::mq::Device
         // its size,
         // custom deletion function (called when transfer is done),
         // and pointer to the object managing the data buffer
-        FairMQMessagePtr msg2(NewMessage(const_cast<char*>(text->c_str()),
+        fair::mq::MessagePtr msg2(NewMessage(const_cast<char*>(text->c_str()),
                                         text->length(),
                                         [](void* /*data*/, void* object) { delete static_cast<std::string*>(object); },
                                         text));

--- a/examples/dds/sampler.cxx
+++ b/examples/dds/sampler.cxx
@@ -24,7 +24,7 @@ struct Sampler : fair::mq::Device
     {
         // NewSimpleMessage creates a copy of the data and takes care of its destruction (after the transfer takes place).
         // Should only be used for small data because of the cost of an additional copy
-        FairMQMessagePtr msg(NewSimpleMessage("Data"));
+        fair::mq::MessagePtr msg(NewSimpleMessage("Data"));
 
         LOG(info) << "Sending \"Data\"";
 

--- a/examples/dds/sink.cxx
+++ b/examples/dds/sink.cxx
@@ -25,7 +25,7 @@ struct Sink : fair::mq::Device
         fIterations = fConfig->GetValue<uint64_t>("iterations");
     }
 
-    bool HandleData(FairMQMessagePtr& msg, int)
+    bool HandleData(fair::mq::MessagePtr& msg, int)
     {
         LOG(info) << "Received: \"" << std::string(static_cast<char*>(msg->GetData()), msg->GetSize()) << "\"";
 

--- a/examples/multipart/README.md
+++ b/examples/multipart/README.md
@@ -5,7 +5,7 @@ A topology of two devices - Sampler and Sink, communicating with PUSH-PULL patte
 
 The Sampler sends a multipart message to the Sink, consisting of two message parts - header and body.
 
-Each message part is a regular FairMQMessage. To combine them into a multi-part message use `FairMQParts`. Add messages to `FairMQParts` with `AddPart` method.
+Each message part is a regular fair::mq::Message. To combine them into a multi-part message use `fair::mq::Parts`. Add messages to `fair::mq::Parts` with `AddPart` method.
 
 All parts are guaranteed to be delivered together. The Receive call in the sink will recive the entire parts structure.
 

--- a/examples/multipart/sampler.cxx
+++ b/examples/multipart/sampler.cxx
@@ -35,15 +35,15 @@ struct Sampler : fair::mq::Device
         }
         LOG(info) << "Sending header with stopFlag: " << header.stopFlag;
 
-        FairMQParts parts;
+        fair::mq::Parts parts;
 
         // NewSimpleMessage creates a copy of the data and takes care of its destruction (after the transfer takes place).
         // Should only be used for small data because of the cost of an additional copy
         parts.AddPart(NewSimpleMessage(header));
         parts.AddPart(NewMessage(1000));
 
-        // create more data parts, testing the FairMQParts in-place constructor
-        FairMQParts auxData{ NewMessage(500), NewMessage(600), NewMessage(700) };
+        // create more data parts, testing the fair::mq::Parts in-place constructor
+        fair::mq::Parts auxData{ NewMessage(500), NewMessage(600), NewMessage(700) };
         assert(auxData.Size() == 3);
         parts.AddPart(std::move(auxData));
         assert(auxData.Size() == 0);

--- a/examples/multipart/sink.cxx
+++ b/examples/multipart/sink.cxx
@@ -20,7 +20,7 @@ struct Sink : fair::mq::Device
         OnData("data", &Sink::HandleData);
     }
 
-    bool HandleData(FairMQParts& parts, int)
+    bool HandleData(fair::mq::Parts& parts, int)
     {
         LOG(info) << "Received message with " << parts.Size() << " parts";
 

--- a/examples/multiple-channels/README.md
+++ b/examples/multiple-channels/README.md
@@ -5,4 +5,4 @@ This example demonstrates how to work with multiple channels and multiplex betwe
 
 A topology of three devices - **Sampler**, **Sink** and **Broadcaster**. The Sampler sends data to the Sink via the PUSH-PULL pattern. The Broadcaster device sends a message to both Sampler and Sink containing a string "OK" every second. The Broadcaster sends the message via PUB pattern. Both Sampler and Sink, besides doing their PUSH-PULL job, listen via SUB to the Broadcaster.
 
-The multiplexing between their data channels and the broadcast channels happens with `FairMQPoller`.
+The multiplexing between their data channels and the broadcast channels happens with `fair::mq::Poller`.

--- a/examples/multiple-channels/broadcaster.cxx
+++ b/examples/multiple-channels/broadcaster.cxx
@@ -22,7 +22,7 @@ struct Broadcaster : fair::mq::Device
 
         // NewSimpleMessage creates a copy of the data and takes care of its destruction (after the transfer takes place).
         // Should only be used for small data because of the cost of an additional copy
-        FairMQMessagePtr msg(NewSimpleMessage("OK"));
+        fair::mq::MessagePtr msg(NewSimpleMessage("OK"));
 
         LOG(info) << "Sending OK";
 

--- a/examples/multiple-channels/sampler.cxx
+++ b/examples/multiple-channels/sampler.cxx
@@ -7,7 +7,7 @@
  ********************************************************************************/
 
 #include <fairmq/Device.h>
-#include <FairMQPoller.h>
+#include <fairmq/Poller.h>
 #include <fairmq/runDevice.h>
 
 #include <chrono>
@@ -26,13 +26,13 @@ struct Sampler : fair::mq::Device
 
     void Run() override
     {
-        FairMQPollerPtr poller(NewPoller("data", "broadcast"));
+        fair::mq::PollerPtr poller(NewPoller("data", "broadcast"));
 
         while (!NewStatePending()) {
             poller->Poll(100);
 
             if (poller->CheckInput("broadcast", 0)) {
-                FairMQMessagePtr msg(NewMessage());
+                fair::mq::MessagePtr msg(NewMessage());
 
                 if (Receive(msg, "broadcast") > 0) {
                     LOG(info) << "Received broadcast: \"" << std::string(static_cast<char*>(msg->GetData()), msg->GetSize()) << "\"";
@@ -42,7 +42,7 @@ struct Sampler : fair::mq::Device
             if (poller->CheckOutput("data", 0)) {
                 std::this_thread::sleep_for(std::chrono::seconds(1));
 
-                FairMQMessagePtr msg(NewSimpleMessage(fText));
+                fair::mq::MessagePtr msg(NewSimpleMessage(fText));
 
                 if (Send(msg, "data") > 0) {
                     LOG(info) << "Sent \"" << fText << "\"";

--- a/examples/multiple-channels/sink.cxx
+++ b/examples/multiple-channels/sink.cxx
@@ -27,7 +27,7 @@ struct Sink : fair::mq::Device
         fMaxIterations = fConfig->GetProperty<uint64_t>("max-iterations");
     }
 
-    bool HandleBroadcast(FairMQMessagePtr& msg, int /*index*/)
+    bool HandleBroadcast(fair::mq::MessagePtr& msg, int /*index*/)
     {
         LOG(info) << "Received broadcast: \"" << std::string(static_cast<char*>(msg->GetData()), msg->GetSize()) << "\"";
         fReceivedBroadcast = true;
@@ -35,7 +35,7 @@ struct Sink : fair::mq::Device
         return CheckIterations();
     }
 
-    bool HandleData(FairMQMessagePtr& msg, int /*index*/)
+    bool HandleData(fair::mq::MessagePtr& msg, int /*index*/)
     {
         LOG(info) << "Received message: \"" << std::string(static_cast<char*>(msg->GetData()), msg->GetSize()) << "\"";
         fReceivedData = true;

--- a/examples/multiple-transports/sampler1.cxx
+++ b/examples/multiple-transports/sampler1.cxx
@@ -28,7 +28,7 @@ struct Sampler1 : fair::mq::Device
     bool ConditionalRun() override
     {
         // Creates a message using the transport of channel data1
-        FairMQMessagePtr msg(NewMessageFor("data1", 0, 1000000));
+        fair::mq::MessagePtr msg(NewMessageFor("data1", 0, 1000000));
 
         // in case of error or transfer interruption, return false to go to IDLE state
         // successfull transfer will return number of bytes transfered (can be 0 if sending an empty message).
@@ -54,7 +54,7 @@ struct Sampler1 : fair::mq::Device
         uint64_t numAcks = 0;
 
         while (!NewStatePending()) {
-            FairMQMessagePtr ack(NewMessageFor("ack", 0));
+            fair::mq::MessagePtr ack(NewMessageFor("ack", 0));
             if (Receive(ack, "ack") < 0) {
                 break;
             }

--- a/examples/multiple-transports/sampler2.cxx
+++ b/examples/multiple-transports/sampler2.cxx
@@ -22,7 +22,7 @@ struct Sampler2 : fair::mq::Device
 
     bool ConditionalRun() override
     {
-        FairMQMessagePtr msg(NewMessage(1000));
+        fair::mq::MessagePtr msg(NewMessage(1000));
 
         // in case of error or transfer interruption, return false to go to IDLE state
         // successfull transfer will return number of bytes transfered (can be 0 if sending an empty message).

--- a/examples/multiple-transports/sink.cxx
+++ b/examples/multiple-transports/sink.cxx
@@ -26,11 +26,11 @@ struct Sink : fair::mq::Device
     }
 
     // handler is called whenever a message arrives on "data", with a reference to the message and a sub-channel index (here 0)
-    bool HandleData1(FairMQMessagePtr& /*msg*/, int /*index*/)
+    bool HandleData1(fair::mq::MessagePtr& /*msg*/, int /*index*/)
     {
         fNumIterations1++;
         // Creates a message using the transport of channel ack
-        FairMQMessagePtr ack(NewMessageFor("ack", 0));
+        fair::mq::MessagePtr ack(NewMessageFor("ack", 0));
         if (Send(ack, "ack") < 0) {
             return false;
         }
@@ -40,7 +40,7 @@ struct Sink : fair::mq::Device
     }
 
     // handler is called whenever a message arrives on "data", with a reference to the message and a sub-channel index (here 0)
-    bool HandleData2(FairMQMessagePtr& /*msg*/, int /*index*/)
+    bool HandleData2(fair::mq::MessagePtr& /*msg*/, int /*index*/)
     {
         fNumIterations2++;
         // return true if want to be called again (otherwise go to IDLE state)

--- a/examples/n-m/receiver.cxx
+++ b/examples/n-m/receiver.cxx
@@ -24,7 +24,7 @@ namespace bpo = boost::program_options;
 
 struct TFBuffer
 {
-    FairMQParts parts;
+    fair::mq::Parts parts;
     chrono::steady_clock::time_point start;
     chrono::steady_clock::time_point end;
 };
@@ -43,7 +43,7 @@ struct Receiver : fair::mq::Device
         fMaxTimeframes = GetConfig()->GetValue<int>("max-timeframes");
     }
 
-    bool HandleData(FairMQParts& parts, int /* index */)
+    bool HandleData(fair::mq::Parts& parts, int /* index */)
     {
         Header& h = *(static_cast<Header*>(parts.At(0)->GetData()));
         // LOG(info) << "Received sub-time frame #" << h.id << " from Sender" << h.senderIndex;
@@ -107,7 +107,7 @@ void addCustomOptions(bpo::options_description& options)
         ("max-timeframes", bpo::value<int>()->default_value(0), "Maximum number of timeframes to receive (0 - unlimited)");
 }
 
-std::unique_ptr<fair::mq::Device> getDevice(FairMQProgOptions& /* config */)
+std::unique_ptr<fair::mq::Device> getDevice(fair::mq::ProgOptions& /* config */)
 {
     return std::make_unique<Receiver>();
 }

--- a/examples/n-m/sender.cxx
+++ b/examples/n-m/sender.cxx
@@ -28,11 +28,11 @@ struct Sender : fair::mq::Device
 
     void Run() override
     {
-        FairMQChannel& dataInChannel = GetChannel("sync", 0);
+        fair::mq::Channel& dataInChannel = GetChannel("sync", 0);
 
         while (!NewStatePending()) {
             Header h;
-            FairMQMessagePtr id(NewMessage());
+            fair::mq::MessagePtr id(NewMessage());
             if (dataInChannel.Receive(id) > 0) {
                 h.id = *(static_cast<uint16_t*>(id->GetData()));
                 h.senderIndex = fIndex;
@@ -40,7 +40,7 @@ struct Sender : fair::mq::Device
                 continue;
             }
 
-            FairMQParts parts;
+            fair::mq::Parts parts;
             parts.AddPart(NewSimpleMessage(h));
             parts.AddPart(NewMessage(fSubtimeframeSize));
 
@@ -66,7 +66,7 @@ void addCustomOptions(bpo::options_description& options)
         ("subtimeframe-size", bpo::value<int>()->default_value(1000), "Subtimeframe size in bytes")
         ("num-receivers", bpo::value<int>()->required(), "Number of EPNs");
 }
-std::unique_ptr<fair::mq::Device> getDevice(FairMQProgOptions& /* config */)
+std::unique_ptr<fair::mq::Device> getDevice(fair::mq::ProgOptions& /* config */)
 {
     return std::make_unique<Sender>();
 }

--- a/examples/n-m/synchronizer.cxx
+++ b/examples/n-m/synchronizer.cxx
@@ -19,7 +19,7 @@ struct Synchronizer : fair::mq::Device
 {
     bool ConditionalRun() override
     {
-        FairMQMessagePtr msg(NewSimpleMessage(fTimeframeId));
+        fair::mq::MessagePtr msg(NewSimpleMessage(fTimeframeId));
 
         if (Send(msg, "sync") > 0) {
             if (++fTimeframeId == UINT16_MAX - 1) {
@@ -37,7 +37,7 @@ struct Synchronizer : fair::mq::Device
 };
 
 void addCustomOptions(bpo::options_description& /* options */) {}
-std::unique_ptr<fair::mq::Device> getDevice(FairMQProgOptions& /* config */)
+std::unique_ptr<fair::mq::Device> getDevice(fair::mq::ProgOptions& /* config */)
 {
     return std::make_unique<Synchronizer>();
 }

--- a/examples/qc/qCDispatcher.cxx
+++ b/examples/qc/qCDispatcher.cxx
@@ -30,10 +30,10 @@ struct QCDispatcher : fair::mq::Device
         });
     }
 
-    bool HandleData(FairMQMessagePtr& msg, int)
+    bool HandleData(fair::mq::MessagePtr& msg, int)
     {
         if (fDoQC.load() == true) {
-            FairMQMessagePtr msgCopy(NewMessage());
+            fair::mq::MessagePtr msgCopy(NewMessage());
             msgCopy->Copy(*msg);
             if (Send(msg, "qc") < 0) {
                 return false;

--- a/examples/qc/qCTask.cxx
+++ b/examples/qc/qCTask.cxx
@@ -9,12 +9,12 @@
 #include <fairmq/Device.h>
 #include <fairmq/runDevice.h>
 
-class QCTask : public FairMQDevice
+class QCTask : public fair::mq::Device
 {
   public:
     QCTask()
     {
-        OnData("qc", [](FairMQMessagePtr& /*msg*/, int) {
+        OnData("qc", [](fair::mq::MessagePtr& /*msg*/, int) {
             LOG(info) << "received data";
             return false;
         });

--- a/examples/qc/sampler.cxx
+++ b/examples/qc/sampler.cxx
@@ -16,7 +16,7 @@ struct Sampler : fair::mq::Device
 {
     bool ConditionalRun() override
     {
-        FairMQMessagePtr msg(NewMessage(1000));
+        fair::mq::MessagePtr msg(NewMessage(1000));
 
         if (Send(msg, "data1") < 0) {
             return false;

--- a/examples/qc/sink.cxx
+++ b/examples/qc/sink.cxx
@@ -14,7 +14,7 @@
 struct Sink : fair::mq::Device
 {
     Sink() { OnData("data2", &Sink::HandleData); }
-    bool HandleData(FairMQMessagePtr& /*msg*/, int /*index*/) { return true; }
+    bool HandleData(fair::mq::MessagePtr& /*msg*/, int /*index*/) { return true; }
 };
 
 namespace bpo = boost::program_options;

--- a/examples/readout/builder.cxx
+++ b/examples/readout/builder.cxx
@@ -13,7 +13,7 @@
 
 namespace bpo = boost::program_options;
 
-class Builder : public FairMQDevice
+class Builder : public fair::mq::Device
 {
   public:
     Builder() = default;
@@ -24,7 +24,7 @@ class Builder : public FairMQDevice
         OnData("rb", &Builder::HandleData);
     }
 
-    bool HandleData(FairMQMessagePtr& msg, int /*index*/)
+    bool HandleData(fair::mq::MessagePtr& msg, int /*index*/)
     {
         if (Send(msg, fOutputChannelName) < 0) {
             return false;

--- a/examples/readout/processor.cxx
+++ b/examples/readout/processor.cxx
@@ -18,9 +18,9 @@ struct Processor : fair::mq::Device
         OnData("bp", &Processor::HandleData);
     }
 
-    bool HandleData(FairMQMessagePtr& msg, int /*index*/)
+    bool HandleData(fair::mq::MessagePtr& msg, int /*index*/)
     {
-        FairMQMessagePtr msg2(NewMessageFor("ps", 0, msg->GetSize()));
+        fair::mq::MessagePtr msg2(NewMessageFor("ps", 0, msg->GetSize()));
         if (Send(msg2, "ps") < 0) {
             return false;
         }

--- a/examples/readout/readout.cxx
+++ b/examples/readout/readout.cxx
@@ -22,7 +22,7 @@ struct Readout : fair::mq::Device
         fMsgSize = fConfig->GetProperty<int>("msg-size");
         fMaxIterations = fConfig->GetProperty<uint64_t>("max-iterations");
 
-        fRegion = FairMQUnmanagedRegionPtr(NewUnmanagedRegionFor("rb",
+        fRegion = fair::mq::UnmanagedRegionPtr(NewUnmanagedRegionFor("rb",
                                                                 0,
                                                                 10000000,
                                                                 [this](const std::vector<fair::mq::RegionBlock>& blocks) { // callback to be called when message buffers no longer needed by transport
@@ -36,7 +36,7 @@ struct Readout : fair::mq::Device
 
     bool ConditionalRun() override
     {
-        FairMQMessagePtr msg(NewMessageFor("rb", // channel
+        fair::mq::MessagePtr msg(NewMessageFor("rb", // channel
                                             0, // sub-channel
                                             fRegion, // region
                                             fRegion->GetData(), // ptr within region
@@ -71,7 +71,7 @@ struct Readout : fair::mq::Device
     int fMsgSize = 10000;
     uint64_t fMaxIterations = 0;
     uint64_t fNumIterations = 0;
-    FairMQUnmanagedRegionPtr fRegion = nullptr;
+    fair::mq::UnmanagedRegionPtr fRegion = nullptr;
     std::atomic<uint64_t> fNumUnackedMsgs = 0;
 };
 

--- a/examples/readout/sender.cxx
+++ b/examples/readout/sender.cxx
@@ -21,7 +21,7 @@ struct Sender : fair::mq::Device
         OnData(fInputChannelName, &Sender::HandleData);
     }
 
-    bool HandleData(FairMQMessagePtr& msg, int /*index*/)
+    bool HandleData(fair::mq::MessagePtr& msg, int /*index*/)
     {
         if (Send(msg, "sr") < 0) {
             return false;

--- a/examples/region/sampler.cxx
+++ b/examples/region/sampler.cxx
@@ -23,7 +23,7 @@ struct Sampler : fair::mq::Device
         fLinger = fConfig->GetProperty<uint32_t>("region-linger");
         fMaxIterations = fConfig->GetProperty<uint64_t>("max-iterations");
 
-        GetChannel("data", 0).Transport()->SubscribeToRegionEvents([](FairMQRegionInfo info) {
+        GetChannel("data", 0).Transport()->SubscribeToRegionEvents([](fair::mq::RegionInfo info) {
             LOG(info) << "Region event: " << info.event << ": "
                     << (info.managed ? "managed" : "unmanaged")
                     << ", id: " << info.id
@@ -36,7 +36,7 @@ struct Sampler : fair::mq::Device
         regionCfg.linger = fLinger; // delay in ms before region destruction to collect outstanding events
         regionCfg.lock = true; // mlock region after creation
         regionCfg.zero = true; // zero region content after creation
-        fRegion = FairMQUnmanagedRegionPtr(NewUnmanagedRegionFor("data", // region is created using the transport of this channel...
+        fRegion = fair::mq::UnmanagedRegionPtr(NewUnmanagedRegionFor("data", // region is created using the transport of this channel...
                                                                 0,      // ... and this sub-channel
                                                                 10000000, // region size
                                                                 [this](const std::vector<fair::mq::RegionBlock>& blocks) { // callback to be called when message buffers no longer needed by transport
@@ -50,7 +50,7 @@ struct Sampler : fair::mq::Device
 
     bool ConditionalRun() override
     {
-        FairMQMessagePtr msg(NewMessageFor("data", // channel
+        fair::mq::MessagePtr msg(NewMessageFor("data", // channel
                                             0, // sub-channel
                                             fRegion, // region
                                             fRegion->GetData(), // ptr within region
@@ -93,7 +93,7 @@ struct Sampler : fair::mq::Device
     uint32_t fLinger = 100;
     uint64_t fMaxIterations = 0;
     uint64_t fNumIterations = 0;
-    FairMQUnmanagedRegionPtr fRegion = nullptr;
+    fair::mq::UnmanagedRegionPtr fRegion = nullptr;
     std::mutex fMtx;
     uint64_t fNumUnackedMsgs = 0;
 };

--- a/examples/req-rep/client.cxx
+++ b/examples/req-rep/client.cxx
@@ -32,11 +32,11 @@ struct Client : fair::mq::Device
         // its size,
         // custom deletion function (called when transfer is done),
         // and pointer to the object managing the data buffer
-        FairMQMessagePtr req(NewMessage(const_cast<char*>(text->c_str()), // data
+        fair::mq::MessagePtr req(NewMessage(const_cast<char*>(text->c_str()), // data
                                                             text->length(), // size
                                                             [](void* /*data*/, void* object) { delete static_cast<std::string*>(object); }, // deletion callback
                                                             text)); // object that manages the data
-        FairMQMessagePtr rep(NewMessage());
+        fair::mq::MessagePtr rep(NewMessage());
 
         LOG(info) << "Sending \"" << fText << "\" to server.";
 

--- a/examples/req-rep/server.cxx
+++ b/examples/req-rep/server.cxx
@@ -26,7 +26,7 @@ struct Server : fair::mq::Device
         fMaxIterations = fConfig->GetProperty<uint64_t>("max-iterations");
     }
 
-    bool HandleData(FairMQMessagePtr& req, int)
+    bool HandleData(fair::mq::MessagePtr& req, int)
     {
         LOG(info) << "Received request from client: \"" << std::string(static_cast<char*>(req->GetData()), req->GetSize()) << "\"";
 
@@ -34,7 +34,7 @@ struct Server : fair::mq::Device
 
         LOG(info) << "Sending reply to client.";
 
-        FairMQMessagePtr rep(NewMessage(const_cast<char*>(text->c_str()), // data
+        fair::mq::MessagePtr rep(NewMessage(const_cast<char*>(text->c_str()), // data
                                                             text->length(), // size
                                                             [](void* /*data*/, void* object) { delete static_cast<std::string*>(object); }, // deletion callback
                                                             text)); // object that manages the data

--- a/fairmq/JSONParser.cxx
+++ b/fairmq/JSONParser.cxx
@@ -30,13 +30,13 @@
 
 using namespace std;
 using namespace fair::mq;
-using namespace fair::mq::tools;
+using namespace tools;
 using namespace boost::property_tree;
 
 namespace fair::mq
 {
 
-fair::mq::Properties PtreeParser(const ptree& pt, const string& id)
+Properties PtreeParser(const ptree& pt, const string& id)
 {
     if (id.empty()) {
         throw ParserError("no device ID provided. Provide with `--id` cmd option");
@@ -47,7 +47,7 @@ fair::mq::Properties PtreeParser(const ptree& pt, const string& id)
     return helper::DeviceParser(pt.get_child("fairMQOptions"), id);
 }
 
-fair::mq::Properties JSONParser(const string& filename, const string& deviceId)
+Properties JSONParser(const string& filename, const string& deviceId)
 {
     ptree pt;
     LOG(debug) << "Parsing JSON from " << filename << " ...";
@@ -58,9 +58,9 @@ fair::mq::Properties JSONParser(const string& filename, const string& deviceId)
 namespace helper
 {
 
-fair::mq::Properties DeviceParser(const ptree& fairMQOptions, const string& deviceId)
+Properties DeviceParser(const ptree& fairMQOptions, const string& deviceId)
 {
-    fair::mq::Properties properties;
+    Properties properties;
 
     for (const auto& node : fairMQOptions) {
         if (node.first == "devices") {
@@ -82,27 +82,27 @@ fair::mq::Properties DeviceParser(const ptree& fairMQOptions, const string& devi
     return properties;
 }
 
-void ChannelParser(const ptree& tree, fair::mq::Properties& properties)
+void ChannelParser(const ptree& tree, Properties& properties)
 {
     for (const auto& node : tree) {
         if (node.first == "channels") {
             for (const auto& cn : node.second) {
-                fair::mq::Properties commonProperties;
-                commonProperties.emplace("type", cn.second.get<string>("type", FairMQChannel::DefaultType));
-                commonProperties.emplace("method", cn.second.get<string>("method", FairMQChannel::DefaultMethod));
-                commonProperties.emplace("address", cn.second.get<string>("address", FairMQChannel::DefaultAddress));
-                commonProperties.emplace("transport", cn.second.get<string>("transport", FairMQChannel::DefaultTransportName));
-                commonProperties.emplace("sndBufSize", cn.second.get<int>("sndBufSize", FairMQChannel::DefaultSndBufSize));
-                commonProperties.emplace("rcvBufSize", cn.second.get<int>("rcvBufSize", FairMQChannel::DefaultRcvBufSize));
-                commonProperties.emplace("sndKernelSize", cn.second.get<int>("sndKernelSize", FairMQChannel::DefaultSndKernelSize));
-                commonProperties.emplace("rcvKernelSize", cn.second.get<int>("rcvKernelSize", FairMQChannel::DefaultRcvKernelSize));
-                commonProperties.emplace("sndTimeoutMs", cn.second.get<int>("sndTimeoutMs", FairMQChannel::DefaultSndTimeoutMs));
-                commonProperties.emplace("rcvTimeoutMs", cn.second.get<int>("rcvTimeoutMs", FairMQChannel::DefaultRcvTimeoutMs));
-                commonProperties.emplace("linger", cn.second.get<int>("linger", FairMQChannel::DefaultLinger));
-                commonProperties.emplace("rateLogging", cn.second.get<int>("rateLogging", FairMQChannel::DefaultRateLogging));
-                commonProperties.emplace("portRangeMin", cn.second.get<int>("portRangeMin", FairMQChannel::DefaultPortRangeMin));
-                commonProperties.emplace("portRangeMax", cn.second.get<int>("portRangeMax", FairMQChannel::DefaultPortRangeMax));
-                commonProperties.emplace("autoBind", cn.second.get<bool>("autoBind", FairMQChannel::DefaultAutoBind));
+                Properties commonProperties;
+                commonProperties.emplace("type", cn.second.get<string>("type", Channel::DefaultType));
+                commonProperties.emplace("method", cn.second.get<string>("method", Channel::DefaultMethod));
+                commonProperties.emplace("address", cn.second.get<string>("address", Channel::DefaultAddress));
+                commonProperties.emplace("transport", cn.second.get<string>("transport", Channel::DefaultTransportName));
+                commonProperties.emplace("sndBufSize", cn.second.get<int>("sndBufSize", Channel::DefaultSndBufSize));
+                commonProperties.emplace("rcvBufSize", cn.second.get<int>("rcvBufSize", Channel::DefaultRcvBufSize));
+                commonProperties.emplace("sndKernelSize", cn.second.get<int>("sndKernelSize", Channel::DefaultSndKernelSize));
+                commonProperties.emplace("rcvKernelSize", cn.second.get<int>("rcvKernelSize", Channel::DefaultRcvKernelSize));
+                commonProperties.emplace("sndTimeoutMs", cn.second.get<int>("sndTimeoutMs", Channel::DefaultSndTimeoutMs));
+                commonProperties.emplace("rcvTimeoutMs", cn.second.get<int>("rcvTimeoutMs", Channel::DefaultRcvTimeoutMs));
+                commonProperties.emplace("linger", cn.second.get<int>("linger", Channel::DefaultLinger));
+                commonProperties.emplace("rateLogging", cn.second.get<int>("rateLogging", Channel::DefaultRateLogging));
+                commonProperties.emplace("portRangeMin", cn.second.get<int>("portRangeMin", Channel::DefaultPortRangeMin));
+                commonProperties.emplace("portRangeMax", cn.second.get<int>("portRangeMax", Channel::DefaultPortRangeMax));
+                commonProperties.emplace("autoBind", cn.second.get<bool>("autoBind", Channel::DefaultAutoBind));
 
                 string name = cn.second.get<string>("name");
                 int numSockets = cn.second.get<int>("numSockets", 0);
@@ -128,7 +128,7 @@ void ChannelParser(const ptree& tree, fair::mq::Properties& properties)
     }
 }
 
-void SubChannelParser(const ptree& channelTree, fair::mq::Properties& properties, const string& channelName, const fair::mq::Properties& commonProperties)
+void SubChannelParser(const ptree& channelTree, Properties& properties, const string& channelName, const Properties& commonProperties)
 {
     // for each socket in channel
     int i = 0;
@@ -137,7 +137,7 @@ void SubChannelParser(const ptree& channelTree, fair::mq::Properties& properties
         if (node.first == "sockets") {
             for (const auto& sn : node.second) {
                 // a sub-channel inherits relevant properties from the common channel ...
-                fair::mq::Properties newProperties(commonProperties);
+                Properties newProperties(commonProperties);
 
                 // ... and adds/overwrites its own properties
                 newProperties["type"] = sn.second.get<string>("type", boost::any_cast<string>(commonProperties.at("type")));
@@ -177,7 +177,7 @@ void SubChannelParser(const ptree& channelTree, fair::mq::Properties& properties
         LOG(trace) << "\tNo sockets specified,";
         LOG(trace) << "\tapplying common settings to the channel:";
 
-        fair::mq::Properties newProperties(commonProperties);
+        Properties newProperties(commonProperties);
 
         for (auto& p : newProperties) {
             LOG(trace) << "\t" << setw(13) << left << p.first << " : " << p.second;

--- a/fairmq/MemoryResourceTools.h
+++ b/fairmq/MemoryResourceTools.h
@@ -12,7 +12,7 @@
 ///
 /// @author Mikolaj Krzewicki, mkrzewic@cern.ch
 
-#include <fairmq/FairMQTransportFactory.h>
+#include <fairmq/TransportFactory.h>
 #include <fairmq/MemoryResources.h>
 
 namespace fair::mq
@@ -28,13 +28,13 @@ template<typename ContainerT>
 //        pmr::polymorphic_allocator<typename
 //        ContainerT::value_type>,
 //        typename ContainerT::allocator_type>::value == true,
-//    FairMQMessagePtr>::type
-FairMQMessagePtr getMessage(ContainerT &&container_, FairMQMemoryResource *targetResource = nullptr)
+//        MessagePtr>::type
+MessagePtr getMessage(ContainerT &&container_, MemoryResource *targetResource = nullptr)
 {
     auto container = std::move(container_);
     auto alloc = container.get_allocator();
 
-    auto resource = dynamic_cast<FairMQMemoryResource *>(alloc.resource());
+    auto resource = dynamic_cast<MemoryResource *>(alloc.resource());
     if (!resource && !targetResource) {
         throw std::runtime_error("Neither the container or target resource specified");
     }

--- a/fairmq/Plugin.cxx
+++ b/fairmq/Plugin.cxx
@@ -7,7 +7,7 @@
  ********************************************************************************/
 
 #include <fairmq/Plugin.h>
-#include <FairMQLogger.h>
+#include <fairlogger/Logger.h>
 #include <utility>
 
 using namespace std;

--- a/fairmq/ProgOptions.cxx
+++ b/fairmq/ProgOptions.cxx
@@ -351,7 +351,7 @@ void ProgOptions::DeleteProperty(const string& key)
     vm.erase(key);
 }
 
-void ProgOptions::AddChannel(const string& name, const FairMQChannel& channel)
+void ProgOptions::AddChannel(const string& name, const Channel& channel)
 {
     lock_guard<mutex> lock(fMtx);
     unordered_map<string, int> existingChannels = GetChannelInfoImpl();

--- a/fairmq/devices/BenchmarkSampler.h
+++ b/fairmq/devices/BenchmarkSampler.h
@@ -44,7 +44,7 @@ class BenchmarkSampler : public Device
     void Run() override
     {
         // store the channel reference to avoid traversing the map on every loop iteration
-        FairMQChannel& dataOutChannel = GetChannel(fOutChannelName, 0);
+        Channel& dataOutChannel = GetChannel(fOutChannelName, 0);
 
         LOG(info) << "Starting the benchmark with message size of " << fMsgSize << " and " << fMaxIterations << " iterations.";
         auto tStart = std::chrono::high_resolution_clock::now();
@@ -53,7 +53,7 @@ class BenchmarkSampler : public Device
 
         while (!NewStatePending()) {
             if (fMultipart) {
-                FairMQParts parts;
+                Parts parts;
 
                 for (size_t i = 0; i < fNumParts; ++i) {
                     parts.AddPart(dataOutChannel.NewMessage(fMsgSize, fair::mq::Alignment{fMsgAlignment}));
@@ -71,7 +71,7 @@ class BenchmarkSampler : public Device
                     ++fNumIterations;
                 }
             } else {
-                FairMQMessagePtr msg(dataOutChannel.NewMessage(fMsgSize, fair::mq::Alignment{fMsgAlignment}));
+                MessagePtr msg(dataOutChannel.NewMessage(fMsgSize, fair::mq::Alignment{fMsgAlignment}));
                 if (fMemSet) {
                     std::memset(msg->GetData(), 0, msg->GetSize());
                 }

--- a/fairmq/devices/Merger.h
+++ b/fairmq/devices/Merger.h
@@ -9,7 +9,7 @@
 #ifndef FAIR_MQ_MERGER_H
 #define FAIR_MQ_MERGER_H
 
-#include <FairMQPoller.h>
+#include <fairmq/Poller.h>
 #include <fairmq/Device.h>
 
 #include <fairlogger/Logger.h>
@@ -45,13 +45,13 @@ class Merger : public Device
     {
         int numInputs = GetNumSubChannels(fInChannelName);
 
-        std::vector<FairMQChannel*> chans;
+        std::vector<Channel*> chans;
 
         for (auto& chan : fChannels.at(fInChannelName)) {
             chans.push_back(&chan);
         }
 
-        FairMQPollerPtr poller(NewPoller(chans));
+        PollerPtr poller(NewPoller(chans));
 
         if (fMultipart) {
             while (!NewStatePending()) {
@@ -61,7 +61,7 @@ class Merger : public Device
                 for (int i = 0; i < numInputs; ++i) {
                     // Check if the channel has data ready to be received.
                     if (poller->CheckInput(i)) {
-                        FairMQParts payload;
+                        Parts payload;
 
                         if (Receive(payload, fInChannelName, i) >= 0) {
                             if (Send(payload, fOutChannelName) < 0) {
@@ -83,7 +83,7 @@ class Merger : public Device
                 for (int i = 0; i < numInputs; ++i) {
                     // Check if the channel has data ready to be received.
                     if (poller->CheckInput(i)) {
-                        FairMQMessagePtr payload(fTransportFactory->CreateMessage());
+                        MessagePtr payload(fTransportFactory->CreateMessage());
 
                         if (Receive(payload, fInChannelName, i) >= 0) {
                             if (Send(payload, fOutChannelName) < 0) {

--- a/fairmq/devices/Multiplier.h
+++ b/fairmq/devices/Multiplier.h
@@ -40,11 +40,11 @@ class Multiplier : public Device
     }
 
 
-    bool HandleSingleData(std::unique_ptr<FairMQMessage>& payload, int)
+    bool HandleSingleData(std::unique_ptr<Message>& payload, int)
     {
         for (unsigned int i = 0; i < fOutChannelNames.size() - 1; ++i) { // all except last channel
             for (unsigned int j = 0; j < GetNumSubChannels(fOutChannelNames.at(i)); ++j) { // all subChannels in a channel
-                FairMQMessagePtr msgCopy(fTransportFactory->CreateMessage());
+                MessagePtr msgCopy(fTransportFactory->CreateMessage());
                 msgCopy->Copy(*payload);
 
                 Send(msgCopy, fOutChannelNames.at(i), j);
@@ -54,7 +54,7 @@ class Multiplier : public Device
         unsigned int lastChannelSize = GetNumSubChannels(fOutChannelNames.back());
 
         for (unsigned int i = 0; i < lastChannelSize - 1; ++i) { // iterate over all except last subChannels of the last channel
-            FairMQMessagePtr msgCopy(fTransportFactory->CreateMessage());
+            MessagePtr msgCopy(fTransportFactory->CreateMessage());
             msgCopy->Copy(*payload);
 
             Send(msgCopy, fOutChannelNames.back(), i);
@@ -65,14 +65,14 @@ class Multiplier : public Device
         return true;
     }
 
-    bool HandleMultipartData(FairMQParts& payload, int)
+    bool HandleMultipartData(Parts& payload, int)
     {
         for (unsigned int i = 0; i < fOutChannelNames.size() - 1; ++i) { // all except last channel
             for (unsigned int j = 0; j < GetNumSubChannels(fOutChannelNames.at(i)); ++j) { // all subChannels in a channel
-                FairMQParts parts;
+                Parts parts;
 
                 for (int k = 0; k < payload.Size(); ++k) {
-                    FairMQMessagePtr msgCopy(fTransportFactory->CreateMessage());
+                    MessagePtr msgCopy(fTransportFactory->CreateMessage());
                     msgCopy->Copy(payload.AtRef(k));
                     parts.AddPart(std::move(msgCopy));
                 }
@@ -84,10 +84,10 @@ class Multiplier : public Device
         unsigned int lastChannelSize = GetNumSubChannels(fOutChannelNames.back());
 
         for (unsigned int i = 0; i < lastChannelSize - 1; ++i) { // iterate over all except last subChannels of the last channel
-            FairMQParts parts;
+            Parts parts;
 
             for (int k = 0; k < payload.Size(); ++k) {
-                FairMQMessagePtr msgCopy(fTransportFactory->CreateMessage());
+                MessagePtr msgCopy(fTransportFactory->CreateMessage());
                 msgCopy->Copy(payload.AtRef(k));
                 parts.AddPart(std::move(msgCopy));
             }

--- a/fairmq/devices/Proxy.h
+++ b/fairmq/devices/Proxy.h
@@ -34,7 +34,7 @@ class Proxy : public Device
     {
         if (fMultipart) {
             while (!NewStatePending()) {
-                FairMQParts payload;
+                Parts payload;
                 if (Receive(payload, fInChannelName) >= 0) {
                     if (Send(payload, fOutChannelName) < 0) {
                         LOG(debug) << "Transfer interrupted";
@@ -47,7 +47,7 @@ class Proxy : public Device
             }
         } else {
             while (!NewStatePending()) {
-                FairMQMessagePtr payload(fTransportFactory->CreateMessage());
+                MessagePtr payload(fTransportFactory->CreateMessage());
                 if (Receive(payload, fInChannelName) >= 0) {
                     if (Send(payload, fOutChannelName) < 0) {
                         LOG(debug) << "Transfer interrupted";

--- a/fairmq/devices/Sink.h
+++ b/fairmq/devices/Sink.h
@@ -9,7 +9,6 @@
 #ifndef FAIR_MQ_SINK_H
 #define FAIR_MQ_SINK_H
 
-#include <FairMQPoller.h>
 #include <fairmq/Device.h>
 #include <fairmq/tools/Strings.h>
 
@@ -48,7 +47,7 @@ class Sink : public Device
     void Run() override
     {
         // store the channel reference to avoid traversing the map on every loop iteration
-        FairMQChannel& dataInChannel = GetChannel(fInChannelName, 0);
+        Channel& dataInChannel = GetChannel(fInChannelName, 0);
 
         LOG(info) << "Starting sink and expecting to receive " << fMaxIterations << " messages.";
         auto tStart = std::chrono::high_resolution_clock::now();
@@ -70,7 +69,7 @@ class Sink : public Device
 
         while (!NewStatePending()) {
             if (fMultipart) {
-                FairMQParts parts;
+                Parts parts;
                 if (dataInChannel.Receive(parts) < 0) {
                     continue;
                 }
@@ -80,7 +79,7 @@ class Sink : public Device
                     }
                 }
             } else {
-                FairMQMessagePtr msg(dataInChannel.NewMessage());
+                MessagePtr msg(dataInChannel.NewMessage());
                 if (dataInChannel.Receive(msg) < 0) {
                     continue;
                 }

--- a/fairmq/devices/Splitter.h
+++ b/fairmq/devices/Splitter.h
@@ -34,9 +34,9 @@ class Splitter : public Device
         fDirection = 0;
 
         if (fMultipart) {
-            OnData(fInChannelName, &Splitter::HandleData<FairMQParts>);
+            OnData(fInChannelName, &Splitter::HandleData<Parts>);
         } else {
-            OnData(fInChannelName, &Splitter::HandleData<FairMQMessagePtr>);
+            OnData(fInChannelName, &Splitter::HandleData<MessagePtr>);
         }
     }
 

--- a/fairmq/ofi/Socket.cxx
+++ b/fairmq/ofi/Socket.cxx
@@ -10,7 +10,7 @@
 #include <fairmq/ofi/Socket.h>
 #include <fairmq/ofi/TransportFactory.h>
 #include <fairmq/tools/Strings.h>
-#include <FairMQLogger.h>
+#include <fairlogger/Logger.h>
 
 #include <asiofi.hpp>
 #include <asio/buffer.hpp>

--- a/fairmq/plugins/PMIx/PMIxCommands.h
+++ b/fairmq/plugins/PMIx/PMIxCommands.h
@@ -11,7 +11,7 @@
 
 #include "PMIx.hpp"
 
-#include <FairMQLogger.h>
+#include <fairlogger/Logger.h>
 #include <fairmq/tools/Semaphore.h>
 #include <memory> // make_unique
 #include <string>

--- a/fairmq/plugins/PMIx/PMIxPlugin.h
+++ b/fairmq/plugins/PMIx/PMIxPlugin.h
@@ -14,7 +14,7 @@
 
 #include <fairmq/Plugin.h>
 #include <fairmq/Version.h>
-#include <FairMQLogger.h>
+#include <fairlogger/Logger.h>
 
 #include <string>
 #include <sstream>

--- a/fairmq/runFairMQDevice.h
+++ b/fairmq/runFairMQDevice.h
@@ -11,7 +11,7 @@
 #include <memory>
 #include <string>
 
-using FairMQDevicePtr = FairMQDevice*;
+using FairMQDevicePtr = fair::mq::Device*;
 
 // to be implemented by the user to return a child class of FairMQDevice
 FairMQDevicePtr getDevice(const fair::mq::ProgOptions& config);
@@ -45,7 +45,7 @@ int main(int argc, char* argv[])
         // });
 
         runner.AddHook<InstantiateDevice>([](DeviceRunner& r){
-            r.fDevice = std::unique_ptr<FairMQDevice>{getDevice(r.fConfig)};
+            r.fDevice = std::unique_ptr<fair::mq::Device>{getDevice(r.fConfig)};
         });
 
         return runner.Run();

--- a/fairmq/shmem/Message.h
+++ b/fairmq/shmem/Message.h
@@ -35,7 +35,7 @@ class Message final : public fair::mq::Message
     friend class Socket;
 
   public:
-    Message(Manager& manager, FairMQTransportFactory* factory = nullptr)
+    Message(Manager& manager, fair::mq::TransportFactory* factory = nullptr)
         : fair::mq::Message(factory)
         , fManager(manager)
         , fQueued(false)
@@ -46,7 +46,7 @@ class Message final : public fair::mq::Message
         fManager.IncrementMsgCounter();
     }
 
-    Message(Manager& manager, Alignment alignment, FairMQTransportFactory* factory = nullptr)
+    Message(Manager& manager, Alignment alignment, fair::mq::TransportFactory* factory = nullptr)
         : fair::mq::Message(factory)
         , fManager(manager)
         , fQueued(false)
@@ -58,7 +58,7 @@ class Message final : public fair::mq::Message
         fManager.IncrementMsgCounter();
     }
 
-    Message(Manager& manager, const size_t size, FairMQTransportFactory* factory = nullptr)
+    Message(Manager& manager, const size_t size, fair::mq::TransportFactory* factory = nullptr)
         : fair::mq::Message(factory)
         , fManager(manager)
         , fQueued(false)
@@ -70,7 +70,7 @@ class Message final : public fair::mq::Message
         fManager.IncrementMsgCounter();
     }
 
-    Message(Manager& manager, const size_t size, Alignment alignment, FairMQTransportFactory* factory = nullptr)
+    Message(Manager& manager, const size_t size, Alignment alignment, fair::mq::TransportFactory* factory = nullptr)
         : fair::mq::Message(factory)
         , fManager(manager)
         , fQueued(false)
@@ -83,7 +83,7 @@ class Message final : public fair::mq::Message
         fManager.IncrementMsgCounter();
     }
 
-    Message(Manager& manager, void* data, const size_t size, fairmq_free_fn* ffn, void* hint = nullptr, FairMQTransportFactory* factory = nullptr)
+    Message(Manager& manager, void* data, const size_t size, fair::mq::FreeFn* ffn, void* hint = nullptr, fair::mq::TransportFactory* factory = nullptr)
         : fair::mq::Message(factory)
         , fManager(manager)
         , fQueued(false)
@@ -102,7 +102,7 @@ class Message final : public fair::mq::Message
         fManager.IncrementMsgCounter();
     }
 
-    Message(Manager& manager, UnmanagedRegionPtr& region, void* data, const size_t size, void* hint = 0, FairMQTransportFactory* factory = nullptr)
+    Message(Manager& manager, UnmanagedRegionPtr& region, void* data, const size_t size, void* hint = 0, fair::mq::TransportFactory* factory = nullptr)
         : fair::mq::Message(factory)
         , fManager(manager)
         , fQueued(false)
@@ -125,7 +125,7 @@ class Message final : public fair::mq::Message
         fManager.IncrementMsgCounter();
     }
 
-    Message(Manager& manager, MetaHeader& hdr, FairMQTransportFactory* factory = nullptr)
+    Message(Manager& manager, MetaHeader& hdr, fair::mq::TransportFactory* factory = nullptr)
         : fair::mq::Message(factory)
         , fManager(manager)
         , fQueued(false)
@@ -169,7 +169,7 @@ class Message final : public fair::mq::Message
         InitializeChunk(size, fAlignment);
     }
 
-    void Rebuild(void* data, size_t size, fairmq_free_fn* ffn, void* hint = nullptr) override
+    void Rebuild(void* data, size_t size, fair::mq::FreeFn* ffn, void* hint = nullptr) override
     {
         CloseMessage();
         fQueued = false;

--- a/fairmq/shmem/Socket.h
+++ b/fairmq/shmem/Socket.h
@@ -51,7 +51,7 @@ struct ZMsg
 class Socket final : public fair::mq::Socket
 {
   public:
-    Socket(Manager& manager, const std::string& type, const std::string& name, const std::string& id, void* context, FairMQTransportFactory* fac = nullptr)
+    Socket(Manager& manager, const std::string& type, const std::string& name, const std::string& id, void* context, fair::mq::TransportFactory* fac = nullptr)
         : fair::mq::Socket(fac)
         , fManager(manager)
         , fId(id + "." + name + "." + type)

--- a/fairmq/shmem/TransportFactory.h
+++ b/fairmq/shmem/TransportFactory.h
@@ -113,7 +113,7 @@ class TransportFactory final : public fair::mq::TransportFactory
         return std::make_unique<Message>(*fManager, size, alignment, this);
     }
 
-    MessagePtr CreateMessage(void* data, size_t size, fairmq_free_fn* ffn, void* hint = nullptr) override
+    MessagePtr CreateMessage(void* data, size_t size, fair::mq::FreeFn* ffn, void* hint = nullptr) override
     {
         return std::make_unique<Message>(*fManager, data, size, ffn, hint, this);
     }
@@ -128,17 +128,17 @@ class TransportFactory final : public fair::mq::TransportFactory
         return std::make_unique<Socket>(*fManager, type, name, GetId(), fZmqCtx, this);
     }
 
-    PollerPtr CreatePoller(const std::vector<FairMQChannel>& channels) const override
+    PollerPtr CreatePoller(const std::vector<Channel>& channels) const override
     {
         return std::make_unique<Poller>(channels);
     }
 
-    PollerPtr CreatePoller(const std::vector<FairMQChannel*>& channels) const override
+    PollerPtr CreatePoller(const std::vector<Channel*>& channels) const override
     {
         return std::make_unique<Poller>(channels);
     }
 
-    PollerPtr CreatePoller(const std::unordered_map<std::string, std::vector<FairMQChannel>>& channelsMap, const std::vector<std::string>& channelList) const override
+    PollerPtr CreatePoller(const std::unordered_map<std::string, std::vector<Channel>>& channelsMap, const std::vector<std::string>& channelList) const override
     {
         return std::make_unique<Poller>(channelsMap, channelList);
     }

--- a/fairmq/shmem/UnmanagedRegionImpl.h
+++ b/fairmq/shmem/UnmanagedRegionImpl.h
@@ -34,7 +34,7 @@ class UnmanagedRegionImpl final : public fair::mq::UnmanagedRegion
                     RegionCallback callback,
                     RegionBulkCallback bulkCallback,
                     fair::mq::RegionConfig cfg,
-                    FairMQTransportFactory* factory)
+                    fair::mq::TransportFactory* factory)
         : fair::mq::UnmanagedRegion(factory)
         , fManager(manager)
         , fRegion(nullptr)

--- a/fairmq/zeromq/Common.h
+++ b/fairmq/zeromq/Common.h
@@ -141,7 +141,7 @@ inline auto makeMonitorSocket(void* zmqCtx, void* socketToMonitor, std::string_v
         //   the FD is still valid by the time your code receives this event.
         // ZMQ_EVENT_DISCONNECTED - The socket was disconnected unexpectedly. The event value is the
         //   FD of the underlying network socket. Warning: this socket will be closed.
-        auto const rc =
+        [[maybe_unused]] auto const rc =
             zmq_socket_monitor(socketToMonitor,
                                address.c_str(),
                                ZMQ_EVENT_CONNECTED | ZMQ_EVENT_ACCEPTED | ZMQ_EVENT_DISCONNECTED);
@@ -156,11 +156,11 @@ inline auto makeMonitorSocket(void* zmqCtx, void* socketToMonitor, std::string_v
         //            Progress only happens, when a user calls GetNumberOfConnectedPeers()`.
         //            The assumption here is, that not too many events will pile up anyways.
         int const unlimited(0);
-        auto const rc = zmq_setsockopt(mon, ZMQ_RCVHWM, &unlimited, sizeof(unlimited));
+        [[maybe_unused]] auto const rc = zmq_setsockopt(mon, ZMQ_RCVHWM, &unlimited, sizeof(unlimited));
         assertm(rc == 0, "Setting rcv queue size to unlimited succeeded");   // NOLINT
     }
     {   // Connect the reading monitor socket
-        auto const rc = zmq_connect(mon, address.c_str());
+        [[maybe_unused]] auto const rc = zmq_connect(mon, address.c_str());
         assertm(rc == 0, "Connecting reading monitor socket succeeded");   // NOLINT
     }
     return mon;
@@ -192,7 +192,7 @@ inline auto getMonitorEvent(void* monitorSocket) -> int
     assertm(zmq_msg_more(&msg), "A second frame is pending");   // NOLINT
     zmq_msg_init(&msg);
     {
-        auto const rc = zmq_msg_recv(&msg, monitorSocket, 0);
+        [[maybe_unused]] auto const rc = zmq_msg_recv(&msg, monitorSocket, 0);
         assertm(rc >= 0, "second monitor event frame successfully received");   // NOLINT
     }
     assertm(!zmq_msg_more(&msg), "No more frames are pending");   // NOLINT

--- a/fairmq/zeromq/Context.h
+++ b/fairmq/zeromq/Context.h
@@ -10,8 +10,9 @@
 #define FAIR_MQ_ZMQ_CONTEXT_H_
 
 #include <fairmq/tools/Strings.h>
-#include <FairMQLogger.h>
-#include <FairMQUnmanagedRegion.h>
+#include <fairmq/UnmanagedRegion.h>
+
+#include <fairlogger/Logger.h>
 
 #include <zmq.h>
 

--- a/fairmq/zeromq/Message.h
+++ b/fairmq/zeromq/Message.h
@@ -10,9 +10,10 @@
 #define FAIR_MQ_ZMQ_MESSAGE_H
 
 #include <fairmq/zeromq/UnmanagedRegion.h>
-#include <FairMQLogger.h>
-#include <FairMQMessage.h>
-#include <FairMQUnmanagedRegion.h>
+#include <fairmq/Message.h>
+#include <fairmq/UnmanagedRegion.h>
+
+#include <fairlogger/Logger.h>
 
 #include <zmq.h>
 
@@ -38,7 +39,7 @@ class Message final : public fair::mq::Message
     Message& operator=(const Message&) = delete;
     Message& operator=(Message&&) = delete;
 
-    Message(FairMQTransportFactory* factory = nullptr)
+    Message(fair::mq::TransportFactory* factory = nullptr)
         : fair::mq::Message(factory)
         , fMsg(std::make_unique<zmq_msg_t>())
     {
@@ -47,7 +48,7 @@ class Message final : public fair::mq::Message
         }
     }
 
-    Message(Alignment alignment, FairMQTransportFactory* factory = nullptr)
+    Message(Alignment alignment, fair::mq::TransportFactory* factory = nullptr)
         : fair::mq::Message(factory)
         , fAlignment(alignment.alignment)
         , fMsg(std::make_unique<zmq_msg_t>())
@@ -57,7 +58,7 @@ class Message final : public fair::mq::Message
         }
     }
 
-    Message(const size_t size, FairMQTransportFactory* factory = nullptr)
+    Message(const size_t size, fair::mq::TransportFactory* factory = nullptr)
         : fair::mq::Message(factory)
         , fMsg(std::make_unique<zmq_msg_t>())
     {
@@ -80,7 +81,7 @@ class Message final : public fair::mq::Message
         return {static_cast<void*>(fullBufferPtr), static_cast<void*>(alignedPartPtr)};
     }
 
-    Message(const size_t size, Alignment alignment, FairMQTransportFactory* factory = nullptr)
+    Message(const size_t size, Alignment alignment, fair::mq::TransportFactory* factory = nullptr)
         : fair::mq::Message(factory)
         , fAlignment(alignment.alignment)
         , fMsg(std::make_unique<zmq_msg_t>())
@@ -97,7 +98,7 @@ class Message final : public fair::mq::Message
         }
     }
 
-    Message(void* data, const size_t size, fairmq_free_fn* ffn, void* hint = nullptr, FairMQTransportFactory* factory = nullptr)
+    Message(void* data, const size_t size, fair::mq::FreeFn* ffn, void* hint = nullptr, fair::mq::TransportFactory* factory = nullptr)
         : fair::mq::Message(factory)
         , fMsg(std::make_unique<zmq_msg_t>())
     {
@@ -106,7 +107,7 @@ class Message final : public fair::mq::Message
         }
     }
 
-    Message(UnmanagedRegionPtr& region, void* data, const size_t size, void* hint = 0, FairMQTransportFactory* factory = nullptr)
+    Message(UnmanagedRegionPtr& region, void* data, const size_t size, void* hint = 0, fair::mq::TransportFactory* factory = nullptr)
         : fair::mq::Message(factory)
         , fMsg(std::make_unique<zmq_msg_t>())
     {
@@ -184,7 +185,7 @@ class Message final : public fair::mq::Message
         }
     }
 
-    void Rebuild(void* data, size_t size, fairmq_free_fn* ffn, void* hint = nullptr) override
+    void Rebuild(void* data, size_t size, fair::mq::FreeFn* ffn, void* hint = nullptr) override
     {
         CloseMessage();
         fMsg = std::make_unique<zmq_msg_t>();

--- a/fairmq/zeromq/Socket.h
+++ b/fairmq/zeromq/Socket.h
@@ -9,13 +9,14 @@
 #ifndef FAIR_MQ_ZMQ_SOCKET_H
 #define FAIR_MQ_ZMQ_SOCKET_H
 
-#include <FairMQLogger.h>
-#include <FairMQMessage.h>
-#include <FairMQSocket.h>
+#include <fairmq/Message.h>
+#include <fairmq/Socket.h>
 #include <fairmq/tools/Strings.h>
 #include <fairmq/zeromq/Common.h>
 #include <fairmq/zeromq/Context.h>
 #include <fairmq/zeromq/Message.h>
+
+#include <fairlogger/Logger.h>
 
 #include <zmq.h>
 
@@ -30,7 +31,7 @@ namespace fair::mq::zmq
 class Socket final : public fair::mq::Socket
 {
   public:
-    Socket(Context& ctx, const std::string& type, const std::string& name, const std::string& id, FairMQTransportFactory* factory = nullptr)
+    Socket(Context& ctx, const std::string& type, const std::string& name, const std::string& id, fair::mq::TransportFactory* factory = nullptr)
         : fair::mq::Socket(factory)
         , fCtx(ctx)
         , fId(id + "." + name + "." + type)
@@ -219,7 +220,7 @@ class Socket final : public fair::mq::Socket
             bool repeat = false;
 
             do {
-                FairMQMessagePtr part = std::make_unique<Message>(GetTransport());
+                fair::mq::MessagePtr part = std::make_unique<Message>(GetTransport());
 
                 int nbytes = zmq_msg_recv(static_cast<Message*>(part.get())->GetMessage(), fSocket, flags);
                 if (nbytes >= 0) {

--- a/fairmq/zeromq/TransportFactory.h
+++ b/fairmq/zeromq/TransportFactory.h
@@ -14,7 +14,7 @@
 #include <fairmq/zeromq/Socket.h>
 #include <fairmq/zeromq/Poller.h>
 #include <fairmq/zeromq/UnmanagedRegion.h>
-#include <FairMQTransportFactory.h>
+#include <fairmq/TransportFactory.h>
 #include <fairmq/ProgOptions.h>
 
 #include <memory> // unique_ptr, make_unique
@@ -24,11 +24,11 @@
 namespace fair::mq::zmq
 {
 
-class TransportFactory final : public FairMQTransportFactory
+class TransportFactory final : public fair::mq::TransportFactory
 {
   public:
     TransportFactory(const std::string& id = "", const ProgOptions* config = nullptr)
-        : FairMQTransportFactory(id)
+        : fair::mq::TransportFactory(id)
         , fCtx(nullptr)
     {
         int major = 0, minor = 0, patch = 0;
@@ -68,7 +68,7 @@ class TransportFactory final : public FairMQTransportFactory
         return std::make_unique<Message>(size, alignment, this);
     }
 
-    MessagePtr CreateMessage(void* data, size_t size, fairmq_free_fn* ffn, void* hint = nullptr) override
+    MessagePtr CreateMessage(void* data, size_t size, fair::mq::FreeFn* ffn, void* hint = nullptr) override
     {
         return std::make_unique<Message>(data, size, ffn, hint, this);
     }
@@ -83,17 +83,17 @@ class TransportFactory final : public FairMQTransportFactory
         return std::make_unique<Socket>(*fCtx, type, name, GetId(), this);
     }
 
-    PollerPtr CreatePoller(const std::vector<FairMQChannel>& channels) const override
+    PollerPtr CreatePoller(const std::vector<Channel>& channels) const override
     {
         return std::make_unique<Poller>(channels);
     }
 
-    PollerPtr CreatePoller(const std::vector<FairMQChannel*>& channels) const override
+    PollerPtr CreatePoller(const std::vector<Channel*>& channels) const override
     {
         return std::make_unique<Poller>(channels);
     }
 
-    PollerPtr CreatePoller(const std::unordered_map<std::string, std::vector<FairMQChannel>>& channelsMap, const std::vector<std::string>& channelList) const override
+    PollerPtr CreatePoller(const std::unordered_map<std::string, std::vector<Channel>>& channelsMap, const std::vector<std::string>& channelList) const override
     {
         return std::make_unique<Poller>(channelsMap, channelList);
     }

--- a/fairmq/zeromq/UnmanagedRegion.h
+++ b/fairmq/zeromq/UnmanagedRegion.h
@@ -10,8 +10,9 @@
 #define FAIR_MQ_ZMQ_UNMANAGEDREGION_H
 
 #include <fairmq/zeromq/Context.h>
-#include <FairMQUnmanagedRegion.h>
-#include <FairMQLogger.h>
+#include <fairmq/UnmanagedRegion.h>
+
+#include <fairlogger/Logger.h>
 
 #include <cstddef> // size_t
 #include <string>
@@ -33,7 +34,7 @@ class UnmanagedRegion final : public fair::mq::UnmanagedRegion
                     int64_t userFlags,
                     RegionCallback callback,
                     RegionBulkCallback bulkCallback,
-                    FairMQTransportFactory* factory,
+                    fair::mq::TransportFactory* factory,
                     fair::mq::RegionConfig cfg)
         : fair::mq::UnmanagedRegion(factory)
         , fCtx(ctx)

--- a/test/device/TestReceiver.h
+++ b/test/device/TestReceiver.h
@@ -9,8 +9,8 @@
 #ifndef FAIR_MQ_TEST_TESTRECEIVER_H
 #define FAIR_MQ_TEST_TESTRECEIVER_H
 
-#include <FairMQDevice.h>
-#include <FairMQLogger.h>
+#include <fairmq/Device.h>
+#include <fairlogger/Logger.h>
 
 #include <string>
 #include <thread>

--- a/test/device/TestSender.h
+++ b/test/device/TestSender.h
@@ -9,8 +9,8 @@
 #ifndef FAIR_MQ_TEST_TESTSENDER_H
 #define FAIR_MQ_TEST_TESTSENDER_H
 
-#include <FairMQDevice.h>
-#include <FairMQLogger.h>
+#include <fairmq/Device.h>
+#include <fairlogger/Logger.h>
 
 #include <string>
 #include <thread>

--- a/test/device/_multiple_devices.cxx
+++ b/test/device/_multiple_devices.cxx
@@ -21,7 +21,7 @@ namespace
 using namespace std;
 using namespace fair::mq;
 
-void control(FairMQDevice& device)
+void control(Device& device)
 {
     thread t([&] {
         device.ChangeState(Transition::InitDevice);
@@ -62,7 +62,7 @@ class MultipleDevices : public ::testing::Test {
         test::Sender sender("data");
         sender.SetTransport("zeromq");
 
-        FairMQChannel channel("push", "connect", "ipc://multiple-devices-test");
+        Channel channel("push", "connect", "ipc://multiple-devices-test");
         channel.UpdateRateLogging(0);
         sender.AddChannel("data", std::move(channel));
 
@@ -75,7 +75,7 @@ class MultipleDevices : public ::testing::Test {
         test::Receiver receiver("data");
         receiver.SetTransport("zeromq");
 
-        FairMQChannel channel("pull", "bind", "ipc://multiple-devices-test");
+        Channel channel("pull", "bind", "ipc://multiple-devices-test");
         channel.UpdateRateLogging(0);
         receiver.AddChannel("data", std::move(channel));
 

--- a/test/device/_transitions.cxx
+++ b/test/device/_transitions.cxx
@@ -6,8 +6,8 @@
  *                  copied verbatim in the file "LICENSE"                       *
  ********************************************************************************/
 
-#include <FairMQDevice.h>
-#include <FairMQLogger.h>
+#include <fairmq/Device.h>
+#include <fairlogger/Logger.h>
 
 #include <gtest/gtest.h>
 
@@ -20,7 +20,7 @@ namespace
 using namespace std;
 using namespace fair::mq;
 
-class SlowDevice : public FairMQDevice
+class SlowDevice : public Device
 {
   public:
     SlowDevice() = default;
@@ -34,7 +34,7 @@ class SlowDevice : public FairMQDevice
 
 void transitionTo(const vector<State>& states, int numExpectedStates)
 {
-    FairMQDevice device;
+    Device device;
 
     thread t([&] {
         for (const auto& s : states) {

--- a/test/device/_version.cxx
+++ b/test/device/_version.cxx
@@ -6,7 +6,7 @@
  *                  copied verbatim in the file "LICENSE"                       *
  ********************************************************************************/
 
-#include <FairMQDevice.h>
+#include <fairmq/Device.h>
 
 #include <fairmq/tools/Version.h>
 

--- a/test/helper/devices/TestErrorState.h
+++ b/test/helper/devices/TestErrorState.h
@@ -9,8 +9,8 @@
 #ifndef FAIR_MQ_TEST_ERROR_STATE_H
 #define FAIR_MQ_TEST_ERROR_STATE_H
 
-#include <FairMQDevice.h>
-#include <FairMQLogger.h>
+#include <fairmq/Device.h>
+#include <fairlogger/Logger.h>
 
 #include <iostream>
 

--- a/test/helper/devices/TestExceptions.h
+++ b/test/helper/devices/TestExceptions.h
@@ -9,8 +9,8 @@
 #ifndef FAIR_MQ_TEST_EXCEPTIONS_H
 #define FAIR_MQ_TEST_EXCEPTIONS_H
 
-#include <FairMQDevice.h>
-#include <FairMQLogger.h>
+#include <fairmq/Device.h>
+#include <fairlogger/Logger.h>
 
 #include <iostream>
 #include <stdexcept>

--- a/test/helper/devices/TestPairLeft.h
+++ b/test/helper/devices/TestPairLeft.h
@@ -9,7 +9,7 @@
 #ifndef FAIR_MQ_TEST_PAIRLEFT_H
 #define FAIR_MQ_TEST_PAIRLEFT_H
 
-#include <FairMQDevice.h>
+#include <fairmq/Device.h>
 
 #include <cstddef>
 #include <thread>

--- a/test/helper/devices/TestPairRight.h
+++ b/test/helper/devices/TestPairRight.h
@@ -9,7 +9,7 @@
 #ifndef FAIR_MQ_TEST_PAIRRIGHT_H
 #define FAIR_MQ_TEST_PAIRRIGHT_H
 
-#include <FairMQDevice.h>
+#include <fairmq/Device.h>
 #include <cstddef>
 #include <string>
 #include <thread>

--- a/test/helper/devices/TestPollIn.h
+++ b/test/helper/devices/TestPollIn.h
@@ -9,17 +9,20 @@
 #ifndef FAIR_MQ_TEST_POLLIN_H
 #define FAIR_MQ_TEST_POLLIN_H
 
-#include <FairMQDevice.h>
-#include <FairMQLogger.h>
+#include <fairmq/Device.h>
 #include <fairmq/ProgOptions.h>
+
+#include <fairlogger/Logger.h>
+
 #include <thread>
 
 namespace fair::mq::test
 {
 
 using namespace std;
+using namespace fair::mq;
 
-class PollIn : public FairMQDevice
+class PollIn : public Device
 {
   public:
     PollIn()
@@ -35,12 +38,12 @@ class PollIn : public FairMQDevice
 
     auto Run() -> void override
     {
-        vector<FairMQChannel*> chans;
+        vector<Channel*> chans;
 
         chans.push_back(&GetChannel("data1", 0));
         chans.push_back(&GetChannel("data2", 0));
 
-        FairMQPollerPtr poller = nullptr;
+        PollerPtr poller = nullptr;
 
         if (fPollType == 0)
         {
@@ -59,8 +62,8 @@ class PollIn : public FairMQDevice
         bool arrived2 = false;
         bool bothArrived = false;
 
-        FairMQMessagePtr msg1(NewMessage());
-        FairMQMessagePtr msg2(NewMessage());
+        MessagePtr msg1(NewMessage());
+        MessagePtr msg2(NewMessage());
 
         while (!bothArrived)
         {

--- a/test/helper/devices/TestPollOut.h
+++ b/test/helper/devices/TestPollOut.h
@@ -9,7 +9,7 @@
 #ifndef FAIR_MQ_TEST_POLLOUT_H
 #define FAIR_MQ_TEST_POLLOUT_H
 
-#include <FairMQDevice.h>
+#include <fairmq/Device.h>
 #include <thread>
 
 namespace fair::mq::test

--- a/test/helper/devices/TestPub.h
+++ b/test/helper/devices/TestPub.h
@@ -9,8 +9,8 @@
 #ifndef FAIR_MQ_TEST_PUB_H
 #define FAIR_MQ_TEST_PUB_H
 
-#include <FairMQDevice.h>
-#include <FairMQLogger.h>
+#include <fairmq/Device.h>
+#include <fairlogger/Logger.h>
 #include <chrono>
 #include <thread>
 

--- a/test/helper/devices/TestPull.h
+++ b/test/helper/devices/TestPull.h
@@ -9,8 +9,8 @@
 #ifndef FAIR_MQ_TEST_PULL_H
 #define FAIR_MQ_TEST_PULL_H
 
-#include <FairMQDevice.h>
-#include <FairMQLogger.h>
+#include <fairmq/Device.h>
+#include <fairlogger/Logger.h>
 #include <thread>
 
 namespace fair::mq::test

--- a/test/helper/devices/TestPush.h
+++ b/test/helper/devices/TestPush.h
@@ -9,7 +9,7 @@
 #ifndef FAIR_MQ_TEST_PUSH_H
 #define FAIR_MQ_TEST_PUSH_H
 
-#include <FairMQDevice.h>
+#include <fairmq/Device.h>
 #include <thread>
 
 namespace fair::mq::test

--- a/test/helper/devices/TestRep.h
+++ b/test/helper/devices/TestRep.h
@@ -9,8 +9,8 @@
 #ifndef FAIR_MQ_TEST_REP_H
 #define FAIR_MQ_TEST_REP_H
 
-#include <FairMQDevice.h>
-#include <FairMQLogger.h>
+#include <fairmq/Device.h>
+#include <fairlogger/Logger.h>
 #include <thread>
 
 namespace fair::mq::test

--- a/test/helper/devices/TestReq.h
+++ b/test/helper/devices/TestReq.h
@@ -9,8 +9,8 @@
 #ifndef FAIR_MQ_TEST_REQ_H
 #define FAIR_MQ_TEST_REQ_H
 
-#include <FairMQDevice.h>
-#include <FairMQLogger.h>
+#include <fairmq/Device.h>
+#include <fairlogger/Logger.h>
 #include <thread>
 
 namespace fair::mq::test

--- a/test/helper/devices/TestSignals.h
+++ b/test/helper/devices/TestSignals.h
@@ -9,8 +9,8 @@
 #ifndef FAIR_MQ_TEST_SIGNALS_H
 #define FAIR_MQ_TEST_SIGNALS_H
 
-#include <FairMQDevice.h>
-#include <FairMQLogger.h>
+#include <fairmq/Device.h>
+#include <fairlogger/Logger.h>
 
 #include <iostream>
 #include <csignal>

--- a/test/helper/devices/TestSub.h
+++ b/test/helper/devices/TestSub.h
@@ -9,8 +9,8 @@
 #ifndef FAIR_MQ_TEST_SUB_H
 #define FAIR_MQ_TEST_SUB_H
 
-#include <FairMQDevice.h>
-#include <FairMQLogger.h>
+#include <fairmq/Device.h>
+#include <fairlogger/Logger.h>
 #include <chrono>
 #include <thread>
 

--- a/test/helper/devices/TestTransferTimeout.h
+++ b/test/helper/devices/TestTransferTimeout.h
@@ -9,13 +9,16 @@
 #ifndef FAIR_MQ_TEST_TRANSFERTIMEOUT_H
 #define FAIR_MQ_TEST_TRANSFERTIMEOUT_H
 
-#include <FairMQDevice.h>
-#include <FairMQLogger.h>
+#include <fairmq/Device.h>
+
+#include <fairlogger/Logger.h>
 
 namespace fair::mq::test
 {
 
-class TransferTimeout : public FairMQDevice
+using namespace fair::mq;
+
+class TransferTimeout : public Device
 {
   protected:
     auto Run() -> void override
@@ -38,8 +41,8 @@ class TransferTimeout : public FairMQDevice
         bool send2PartsCancelingAfter0ms = false;
         bool receive2PartsCancelingAfter0ms = false;
 
-        FairMQMessagePtr msg1(NewMessage());
-        FairMQMessagePtr msg2(NewMessage());
+        MessagePtr msg1(NewMessage());
+        MessagePtr msg2(NewMessage());
 
         if (Send(msg1, "data-out", 0, 200) == static_cast<int>(TransferCode::timeout)) {
             LOG(info) << "send msg canceled (200ms)";
@@ -69,9 +72,9 @@ class TransferTimeout : public FairMQDevice
             LOG(error) << "receive msg did not cancel (0ms)";
         }
 
-        FairMQParts parts1;
+        Parts parts1;
         parts1.AddPart(NewMessage(10));
-        FairMQParts parts2;
+        Parts parts2;
 
         if (Send(parts1, "data-out", 0, 200) == static_cast<int>(TransferCode::timeout)) {
             LOG(info) << "send 1 part canceled (200ms)";
@@ -101,10 +104,10 @@ class TransferTimeout : public FairMQDevice
             LOG(error) << "receive 1 part did not cancel (0ms)";
         }
 
-        FairMQParts parts3;
+        Parts parts3;
         parts3.AddPart(NewMessage(10));
         parts3.AddPart(NewMessage(10));
-        FairMQParts parts4;
+        Parts parts4;
 
         if (Send(parts3, "data-out", 0, 200) == static_cast<int>(TransferCode::timeout)) {
             LOG(info) << "send 2 parts canceled (200ms)";

--- a/test/helper/devices/TestWaitFor.h
+++ b/test/helper/devices/TestWaitFor.h
@@ -9,8 +9,8 @@
 #ifndef FAIR_MQ_TEST_WAITFOR_H
 #define FAIR_MQ_TEST_WAITFOR_H
 
-#include <FairMQDevice.h>
-#include <FairMQLogger.h>
+#include <fairmq/Device.h>
+#include <fairlogger/Logger.h>
 
 #include <iostream>
 

--- a/test/memory_resources/_memory_resources.cxx
+++ b/test/memory_resources/_memory_resources.cxx
@@ -6,7 +6,7 @@
  *                  copied verbatim in the file "LICENSE"                       *
  ********************************************************************************/
 
-#include <fairmq/FairMQTransportFactory.h>
+#include <fairmq/TransportFactory.h>
 #include <fairmq/MemoryResourceTools.h>
 #include <fairmq/ProgOptions.h>
 #include <fairmq/tools/Unique.h>
@@ -24,7 +24,7 @@ namespace
 using namespace std;
 using namespace fair::mq;
 
-using FactoryType = shared_ptr<FairMQTransportFactory>;
+using FactoryType = shared_ptr<TransportFactory>;
 
 struct TestData
 {
@@ -81,8 +81,8 @@ TEST(MemoryResources, transportAllocatorMap)
     // config.SetProperty<string>("session", to_string(session));
     config.SetProperty<string>("session", "default");
 
-    FactoryType factoryZMQ = FairMQTransportFactory::CreateTransportFactory("zeromq", fair::mq::tools::Uuid(), &config);
-    FactoryType factorySHM = FairMQTransportFactory::CreateTransportFactory("shmem", fair::mq::tools::Uuid(), &config);
+    FactoryType factoryZMQ = TransportFactory::CreateTransportFactory("zeromq", fair::mq::tools::Uuid(), &config);
+    FactoryType factorySHM = TransportFactory::CreateTransportFactory("shmem", fair::mq::tools::Uuid(), &config);
 
     auto allocZMQ = factoryZMQ->GetMemoryResource();
     auto allocSHM = factorySHM->GetMemoryResource();
@@ -103,7 +103,7 @@ TEST(MemoryResources, allocator)
     ProgOptions config;
     config.SetProperty<string>("session", to_string(session));
 
-    FactoryType factoryZMQ = FairMQTransportFactory::CreateTransportFactory("zeromq", fair::mq::tools::Uuid(), &config);
+    FactoryType factoryZMQ = TransportFactory::CreateTransportFactory("zeromq", fair::mq::tools::Uuid(), &config);
 
     auto allocZMQ = factoryZMQ->GetMemoryResource();
 
@@ -131,12 +131,12 @@ TEST(MemoryResources, getMessage)
     ProgOptions config;
     config.SetProperty<string>("session", to_string(session));
 
-    FactoryType factoryZMQ = FairMQTransportFactory::CreateTransportFactory("zeromq", fair::mq::tools::Uuid(), &config);
-    FactoryType factorySHM = FairMQTransportFactory::CreateTransportFactory("shmem", fair::mq::tools::Uuid(), &config);
+    FactoryType factoryZMQ = TransportFactory::CreateTransportFactory("zeromq", fair::mq::tools::Uuid(), &config);
+    FactoryType factorySHM = TransportFactory::CreateTransportFactory("shmem", fair::mq::tools::Uuid(), &config);
 
     auto allocZMQ = factoryZMQ->GetMemoryResource();
 
-    FairMQMessagePtr message{nullptr};
+    MessagePtr message{nullptr};
 
     int* messageArray{nullptr};
 

--- a/test/message/_message.cxx
+++ b/test/message/_message.cxx
@@ -6,7 +6,6 @@
  *                  copied verbatim in the file "LICENSE"                       *
  ********************************************************************************/
 
-#include <fairlogger/Logger.h>
 #include <fairmq/Channel.h>
 #include <fairmq/ProgOptions.h>
 #include <fairmq/tools/Semaphore.h>
@@ -14,6 +13,8 @@
 #include <fairmq/tools/Unique.h>
 #include <fairmq/TransportFactory.h>
 #include <fairmq/shmem/Message.h>
+
+#include <fairlogger/Logger.h>
 
 #include <gtest/gtest.h>
 
@@ -282,8 +283,8 @@ auto ZeroCopyFromUnmanaged(string const& address) -> void
     });
 
     {
-        FairMQChannel push("Push", "push", factory1);
-        FairMQChannel pull("Pull", "pull", factory2);
+        Channel push("Push", "push", factory1);
+        Channel pull("Pull", "pull", factory2);
 
         push.Bind(address);
         pull.Connect(address);

--- a/test/parts/_iterator_interface.cxx
+++ b/test/parts/_iterator_interface.cxx
@@ -7,8 +7,8 @@
  ********************************************************************************/
 
 #include <gtest/gtest.h>
-#include <FairMQParts.h>
-#include <FairMQTransportFactory.h>
+#include <fairmq/Parts.h>
+#include <fairmq/TransportFactory.h>
 #include <string>
 #include <sstream>
 #include <algorithm>
@@ -21,11 +21,11 @@ using namespace std;
 
 class RandomAccessIterator : public ::testing::Test {
   protected:
-    FairMQParts mParts;
-    shared_ptr<FairMQTransportFactory> mFactory;
+    fair::mq::Parts mParts;
+    shared_ptr<fair::mq::TransportFactory> mFactory;
 
     RandomAccessIterator()
-        : mFactory(FairMQTransportFactory::CreateTransportFactory("zeromq"))
+        : mFactory(fair::mq::TransportFactory::CreateTransportFactory("zeromq"))
     {
         mParts.AddPart(mFactory->NewSimpleMessage("1"));
         mParts.AddPart(mFactory->NewSimpleMessage("2"));
@@ -62,7 +62,7 @@ TEST_F(RandomAccessIterator, RangeForLoopMutation)
 TEST_F(RandomAccessIterator, ForEachConst)
 {
     stringstream out;
-    for_each(mParts.cbegin(), mParts.cend(), [&out](const FairMQMessagePtr& part) {
+    for_each(mParts.cbegin(), mParts.cend(), [&out](const fair::mq::MessagePtr& part) {
         out << string{static_cast<char*>(part->GetData()), part->GetSize()};
     });
 

--- a/test/plugin_services/Fixture.h
+++ b/test/plugin_services/Fixture.h
@@ -9,17 +9,19 @@
 #ifndef FAIR_MQ_TEST_FIXTURE
 #define FAIR_MQ_TEST_FIXTURE
 
-#include <gtest/gtest.h>
 #include <fairmq/PluginServices.h>
-#include <FairMQDevice.h>
+#include <fairmq/Device.h>
 #include <fairmq/ProgOptions.h>
+
+#include <gtest/gtest.h>
+
 #include <memory>
 #include <thread>
 
 namespace fair::mq::test
 {
 
-inline auto control(FairMQDevice& device) -> void
+inline auto control(fair::mq::Device& device) -> void
 {
     device.ChangeState(fair::mq::Transition::InitDevice);
     device.WaitForState(fair::mq::State::InitializingDevice);
@@ -42,7 +44,7 @@ struct PluginServices : ::testing::Test {
         , mServices(mConfig, mDevice)
         , fRunStateMachineThread()
     {
-        fRunStateMachineThread = std::thread(&FairMQDevice::RunStateMachine, &mDevice);
+        fRunStateMachineThread = std::thread(&fair::mq::Device::RunStateMachine, &mDevice);
         mDevice.SetTransport("zeromq");
     }
 
@@ -55,7 +57,7 @@ struct PluginServices : ::testing::Test {
     }
 
     fair::mq::ProgOptions mConfig;
-    FairMQDevice mDevice;
+    fair::mq::Device mDevice;
     fair::mq::PluginServices mServices;
     std::thread fRunStateMachineThread;
 };

--- a/test/plugins/_plugin.cxx
+++ b/test/plugins/_plugin.cxx
@@ -10,7 +10,7 @@
 #include <fairmq/Plugin.h>
 #include <fairmq/PluginServices.h>
 #include <fairmq/tools/Version.h>
-#include <FairMQDevice.h>
+#include <fairmq/Device.h>
 #include <fairmq/ProgOptions.h>
 #include <memory>
 #include <sstream>
@@ -24,28 +24,28 @@ namespace _plugin
 using namespace std;
 using namespace fair::mq;
 
-auto control(FairMQDevice& device) -> void
+auto control(Device& device) -> void
 {
     device.SetTransport("zeromq");
 
-    device.ChangeState(fair::mq::Transition::InitDevice);
-    device.WaitForState(fair::mq::State::InitializingDevice);
-    device.ChangeState(fair::mq::Transition::CompleteInit);
-    device.WaitForState(fair::mq::State::Initialized);
-    device.ChangeState(fair::mq::Transition::Bind);
-    device.WaitForState(fair::mq::State::Bound);
-    device.ChangeState(fair::mq::Transition::Connect);
-    device.WaitForState(fair::mq::State::DeviceReady);
-    device.ChangeState(fair::mq::Transition::ResetDevice);
-    device.WaitForState(fair::mq::State::Idle);
+    device.ChangeState(Transition::InitDevice);
+    device.WaitForState(State::InitializingDevice);
+    device.ChangeState(Transition::CompleteInit);
+    device.WaitForState(State::Initialized);
+    device.ChangeState(Transition::Bind);
+    device.WaitForState(State::Bound);
+    device.ChangeState(Transition::Connect);
+    device.WaitForState(State::DeviceReady);
+    device.ChangeState(Transition::ResetDevice);
+    device.WaitForState(State::Idle);
 
-    device.ChangeState(fair::mq::Transition::End);
+    device.ChangeState(Transition::End);
 }
 
 TEST(Plugin, Operators)
 {
-    fair::mq::ProgOptions config;
-    FairMQDevice device;
+    ProgOptions config;
+    Device device;
     PluginServices services{config, device};
     Plugin p1{"dds", {1, 0, 0}, "Foo Bar <foo.bar@test.net>", "https://git.test.net/dds.git", &services};
     Plugin p2{"dds", {1, 0, 0}, "Foo Bar <foo.bar@test.net>", "https://git.test.net/dds.git", &services};
@@ -61,8 +61,8 @@ TEST(Plugin, Operators)
 
 TEST(Plugin, OstreamOperators)
 {
-    fair::mq::ProgOptions config;
-    FairMQDevice device;
+    ProgOptions config;
+    Device device;
     PluginServices services{config, device};
     Plugin p1{"dds", {1, 0, 0}, "Foo Bar <foo.bar@test.net>", "https://git.test.net/dds.git", &services};
     stringstream ss;
@@ -77,9 +77,9 @@ TEST(Plugin, OstreamOperators)
 
 TEST(PluginVersion, Operators)
 {
-    struct fair::mq::tools::Version v1{1, 0, 0};
-    struct fair::mq::tools::Version v2{1, 0, 0};
-    struct fair::mq::tools::Version v3{1, 2, 0};
+    struct tools::Version v1{1, 0, 0};
+    struct tools::Version v2{1, 0, 0};
+    struct tools::Version v3{1, 2, 0};
     EXPECT_EQ(v1, v2);
     EXPECT_NE(v1, v3);
     EXPECT_GT(v3, v2);

--- a/test/plugins/_plugin_manager.cxx
+++ b/test/plugins/_plugin_manager.cxx
@@ -9,9 +9,9 @@
 #include <gtest/gtest.h>
 #include <fairmq/PluginManager.h>
 #include <fairmq/PluginServices.h>
-#include <FairMQDevice.h>
+#include <fairmq/Device.h>
 #include <fairmq/ProgOptions.h>
-#include <FairMQLogger.h>
+#include <fairlogger/Logger.h>
 #include <fstream>
 #include <memory>
 #include <vector>
@@ -25,28 +25,28 @@ using namespace boost::filesystem;
 using namespace boost::program_options;
 using namespace std;
 
-auto control(FairMQDevice& device) -> void
+auto control(Device& device) -> void
 {
     device.SetTransport("zeromq");
 
-    device.ChangeState(fair::mq::Transition::InitDevice);
-    device.WaitForState(fair::mq::State::InitializingDevice);
-    device.ChangeState(fair::mq::Transition::CompleteInit);
-    device.WaitForState(fair::mq::State::Initialized);
-    device.ChangeState(fair::mq::Transition::Bind);
-    device.WaitForState(fair::mq::State::Bound);
-    device.ChangeState(fair::mq::Transition::Connect);
-    device.WaitForState(fair::mq::State::DeviceReady);
-    device.ChangeState(fair::mq::Transition::ResetDevice);
-    device.WaitForState(fair::mq::State::Idle);
+    device.ChangeState(Transition::InitDevice);
+    device.WaitForState(State::InitializingDevice);
+    device.ChangeState(Transition::CompleteInit);
+    device.WaitForState(State::Initialized);
+    device.ChangeState(Transition::Bind);
+    device.WaitForState(State::Bound);
+    device.ChangeState(Transition::Connect);
+    device.WaitForState(State::DeviceReady);
+    device.ChangeState(Transition::ResetDevice);
+    device.WaitForState(State::Idle);
 
-    device.ChangeState(fair::mq::Transition::End);
+    device.ChangeState(Transition::End);
 }
 
 TEST(PluginManager, LoadPluginDynamic)
 {
-    fair::mq::ProgOptions config;
-    FairMQDevice device;
+    ProgOptions config;
+    Device device;
     PluginManager mgr;
     mgr.EmplacePluginServices(config, device);
 
@@ -77,13 +77,13 @@ TEST(PluginManager, LoadPluginDynamic)
 
 TEST(PluginManager, LoadPluginStatic)
 {
-    FairMQDevice device;
+    Device device;
     PluginManager mgr;
     device.SetTransport("zeromq");
 
     ASSERT_NO_THROW(mgr.LoadPlugin("s:control"));
 
-    fair::mq::ProgOptions config;
+    ProgOptions config;
     config.SetProperty<string>("control", "static");
     config.SetProperty("catch-signals", 0);
     mgr.EmplacePluginServices(config, device);

--- a/test/state_machine/_state_machine.cxx
+++ b/test/state_machine/_state_machine.cxx
@@ -8,7 +8,7 @@
 
 #include <gtest/gtest.h>
 #include <fairmq/StateMachine.h>
-#include <FairMQLogger.h>
+#include <fairlogger/Logger.h>
 #include <string>
 #include <thread>
 

--- a/test/transport/_options.cxx
+++ b/test/transport/_options.cxx
@@ -39,7 +39,7 @@ void CheckOldOptionInterface(Channel& channel, const string& option)
 
 void RunOptionsTest(const string& transport)
 {
-    fair::mq::ProgOptions config;
+    ProgOptions config;
     config.SetProperty<string>("session", tools::Uuid());
     auto factory = TransportFactory::CreateTransportFactory(transport, tools::Uuid(), &config);
     Channel channel("Push", "push", factory);
@@ -85,15 +85,15 @@ void ZeroingAndMlock(const string& transport)
 
 void ZeroingAndMlockOnCreation(const string& transport)
 {
-    size_t session{fair::mq::tools::UuidHash()};
+    size_t session{tools::UuidHash()};
 
-    fair::mq::ProgOptions config;
+    ProgOptions config;
     config.SetProperty<string>("session", to_string(session));
     config.SetProperty<size_t>("shm-segment-size", 16384); // NOLINT
     config.SetProperty<bool>("shm-mlock-segment-on-creation", true);
     config.SetProperty<bool>("shm-zero-segment-on-creation", true);
 
-    auto factory = FairMQTransportFactory::CreateTransportFactory(transport, fair::mq::tools::Uuid(), &config);
+    auto factory = TransportFactory::CreateTransportFactory(transport, tools::Uuid(), &config);
 
     constexpr size_t size{10000};
     auto outMsg(factory->CreateMessage(size));

--- a/test/transport/_shmem.cxx
+++ b/test/transport/_shmem.cxx
@@ -9,7 +9,7 @@
 #include <fairmq/ProgOptions.h>
 #include <fairmq/shmem/Monitor.h>
 #include <fairmq/tools/Unique.h>
-#include <FairMQTransportFactory.h>
+#include <fairmq/TransportFactory.h>
 
 #include <gtest/gtest.h>
 
@@ -29,7 +29,7 @@ void GetFreeMemory()
 
     ASSERT_THROW(shmem::Monitor::GetFreeMemory(shmem::SessionId{sessionId}, 0), shmem::Monitor::MonitorError);
 
-    auto factory = FairMQTransportFactory::CreateTransportFactory("shmem", tools::Uuid(), &config);
+    auto factory = TransportFactory::CreateTransportFactory("shmem", tools::Uuid(), &config);
 
     ASSERT_NO_THROW(shmem::Monitor::GetFreeMemory(shmem::SessionId{sessionId}, 0));
     ASSERT_THROW(shmem::Monitor::GetFreeMemory(shmem::SessionId{sessionId}, 1), shmem::Monitor::MonitorError);


### PR DESCRIPTION
- get rid of obsolete names.
- also hide the warnings from #403 with [[maybe_unused]].
