### PR TITLE
Drop unused variable

### DIFF
--- a/fairmq/Device.cxx
+++ b/fairmq/Device.cxx
@@ -176,7 +176,6 @@ void Device::InitWrapper()
 
     // Fill the uninitialized channel containers
     for (auto& channel : GetChannels()) {
-        int subChannelIndex = 0;
         for (auto& subChannel : channel.second) {
             // set channel transport
             LOG(debug) << "Initializing transport for channel " << subChannel.fName << ": " << TransportNames.at(subChannel.fTransportType);
@@ -208,8 +207,6 @@ void Device::InitWrapper()
                 LOG(error) << "Cannot update configuration. Socket method (bind/connect) for channel '" << subChannel.fName << "' not specified.";
                 throw runtime_error(tools::ToString("Cannot update configuration. Socket method (bind/connect) for channel ", subChannel.fName, " not specified."));
             }
-
-            subChannelIndex++;
         }
     }
 


### PR DESCRIPTION
Drop unused variable

The else clause at the end makes the postincrement impossible.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/FairRootGroup/FairMQ/pull/486).
* #487
* __->__ #486