### PR TITLE
New example with a custom controller

### DIFF
--- a/examples/custom-controller/CMakeLists.txt
+++ b/examples/custom-controller/CMakeLists.txt
@@ -1,22 +1,20 @@
 ################################################################################
-# Copyright (C) 2018-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  #
+#    Copyright (C) 2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    #
 #                                                                              #
 #              This software is distributed under the terms of the             #
 #              GNU Lesser General Public Licence (LGPL) version 3,             #
 #                  copied verbatim in the file "LICENSE"                       #
 ################################################################################
 
-add_subdirectory(1-1)
-add_subdirectory(1-n-1)
-add_subdirectory(builtin-devices)
-add_subdirectory(copypush)
-add_subdirectory(custom-controller)
-add_subdirectory(dds)
-add_subdirectory(multipart)
-add_subdirectory(multiple-channels)
-add_subdirectory(multiple-transports)
-add_subdirectory(n-m)
-add_subdirectory(qc)
-add_subdirectory(readout)
-add_subdirectory(region)
-add_subdirectory(req-rep)
+set(target fairmq-ex-custom-controller)
+add_executable(${target} main.cxx)
+target_link_libraries(${target} PRIVATE FairMQ)
+set_target_properties(${target} PROPERTIES
+  CXX_VISIBILITY_PRESET hidden
+  ENABLE_EXPORTS ON
+)
+
+set(test Example.custom-controller)
+add_test(NAME ${test} COMMAND ${CMAKE_CURRENT_BINARY_DIR}/${target})
+set_tests_properties(${test} PROPERTIES TIMEOUT 30)
+

--- a/examples/custom-controller/MyController.h
+++ b/examples/custom-controller/MyController.h
@@ -1,0 +1,97 @@
+/********************************************************************************
+ *    Copyright (C) 2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ *                                                                              *
+ *              This software is distributed under the terms of the             *
+ *              GNU Lesser General Public Licence (LGPL) version 3,             *
+ *                  copied verbatim in the file "LICENSE"                       *
+ ********************************************************************************/
+
+#ifndef FAIR_MQ_EXAMPLE_CUSTOM_CONTROLLER_PLUGIN
+#define FAIR_MQ_EXAMPLE_CUSTOM_CONTROLLER_PLUGIN
+
+#include <fairmq/Plugin.h>
+#include <utility>   // for std::forward
+
+namespace example {
+
+struct MyController : fair::mq::Plugin   // NOLINT
+{
+    template<typename... Args>
+    MyController(Args&&... args)
+        : Plugin(std::forward<Args>(args)...)
+    {
+        TakeDeviceControl();
+
+        SubscribeToDeviceStateChange([this](auto state) {
+            auto shutdown = GetProperty<bool>("please-shut-me-down", false);
+            try {
+                switch (state) {
+                    case DeviceState::Idle: {
+                        ChangeDeviceState(shutdown ? DeviceStateTransition::End
+                                                    : DeviceStateTransition::InitDevice);
+                        break;
+                    }
+                    case DeviceState::InitializingDevice: {
+                        ChangeDeviceState(DeviceStateTransition::CompleteInit);
+                        break;
+                    }
+                    case DeviceState::Initialized: {
+                        ChangeDeviceState(DeviceStateTransition::Bind);
+                        break;
+                    }
+                    case DeviceState::Bound: {
+                        ChangeDeviceState(DeviceStateTransition::Connect);
+                        break;
+                    }
+                    case DeviceState::DeviceReady: {
+                        ChangeDeviceState(shutdown ? DeviceStateTransition::ResetDevice
+                                                    : DeviceStateTransition::InitTask);
+                        break;
+                    }
+                    case DeviceState::Ready: {
+                        ChangeDeviceState(shutdown ? DeviceStateTransition::ResetTask
+                                                    : DeviceStateTransition::Run);
+                        break;
+                    }
+                    case DeviceState::Running: {
+                        ChangeDeviceState(DeviceStateTransition::Stop);
+                        break;
+                    }
+                    case DeviceState::Exiting: {
+                        ReleaseDeviceControl();
+                        break;
+                    }
+                    default:
+                        break;
+                }
+            } catch (fair::mq::PluginServices::DeviceControlError const&) {
+                // this means we do not have device control
+            }
+        });
+    }
+
+    ~MyController() override { ReleaseDeviceControl(); }
+};
+
+// auto MyControllerProgramOptions() -> fair::mq::Plugin::ProgOptions
+// {
+// auto plugin_options = boost::program_options::options_description{"MyController Plugin"};
+// plugin_options.add_options()
+// ("custom-dummy-option", boost::program_options::value<std::string>(), "Cool custom option.")
+// ("custom-dummy-option2", boost::program_options::value<std::string>(), "Another one.");
+// return plugin_options;
+// }
+
+}   // namespace example
+
+REGISTER_FAIRMQ_PLUGIN(example::MyController,   // Class name
+                       mycontroller,            // Plugin name (string, lower case chars only)
+                       (fair::mq::Plugin::Version{0, 42, 0}),     // Version
+                       "Mr. Dummy <dummy@test.net>",              // Maintainer
+                       "https://git.test.net/mycontroller.git",   // Homepage
+                       //                       example::MyControllerProgramOptions   // Free
+                       //                       function which declares custom
+                       // program options for the plugin
+                       fair::mq::Plugin::NoProgramOptions)
+
+#endif /* FAIR_MQ_EXAMPLE_CUSTOM_CONTROLLER_PLUGIN */

--- a/examples/custom-controller/MyDevice.h
+++ b/examples/custom-controller/MyDevice.h
@@ -1,0 +1,21 @@
+/********************************************************************************
+ *    Copyright (C) 2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ *                                                                              *
+ *              This software is distributed under the terms of the             *
+ *              GNU Lesser General Public Licence (LGPL) version 3,             *
+ *                  copied verbatim in the file "LICENSE"                       *
+ ********************************************************************************/
+
+#ifndef FAIR_MQ_EXAMPLE_CUSTOM_CONTROLLER_DEVICE
+#define FAIR_MQ_EXAMPLE_CUSTOM_CONTROLLER_DEVICE
+
+#include <fairmq/Device.h>
+
+namespace example {
+
+using MyDevice = typename fair::mq::Device;
+
+}   // namespace example
+
+#endif /* FAIR_MQ_EXAMPLE_CUSTOM_CONTROLLER_DEVICE */
+

--- a/examples/custom-controller/main.cxx
+++ b/examples/custom-controller/main.cxx
@@ -1,0 +1,46 @@
+/********************************************************************************
+ *    Copyright (C) 2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ *                                                                              *
+ *              This software is distributed under the terms of the             *
+ *              GNU Lesser General Public Licence (LGPL) version 3,             *
+ *                  copied verbatim in the file "LICENSE"                       *
+ ********************************************************************************/
+
+#include "MyController.h"
+#include "MyDevice.h"
+
+#include <chrono>   // for std::chrono_literals
+#include <fairlogger/Logger.h>
+#include <fairmq/DeviceRunner.h>
+#include <memory>   // for std::make_unique
+
+int main(int argc, char* argv[])
+{
+    using namespace fair::mq;
+    using namespace std::chrono_literals;
+
+    DeviceRunner runner(argc, argv);
+
+    runner.AddHook<hooks::LoadPlugins>([](DeviceRunner& r) {
+        r.fPluginManager.LoadPlugin("s:mycontroller");
+        // 's:' stands for static because the plugin is compiled into the executable
+        // 'mycontroller' is the plugin name passed as second arg to REGISTER_FAIRMQ_PLUGIN
+    });
+
+    fair::Logger::SetConsoleSeverity(fair::Severity::debug);
+
+    runner.AddHook<hooks::InstantiateDevice>([](DeviceRunner& r) {
+        r.fConfig.SetProperty<int>("catch-signals", 0);
+        r.fConfig.SetProperty<bool>("please-shut-me-down", false);
+        r.fDevice = std::make_unique<example::MyDevice>(r.fConfig);
+
+        r.fDevice->SubscribeToStateChange("example", [&r](auto state) {
+            if (state == State::Running) {
+                r.fDevice->WaitFor(3s);
+                r.fConfig.SetProperty<bool>("please-shut-me-down", true);
+            }
+        });
+    });
+
+    return runner.RunWithExceptionHandlers();
+}


### PR DESCRIPTION
New example demonstrating a simple custom controller (statically compiled into the executable) which executes a simple static plan through the state machine (similar to the built-in `--control static`). Builtin signal handling is disabled.