### PR TITLE
ci: Check codemeta/zenodo with AUTHORS/CONTRIBUTORS

### DIFF
--- a/.github/workflows/check_metadata.yaml
+++ b/.github/workflows/check_metadata.yaml
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH, Darmstadt, Germany
+#
+# SPDX-License-Identifier: CC0-1.0
+
+name: Check AUTHORS and CONTRIBUTORS in metadata
+
+on:
+  push:
+    paths:
+    - AUTHORS
+    - CONTRIBUTORS
+    - codemeta.json
+    - .zenodo.json
+  pull_request:
+    paths:
+    - AUTHORS
+    - CONTRIBUTORS
+    - codemeta.json
+    - .zenodo.json
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Try updating metadata
+        run: python meta_update.py
+      - name: Check for Updates
+        run: git diff --exit-code


### PR DESCRIPTION
If AUTHORS or CONTRIBUTORS are changed,
check that the changes are merged into codemeta.json, and .zenodo.json.

See: https://github.com/FairRootGroup/FairRoot/pull/1475

---

Checklist:

* [X] Rebased against `dev` branch
* [X] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [X] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
