### PR TITLE
Use std::move rather than just move

### DIFF
--- a/fairmq/Device.cxx
+++ b/fairmq/Device.cxx
@@ -176,7 +176,6 @@ void Device::InitWrapper()
 
     // Fill the uninitialized channel containers
     for (auto& channel : GetChannels()) {
-        int subChannelIndex = 0;
         for (auto& subChannel : channel.second) {
             // set channel transport
             LOG(debug) << "Initializing transport for channel " << subChannel.fName << ": " << TransportNames.at(subChannel.fTransportType);
@@ -208,8 +207,6 @@ void Device::InitWrapper()
                 LOG(error) << "Cannot update configuration. Socket method (bind/connect) for channel '" << subChannel.fName << "' not specified.";
                 throw runtime_error(tools::ToString("Cannot update configuration. Socket method (bind/connect) for channel ", subChannel.fName, " not specified."));
             }
-
-            subChannelIndex++;
         }
     }
 

--- a/fairmq/tools/Process.cxx
+++ b/fairmq/tools/Process.cxx
@@ -29,7 +29,7 @@ class LinePrinter
   public:
     LinePrinter(stringstream& out, string prefix)
         : fOut(out)
-        , fPrefix(move(prefix))
+        , fPrefix(std::move(prefix))
     {}
 
     // prints line with prefix on both cout (thread-safe) and output stream

--- a/fairmq/zeromq/Socket.h
+++ b/fairmq/zeromq/Socket.h
@@ -225,7 +225,7 @@ class Socket final : public fair::mq::Socket
                 int nbytes = zmq_msg_recv(static_cast<Message*>(part.get())->GetMessage(), fSocket, flags);
                 if (nbytes >= 0) {
                     static_cast<Message*>(part.get())->Realign();
-                    msgVec.push_back(move(part));
+                    msgVec.push_back(std::move(part));
                     totalSize += nbytes;
                 } else if (zmq_errno() == EAGAIN || zmq_errno() == EINTR) {
                     if (fCtx.Interrupted()) {


### PR DESCRIPTION
Use std::move rather than just move

Apparently:

  "warning: unqualified call to 'std::move' [-Wunqualified-std-cast-call]"

is default in new XCode.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/FairRootGroup/FairMQ/pull/487).
* __->__ #487
* #486