### PR TITLE
Extend invalid channel error

### DIFF
--- a/fairmq/Channel.h
+++ b/fairmq/Channel.h
@@ -19,6 +19,7 @@
 
 #include <cstdint>   // int64_t
 #include <memory>   // unique_ptr, shared_ptr
+#include <ostream>
 #include <stdexcept>
 #include <string>
 #include <utility>   // std::move
@@ -379,6 +380,14 @@ class Channel
     static constexpr int DefaultPortRangeMin = 22000;
     static constexpr int DefaultPortRangeMax = 23000;
     static constexpr bool DefaultAutoBind = true;
+
+    friend std::ostream& operator<<(std::ostream& os, const Channel& ch)
+    {
+        return os << "name: " << ch.fName
+                  << ", type: "  << ch.fType
+                  << ", method: "  << ch.fMethod
+                  << ", address: "  << ch.fAddress;
+    }
 
   private:
     std::shared_ptr<TransportFactory> fTransportFactory;

--- a/fairmq/Device.cxx
+++ b/fairmq/Device.cxx
@@ -304,7 +304,7 @@ void Device::ConnectWrapper()
     // first attempt
     AttachChannels(fUninitializedConnectingChannels);
     // if not all channels could be connected, update their address values from config and retry
-    while (!fUninitializedConnectingChannels.empty()) {
+    while (!fUninitializedConnectingChannels.empty() && !NewStatePending()) {
         this_thread::sleep_for(chrono::milliseconds(sleepTimeInMS));
 
         for (auto& chan : fUninitializedConnectingChannels) {

--- a/fairmq/Device.cxx
+++ b/fairmq/Device.cxx
@@ -317,6 +317,10 @@ void Device::ConnectWrapper()
 
         if (numAttempts++ > maxAttempts) {
             LOG(error) << "could not connect all channels after " << fInitializationTimeoutInS << " attempts";
+            LOG(error) << "following channels are still invalid:";
+            for (auto& chan : fUninitializedConnectingChannels) {
+                LOG(error) << "channel: " << *chan;
+            }
             throw runtime_error(tools::ToString("could not connect all channels after ", fInitializationTimeoutInS, " attempts"));
         }
 


### PR DESCRIPTION
Fixes #454.

- Add `operator<<` to `fair::mq::Channel`.
- Extend error message if channel(s) was not configured before timeout.
- Cancel channel validation on pending state.

