### PR TITLE
Shm fixes

### DIFF
--- a/fairmq/shmem/Monitor.cxx
+++ b/fairmq/shmem/Monitor.cxx
@@ -574,7 +574,7 @@ std::vector<std::pair<std::string, bool>> Monitor::Cleanup(const ShmId& shmIdT, 
 
     string managementSegmentName("fmq_" + shmId + "_mng");
     try {
-        bipc::managed_shared_memory managementSegment(bipc::open_only, managementSegmentName.c_str());
+        bipc::managed_shared_memory managementSegment(bipc::open_read_only, managementSegmentName.c_str());
 
         Uint16RegionInfoHashMap* shmRegions = managementSegment.find<Uint16RegionInfoHashMap>(bipc::unique_instance).first;
         if (shmRegions) {


### PR DESCRIPTION
- `shm::Monitor::ResetContent()`: Add nullptr check on segmentInfo.
- `shm::Monitor::ResetContent()`: Reset user data after recreating the management segment, to avoid bumping into locked interprocess locks.
- `shm::Monitor::Cleanup()`: open management data as read only, to avoid bumping into locked interprocess locks. We only read the segmentInfo/regionInfo (read-only) to find out which segments are present and delete everything unconditionally in the next step.
- Add more debug output.
