### PR TITLE
Shm: error on duplicate region IDs

### DIFF
--- a/examples/region/sampler.cxx
+++ b/examples/region/sampler.cxx
@@ -39,12 +39,9 @@ struct Sampler : fair::mq::Device
         if (fExternalRegion) {
             regionCfg.id = 1;
             regionCfg.removeOnDestruction = false;
-            regionCfg.lock = false; // mlock region after creation
-            regionCfg.lock = false; // mlock region after creation
-        } else {
-            regionCfg.lock = true; // mlock region after creation
-            regionCfg.zero = true; // zero region content after creation
         }
+        regionCfg.lock = !fExternalRegion; // mlock region after creation
+        regionCfg.zero = !fExternalRegion; // zero region content after creation
         fRegion = fair::mq::UnmanagedRegionPtr(NewUnmanagedRegionFor(
             "data", // region is created using the transport of this channel...
             0,      // ... and this sub-channel

--- a/fairmq/shmem/Manager.h
+++ b/fairmq/shmem/Manager.h
@@ -396,7 +396,7 @@ class Manager
                 const uint16_t id = cfg.id.value();
 
                 std::lock_guard<std::mutex> lock(fLocalRegionsMtx);
-                auto& region = fRegions[id] = std::make_unique<UnmanagedRegion>(fShmId, size, false, cfg);
+                auto& region = fRegions[id] = std::make_unique<UnmanagedRegion>(fShmId, size, true, cfg);
                 // LOG(debug) << "Created region with id '" << id << "', path: '" << cfg.path << "', flags: '" << cfg.creationFlags << "'";
 
                 // start ack receiver only if a callback has been provided.
@@ -463,7 +463,7 @@ class Manager
                 }
                 // LOG(debug) << "Located remote region with id '" << id << "', path: '" << cfg.path << "', flags: '" << cfg.creationFlags << "'";
 
-                auto r = fRegions.emplace(id, std::make_unique<UnmanagedRegion>(fShmId, 0, true, std::move(cfg)));
+                auto r = fRegions.emplace(id, std::make_unique<UnmanagedRegion>(fShmId, 0, false, std::move(cfg)));
                 r.first->second->InitializeQueues();
                 r.first->second->StartAckSender();
                 return r.first->second.get();
@@ -554,7 +554,7 @@ class Manager
                     if (it != fRegions.end()) {
                         region = it->second.get();
                     } else {
-                        auto r = fRegions.emplace(cfgIt->first, std::make_unique<UnmanagedRegion>(fShmId, 0, true, cfgIt->second));
+                        auto r = fRegions.emplace(cfgIt->first, std::make_unique<UnmanagedRegion>(fShmId, 0, false, cfgIt->second));
                         region = r.first->second.get();
                         region->InitializeQueues();
                         region->StartAckSender();

--- a/fairmq/shmem/Manager.h
+++ b/fairmq/shmem/Manager.h
@@ -207,22 +207,22 @@ class Manager
 
             fEventCounter = fManagementSegment.find<EventCounter>(unique_instance).first;
             if (fEventCounter) {
-                LOG(debug) << "event counter found: " << fEventCounter->fCount;
+                LOG(trace) << "event counter found: " << fEventCounter->fCount;
             } else {
-                LOG(debug) << "no event counter found, creating one and initializing with 0";
+                LOG(trace) << "no event counter found, creating one and initializing with 0";
                 fEventCounter = fManagementSegment.construct<EventCounter>(unique_instance)(0);
-                LOG(debug) << "initialized event counter with: " << fEventCounter->fCount;
+                LOG(trace) << "initialized event counter with: " << fEventCounter->fCount;
             }
 
             fDeviceCounter = fManagementSegment.find<DeviceCounter>(unique_instance).first;
             if (fDeviceCounter) {
-                LOG(debug) << "device counter found, with value of " << fDeviceCounter->fCount << ". incrementing.";
+                LOG(trace) << "device counter found, with value of " << fDeviceCounter->fCount << ". incrementing.";
                 (fDeviceCounter->fCount)++;
-                LOG(debug) << "incremented device counter, now: " << fDeviceCounter->fCount;
+                LOG(trace) << "incremented device counter, now: " << fDeviceCounter->fCount;
             } else {
-                LOG(debug) << "no device counter found, creating one and initializing with 1";
+                LOG(trace) << "no device counter found, creating one and initializing with 1";
                 fDeviceCounter = fManagementSegment.construct<DeviceCounter>(unique_instance)(1);
-                LOG(debug) << "initialized device counter with: " << fDeviceCounter->fCount;
+                LOG(trace) << "initialized device counter with: " << fDeviceCounter->fCount;
             }
 
             fShmSegments = fManagementSegment.find_or_construct<Uint16SegmentInfoHashMap>(unique_instance)(fShmVoidAlloc);
@@ -265,10 +265,10 @@ class Manager
                         }
                     }
                 }
-                LOG(debug) << "Created/opened shared memory segment '" << "fmq_" << fShmId << "_m_" << fSegmentId << "'."
-                << " Size: " << boost::apply_visitor(SegmentSize(), fSegments.at(fSegmentId)) << " bytes."
-                << " Available: " << boost::apply_visitor(SegmentFreeMemory(), fSegments.at(fSegmentId)) << " bytes."
-                << " Allocation algorithm: " << allocationAlgorithm;
+                LOG(debug) << (createdSegment ? "Created" : "Opened") << " managed shared memory segment " << "fmq_" << fShmId << "_m_" << fSegmentId
+                    << ". Size: " << boost::apply_visitor(SegmentSize(), fSegments.at(fSegmentId)) << " bytes."
+                    << " Available: " << boost::apply_visitor(SegmentFreeMemory(), fSegments.at(fSegmentId)) << " bytes."
+                    << " Allocation algorithm: " << allocationAlgorithm;
             } catch (interprocess_exception& bie) {
                 LOG(error) << "Failed to create/open shared memory segment '" << "fmq_" << fShmId << "_m_" << fSegmentId << "': " << bie.what();
                 throw TransportError(tools::ToString("Failed to create/open shared memory segment '", "fmq_", fShmId, "_m_", fSegmentId, "': ", bie.what()));
@@ -447,7 +447,6 @@ class Manager
     UnmanagedRegion* GetRegion(uint16_t id)
     {
         std::lock_guard<std::mutex> lock(fLocalRegionsMtx);
-        // remote region could actually be a local one if a message originates from this device (has been sent out and returned)
         auto it = fRegions.find(id);
         if (it != fRegions.end()) {
             return it->second.get();

--- a/fairmq/shmem/UnmanagedRegionImpl.h
+++ b/fairmq/shmem/UnmanagedRegionImpl.h
@@ -40,9 +40,9 @@ class UnmanagedRegionImpl final : public fair::mq::UnmanagedRegion
         , fRegion(nullptr)
         , fRegionId(0)
     {
-        auto result = fManager.CreateRegion(size, callback, bulkCallback, std::move(cfg));
-        fRegion = result.first;
-        fRegionId = result.second;
+        auto [regionPtr, regionId] = fManager.CreateRegion(size, callback, bulkCallback, std::move(cfg));
+        fRegion = regionPtr;
+        fRegionId = regionId;
     }
 
     UnmanagedRegionImpl(const UnmanagedRegionImpl&) = delete;

--- a/test/region/_region.cxx
+++ b/test/region/_region.cxx
@@ -6,6 +6,11 @@
  *                  copied verbatim in the file "LICENSE"                       *
  ********************************************************************************/
 
+#include <fairmq/shmem/Common.h>
+#include <fairmq/shmem/Monitor.h>
+#include <fairmq/shmem/Segment.h>
+#include <fairmq/shmem/UnmanagedRegion.h>
+
 #include <fairmq/TransportFactory.h>
 #include <fairmq/ProgOptions.h>
 #include <fairmq/tools/Unique.h>
@@ -16,14 +21,46 @@
 
 #include <gtest/gtest.h>
 
+#include <cstdint>
+#include <map>
 #include <memory> // make_unique
 #include <string>
+#include <utility> // pair
+#include <vector> // pair
 
 namespace
 {
 
 using namespace std;
 using namespace fair::mq;
+
+struct ShmOwner
+{
+    ShmOwner(const string& sessionId,
+             const vector<pair<uint16_t, size_t>>& segments,
+             const vector<pair<uint16_t, size_t>>& regions)
+        : fShmId(fair::mq::shmem::makeShmIdStr(sessionId))
+    {
+        LOG(info) << "ShmOwner: creating segments";
+        for (auto [id, size] : segments) {
+            fSegments.emplace(id, fair::mq::shmem::Segment(fShmId, id, size, fair::mq::shmem::rbTreeBestFit));
+        }
+        LOG(info) << "ShmOwner: creating regions";
+        for (auto [id, size] : regions) {
+            fRegions.emplace(id, make_unique<fair::mq::shmem::UnmanagedRegion>(fShmId, id, size));
+        }
+    }
+
+    ~ShmOwner()
+    {
+        LOG(info) << "ShmOwner: cleaning up";
+        fair::mq::shmem::Monitor::Cleanup(fair::mq::shmem::ShmId{fShmId});
+    }
+
+    string fShmId;
+    map<uint16_t, fair::mq::shmem::Segment> fSegments;
+    map<uint16_t, unique_ptr<fair::mq::shmem::UnmanagedRegion>> fRegions;
+};
 
 void RegionsSizeMismatch()
 {
@@ -109,31 +146,69 @@ void RegionsCache(const string& transport, const string& _address)
     }
 }
 
-void RegionEventSubscriptions(const string& transport)
+void RegionEventSubscriptions(const string& transport, bool external)
 {
+    fair::Logger::SetConsoleSeverity(fair::Severity::debug);
+
+    unique_ptr<ShmOwner> shmOwner = nullptr;
+
     size_t session{tools::UuidHash()};
+
+    constexpr int sSize = 100000000;
+    constexpr int r1Size = 1000000;
+    constexpr int r2Size = 5000000;
+    constexpr uint16_t sId = 0;
+    constexpr uint16_t r1id = 100;
+    constexpr uint16_t r2id = 101;
+
+    if (external) {
+        shmOwner = make_unique<ShmOwner>(
+            to_string(session),
+            vector<pair<uint16_t, size_t>>{ { sId, sSize } },
+            vector<pair<uint16_t, size_t>>{ { r1id, r1Size }, { r2id, r2Size } }
+        );
+    }
 
     ProgOptions config;
     config.SetProperty<string>("session", to_string(session));
-    config.SetProperty<size_t>("shm-segment-size", 100000000);
+    config.SetProperty<size_t>("shm-segment-size", sSize);
+    if (external) {
+        config.SetProperty<bool>("shm-no-cleanup", true);
+        config.SetProperty<bool>("shm-monitor", false);
+    }
 
     auto factory = TransportFactory::CreateTransportFactory(transport, tools::Uuid(), &config);
 
-    constexpr int size1 = 1000000;
-    constexpr int size2 = 5000000;
     constexpr int64_t userFlags = 12345;
     tools::Semaphore blocker;
 
     {
-        auto region1 = factory->CreateUnmanagedRegion(size1, [](void*, size_t, void*) {});
+        fair::mq::RegionConfig r1Cfg;
+        if (external) {
+            r1Cfg.id = r1id;
+            r1Cfg.removeOnDestruction = false;
+        }
+        auto region1 = factory->CreateUnmanagedRegion(r1Size, [](void*, size_t, void*) {}, r1Cfg);
         void* ptr1 = region1->GetData();
         uint64_t id1 = region1->GetId();
-        ASSERT_EQ(region1->GetSize(), size1);
+        if (external) {
+            ASSERT_EQ(id1, r1id);
+        }
+        ASSERT_EQ(region1->GetSize(), r1Size);
 
-        auto region2 = factory->CreateUnmanagedRegion(size2, userFlags, [](void*, size_t, void*) {});
+        fair::mq::RegionConfig r2Cfg;
+        r2Cfg.userFlags = userFlags;
+        if (external) {
+            r2Cfg.id = r2id;
+            r2Cfg.removeOnDestruction = false;
+        }
+        auto region2 = factory->CreateUnmanagedRegion(r2Size, [](void*, size_t, void*) {}, r2Cfg);
         void* ptr2 = region2->GetData();
         uint64_t id2 = region2->GetId();
-        ASSERT_EQ(region2->GetSize(), size2);
+        if (external) {
+            ASSERT_EQ(id2, r2id);
+        }
+        ASSERT_EQ(region2->GetSize(), r2Size);
 
         ASSERT_EQ(factory->SubscribedToRegionEvents(), false);
         factory->SubscribeToRegionEvents([&, id1, id2, ptr1, ptr2](RegionInfo info) {
@@ -145,13 +220,15 @@ void RegionEventSubscriptions(const string& transport)
                       << ", flags: " << info.flags;
             if (info.event == RegionEvent::created) {
                 if (info.id == id1) {
-                    ASSERT_EQ(info.size, size1);
+                    ASSERT_EQ(info.size, r1Size);
                     ASSERT_EQ(info.ptr, ptr1);
                     blocker.Signal();
                 } else if (info.id == id2) {
-                    ASSERT_EQ(info.size, size2);
+                    ASSERT_EQ(info.size, r2Size);
                     ASSERT_EQ(info.ptr, ptr2);
-                    ASSERT_EQ(info.flags, userFlags);
+                    if (!external) {
+                        ASSERT_EQ(info.flags, userFlags);
+                    }
                     blocker.Signal();
                 }
             } else if (info.event == RegionEvent::destroyed) {
@@ -171,10 +248,12 @@ void RegionEventSubscriptions(const string& transport)
         LOG(info) << "2 done.";
     }
 
-    blocker.Wait();
-    LOG(info) << "3 done.";
-    blocker.Wait();
-    LOG(info) << "4 done.";
+    if (!external) {
+        blocker.Wait();
+        LOG(info) << "3 done.";
+        blocker.Wait();
+        LOG(info) << "4 done.";
+    }
     LOG(info) << "All done.";
 
     factory->UnsubscribeFromRegionEvents();
@@ -186,9 +265,13 @@ void RegionCallbacks(const string& transport, const string& _address)
     size_t session(tools::UuidHash());
     std::string address(tools::ToString(_address, "_", transport));
 
+    constexpr size_t sSize = 100000000;
+    constexpr size_t r1Size = 2000000;
+    constexpr size_t r2Size = 3000000;
+
     ProgOptions config;
     config.SetProperty<string>("session", to_string(session));
-    config.SetProperty<size_t>("shm-segment-size", 100000000);
+    config.SetProperty<size_t>("shm-segment-size", sSize);
 
     auto factory = TransportFactory::CreateTransportFactory(transport, tools::Uuid(), &config);
 
@@ -207,7 +290,7 @@ void RegionCallbacks(const string& transport, const string& _address)
     void* ptr2 = nullptr;
     size_t size2 = 200;
 
-    auto region1 = factory->CreateUnmanagedRegion(2000000, [&](void* ptr, size_t size, void* hint) {
+    auto region1 = factory->CreateUnmanagedRegion(r1Size, [&](void* ptr, size_t size, void* hint) {
         ASSERT_EQ(ptr, ptr1);
         ASSERT_EQ(size, size1);
         ASSERT_EQ(hint, intPtr1.get());
@@ -216,7 +299,7 @@ void RegionCallbacks(const string& transport, const string& _address)
     });
     ptr1 = region1->GetData();
 
-    auto region2 = factory->CreateUnmanagedRegion(3000000, [&](const std::vector<RegionBlock>& blocks) {
+    auto region2 = factory->CreateUnmanagedRegion(r2Size, [&](const std::vector<RegionBlock>& blocks) {
         ASSERT_EQ(blocks.size(), 1);
         ASSERT_EQ(blocks.at(0).ptr, ptr2);
         ASSERT_EQ(blocks.at(0).size, size2);
@@ -264,12 +347,12 @@ TEST(Cache, shmem)
 
 TEST(EventSubscriptions, zeromq)
 {
-    RegionEventSubscriptions("zeromq");
+    RegionEventSubscriptions("zeromq", false);
 }
 
 TEST(EventSubscriptions, shmem)
 {
-    RegionEventSubscriptions("shmem");
+    RegionEventSubscriptions("shmem", false);
 }
 
 TEST(Callbacks, zeromq)
@@ -280,6 +363,11 @@ TEST(Callbacks, zeromq)
 TEST(Callbacks, shmem)
 {
     RegionCallbacks("shmem", "ipc://test_region_callbacks");
+}
+
+TEST(EventSubscriptionsExternalRegion, shmem)
+{
+    RegionEventSubscriptions("shmem", true);
 }
 
 } // namespace


### PR DESCRIPTION
- Error on duplicate unmanaged region IDs.
- Extend debug output slightly.
- Add a test for externally (outside of a session) created shmem.