### PR TITLE
GUI Controller

### DIFF
--- a/fairmq/plugins/control/Control.h
+++ b/fairmq/plugins/control/Control.h
@@ -43,6 +43,7 @@ class Control : public Plugin
     static auto PrintStateMachine() -> void;
     auto PrintNumberOfConnectedPeers() -> void;
     auto StaticMode() -> void;
+    auto GUIMode() -> void;
     auto SignalHandler() -> void;
     auto RunShutdownSequence() -> void;
     auto RunStartupSequence() -> void;


### PR DESCRIPTION
Provide a controller which is alike the static one but which does not transition to exit whenever it moves away from the Running state. This can be used to trigger transition from an external entity, e.g. the DPL debug GUI, hence the name.