### PR TITLE
codemeta: Add GSI as "maintainer"

### DIFF
--- a/codemeta.json
+++ b/codemeta.json
@@ -9,6 +9,13 @@
   "codeRepository": "https://github.com/FairRootGroup/FairMQ/",
   "issueTracker": "https://github.com/FairRootGroup/FairMQ/issues",
   "identifier": "https://doi.org/10.5281/zenodo.1689985",
+  "maintainer": [
+    {
+      "@type": "ResearchOrganisation",
+      "@id": "https://ror.org/02k8cbn47",
+      "name": "GSI Helmholtz Centre for Heavy Ion Research"
+    }
+  ],
   "author": [
     {
       "@type": "Person",


### PR DESCRIPTION
GSI is providing resources for maintaining FairMQ. So let's document this in codemeta.json.

- [ ] https://github.com/codemeta/codemeta/pull/250#issuecomment-1660417541
  Codemeta < 4.0 does not allow anything but `Person`s in the `maintainer` field. I personally think, we should just ignore this.

---

Checklist:

* [X] Rebased against `dev` branch
* [X] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [X] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
