### PR TITLE
Resume/Interrupt transports consistently

### DIFF
--- a/fairmq/Device.cxx
+++ b/fairmq/Device.cxx
@@ -6,14 +6,19 @@
  *                  copied verbatim in the file "LICENSE"                       *
  ********************************************************************************/
 
-#include <algorithm>                    // std::max, std::any_of
-#include <boost/algorithm/string.hpp>   // join/split
-#include <chrono>
+// FairMQ
 #include <fairmq/Device.h>
 #include <fairmq/Tools.h>
+
+// boost
+#include <boost/algorithm/string.hpp>   // join/split
+
+// std
+#include <algorithm>   // std::max, std::any_of
+#include <chrono>
 #include <iomanip>
 #include <list>
-#include <memory>                       // std::make_unique
+#include <memory>   // std::make_unique
 #include <mutex>
 #include <thread>
 

--- a/fairmq/Device.cxx
+++ b/fairmq/Device.cxx
@@ -90,7 +90,7 @@ Device::Device(ProgOptions* config, tools::Version version)
 
         switch (transition) {
             case Transition::Stop:
-                UnblockTransports();
+                InterruptTransports();
                 break;
             default:
                 break;
@@ -492,7 +492,7 @@ void Device::RunWrapper()
 
     // if Run() exited and the state is still RUNNING, transition to READY.
     if (!NewStatePending()) {
-        UnblockTransports();
+        InterruptTransports();
         ChangeState(Transition::Stop);
     }
 
@@ -771,7 +771,7 @@ void Device::LogSocketRates()
     }
 }
 
-void Device::UnblockTransports()
+void Device::InterruptTransports()
 {
     for (auto& transport : fTransports) {
         transport.second->Interrupt();

--- a/fairmq/Device.cxx
+++ b/fairmq/Device.cxx
@@ -457,11 +457,8 @@ void Device::RunWrapper()
         if (rateLogging && rateLogger->joinable()) { rateLogger->join(); }
     });
 
-
     // notify transports to resume transfers
-    for (auto& t : fTransports) {
-        t.second->Resume();
-    }
+    ResumeTransports();
 
     // change to Error state in case of an exception, to release LogSocketRates
     tools::CallOnDestruction cod([&](){
@@ -773,8 +770,15 @@ void Device::LogSocketRates()
 
 void Device::InterruptTransports()
 {
-    for (auto& transport : fTransports) {
-        transport.second->Interrupt();
+    for (auto& [transportType, transport] : fTransports) {
+        transport->Interrupt();
+    }
+}
+
+void Device::ResumeTransports()
+{
+    for (auto& [transportType, transport] : fTransports) {
+        transport->Resume();
     }
 }
 
@@ -789,8 +793,8 @@ void Device::ResetTaskWrapper()
 
 void Device::ResetWrapper()
 {
-    for (auto& transport : fTransports) {
-        transport.second->Reset();
+    for (auto& [transportType, transport] : fTransports) {
+        transport->Reset();
     }
 
     Reset();

--- a/fairmq/Device.h
+++ b/fairmq/Device.h
@@ -9,11 +9,7 @@
 #ifndef FAIR_MQ_DEVICE_H
 #define FAIR_MQ_DEVICE_H
 
-#include <algorithm>   // find
-#include <atomic>
-#include <chrono>
-#include <cstddef>
-#include <fairlogger/Logger.h>
+// FairMQ
 #include <fairmq/Channel.h>
 #include <fairmq/Message.h>
 #include <fairmq/Parts.h>
@@ -24,6 +20,15 @@
 #include <fairmq/TransportFactory.h>
 #include <fairmq/Transports.h>
 #include <fairmq/UnmanagedRegion.h>
+
+// logger
+#include <fairlogger/Logger.h>
+
+// std
+#include <algorithm>   // find
+#include <atomic>
+#include <chrono>
+#include <cstddef>
 #include <functional>
 #include <memory>   // unique_ptr
 #include <mutex>

--- a/fairmq/Device.h
+++ b/fairmq/Device.h
@@ -590,6 +590,9 @@ class Device
     /// Notifies transports to cease any blocking activity
     void InterruptTransports();
 
+    /// Notifies transports to resume any blocking activity
+    void ResumeTransports();
+
     /// Shuts down the transports and the device
     void Exit() {}
 

--- a/fairmq/Device.h
+++ b/fairmq/Device.h
@@ -637,6 +637,7 @@ class Device
 
     StateQueue fStateQueue;
 
+    std::mutex fTransportMtx;   ///< guards access to transports container
     std::mutex fTransitionMtx;
     bool fTransitioning;
 };

--- a/fairmq/Device.h
+++ b/fairmq/Device.h
@@ -588,7 +588,7 @@ class Device
     void ResetWrapper();
 
     /// Notifies transports to cease any blocking activity
-    void UnblockTransports();
+    void InterruptTransports();
 
     /// Shuts down the transports and the device
     void Exit() {}

--- a/fairmq/StateMachine.h
+++ b/fairmq/StateMachine.h
@@ -35,6 +35,7 @@ class StateMachine
     void SubscribeToStateChange(const std::string& key, std::function<void(const State)> callback);
     void UnsubscribeFromStateChange(const std::string& key);
 
+    void PrepareState(std::function<void(const State)> callback);
     void HandleStates(std::function<void(const State)> callback);
     void StopHandlingStates();
 

--- a/fairmq/plugins/control/Control.cxx
+++ b/fairmq/plugins/control/Control.cxx
@@ -489,12 +489,6 @@ auto Control::RunShutdownSequence() -> void
             case DeviceState::Running:
                 ChangeDeviceState(DeviceStateTransition::Stop);
                 break;
-            case DeviceState::Binding:
-            case DeviceState::Connecting:
-            case DeviceState::InitializingTask:
-            case DeviceState::ResettingTask:
-            case DeviceState::ResettingDevice:
-                ChangeDeviceState(DeviceStateTransition::Auto);
             default:
                 // LOG(debug) << "Controller ignoring event: " << nextState;
                 break;


### PR DESCRIPTION
 - Resume transports before state callbacks & handlers.
 - Interrupt transports on new transitions.

Solves #428.