### PR TITLE
metaUpdater: Some Cleanups, Fixes

### DIFF
--- a/codemeta.json
+++ b/codemeta.json
@@ -17,9 +17,9 @@
     },
     {
       "@type": "Person",
+      "@id": "https://orcid.org/0000-0003-3787-1910",
       "givenName": "Dennis",
-      "familyName": "Klein",
-      "@id": "https://orcid.org/0000-0003-3787-1910"
+      "familyName": "Klein"
     },
     {
       "@type": "Person",
@@ -92,9 +92,9 @@
     },
     {
       "@type": "Person",
+      "@id": "https://orcid.org/0000-0002-5321-8404",
       "givenName": "Christian",
-      "familyName": "Tacke",
-      "@id": "https://orcid.org/0000-0002-5321-8404"
+      "familyName": "Tacke"
     },
     {
       "@type": "Person",

--- a/meta_update.py
+++ b/meta_update.py
@@ -77,7 +77,7 @@ class CodeMetaManipulator(Manipulator):
         if entry is None:
             entry = OrderedDict()
             entry['@type'] = 'Person'
-        for field in ('givenName', 'familyName', 'email', 'orcid'):
+        for field in ('orcid', 'givenName', 'familyName', 'email'):
             val = matchdict.get(field, None)
             if val is not None:
                 if field == 'orcid':

--- a/meta_update.py
+++ b/meta_update.py
@@ -39,7 +39,7 @@ class Manipulator(object):
     def _handle_person_list_file(self, filename, field_name, **kwargs):
         fp = open(filename, 'r', encoding='utf8')
         person_list = self.data.setdefault(field_name, [])
-        for line in fp:
+        for i, line in enumerate(fp, start=0):
             line = line.strip()
             m = self.findregex.match(line)
             if m is None:
@@ -48,7 +48,7 @@ class Manipulator(object):
             entry = self.update_person_entry(found_entry, m.groupdict(),
                                              **kwargs)
             if found_entry is None:
-                person_list.append(entry)
+                person_list.insert(i, entry)
 
 
 class CodeMetaManipulator(Manipulator):

--- a/meta_update.py
+++ b/meta_update.py
@@ -119,11 +119,11 @@ class ZenodoManipulator(Manipulator):
         return None
 
     @staticmethod
-    def update_person_entry(entry, matchdict, **kwargs):
+    def update_person_entry(entry, matchdict, contributor_type=None):
         if entry is None:
             entry = OrderedDict()
-            if kwargs['contributor_type']:
-                entry['type'] = kwargs['contributor_type']
+            if contributor_type:
+                entry['type'] = contributor_type
         for field in ('name', 'orcid'):
             val = matchdict.get(field, None)
             if val is not None:

--- a/meta_update.py
+++ b/meta_update.py
@@ -4,22 +4,28 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
 
-import argparse
+from argparse import ArgumentParser
 import json
 import re
 from collections import OrderedDict
 
 
 class Manipulator(object):
-    def __init__(self, regex):
-        self.findregex = re.compile(regex)
-
     def __str__(self):
         return self.__class__.__name__
 
-    def load(self, filename):
+    def load(self, filename=None):
+        if filename is None:
+            filename = self.default_filename
         with open(filename, 'rb') as fp:
             self.data = json.load(fp, object_pairs_hook=OrderedDict)
+
+    def save(self, filename=None, indent=2):
+        if filename is None:
+            filename = self.default_filename
+        with open(filename, 'w', encoding='utf8') as fp:
+            json.dump(self.data, fp, indent=indent)
+            fp.write('\n')
 
     @staticmethod
     def _dict_entry_cmp(dict1, dict2, field1, field2=None):
@@ -30,34 +36,27 @@ class Manipulator(object):
         else:
             return False
 
-    def _handle_person_list_file(self, filename, cm_field_name, **kwargs):
+    def _handle_person_list_file(self, filename, field_name, **kwargs):
         fp = open(filename, 'r', encoding='utf8')
-        person_list = self.data.setdefault(cm_field_name, [])
+        person_list = self.data.setdefault(field_name, [])
         for line in fp:
             line = line.strip()
             m = self.findregex.match(line)
             if m is None:
                 raise RuntimeError("Could not analyze line %r" % line)
             found_entry = self._find_person_entry(person_list, m.groupdict())
-            entry = self.update_person_entry(found_entry, m.groupdict(), **kwargs)
+            entry = self.update_person_entry(found_entry, m.groupdict(),
+                                             **kwargs)
             if found_entry is None:
                 person_list.append(entry)
 
-    def save(self, filename, indent=2):
-        with open(filename, 'w', encoding='utf8') as fp:
-            json.dump(self.data, fp, indent=indent)
-            fp.write('\n')
-
 
 class CodeMetaManipulator(Manipulator):
-    def __init__(self):
-        super().__init__(r'^(?P<familyName>[-\w\s]*[-\w]),\s*'
-                         r'(?P<givenName>[-\w\s]*[-\w])\s*'
-                         r'(?:<(?P<email>\S+@\S+)>)?\s*'
-                         r'(\[(?P<orcid>\S+)\])?$')
-
-    def load(self, filename='codemeta.json'):
-        super().load(filename)
+    default_filename = 'codemeta.json'
+    findregex = re.compile(r'^(?P<familyName>[-\w\s]*[-\w]),\s*'
+                           r'(?P<givenName>[-\w\s]*[-\w])\s*'
+                           r'(?:<(?P<email>\S+@\S+)>)?\s*'
+                           r'(\[(?P<orcid>\S+)\])?$')
 
     @classmethod
     def _find_person_entry(cls, person_list, matchdict):
@@ -74,7 +73,7 @@ class CodeMetaManipulator(Manipulator):
         return None
 
     @staticmethod
-    def update_person_entry(entry, matchdict, **kwargs):
+    def update_person_entry(entry, matchdict):
         if entry is None:
             entry = OrderedDict()
             entry['@type'] = 'Person'
@@ -91,21 +90,15 @@ class CodeMetaManipulator(Manipulator):
         self._handle_person_list_file('AUTHORS', 'author')
         self._handle_person_list_file('CONTRIBUTORS', 'contributor')
 
-    def save(self, filename='codemeta.json'):
-        super().save(filename)
-
     def version(self, new_version):
         self.data['softwareVersion'] = new_version
 
 
 class ZenodoManipulator(Manipulator):
-    def __init__(self):
-        super().__init__(r'^(?P<name>[-\w\s,]*[-\w])\s*'
-                         r'(?:<(?P<email>\S+@\S+)>)?\s*'
-                         r'(\[https://orcid\.org/(?P<orcid>\S+)\])?$')
-
-    def load(self, filename='.zenodo.json'):
-        super().load(filename)
+    default_filename = '.zenodo.json'
+    findregex = re.compile(r'^(?P<name>[-\w\s,]*[-\w])\s*'
+                           r'(?:<(?P<email>\S+@\S+)>)?\s*'
+                           r'(\[https://orcid\.org/(?P<orcid>\S+)\])?$')
 
     @classmethod
     def _find_person_entry(cls, person_list, matchdict):
@@ -132,9 +125,10 @@ class ZenodoManipulator(Manipulator):
 
     def update_authors(self):
         self._handle_person_list_file('AUTHORS', 'creators')
-        self._handle_person_list_file('CONTRIBUTORS', 'contributors', contributor_type='Other')
+        self._handle_person_list_file('CONTRIBUTORS', 'contributors',
+                                      contributor_type='Other')
 
-    def save(self, filename='.zenodo.json'):
+    def save(self, filename=None):
         super().save(filename, 4)
 
     def version(self, new_version):
@@ -142,7 +136,8 @@ class ZenodoManipulator(Manipulator):
 
 
 def main():
-    parser = argparse.ArgumentParser(description='Update codemeta.json and .zenodo.json')
+    parser = ArgumentParser(description='Update codemeta.json and '
+                                        '.zenodo.json')
     parser.add_argument('--set-version', dest='newversion')
     args = parser.parse_args()
 


### PR DESCRIPTION
* Fix Adding new creators to `.zenodo.json`
* Simplify Code a bit
* reorder `@id` to the top in codemeta.json

---

Checklist:

* [X] Rebased against `dev` branch
* [X] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [X] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
