### PR TITLE
Add 'no control' controller

### DIFF
--- a/test/device/_config.cxx
+++ b/test/device/_config.cxx
@@ -27,7 +27,7 @@ class TestDevice : public Device
 {
   public:
     TestDevice(const string& transport)
-    : fDeviceThread(&Device::RunStateMachine, this)
+        : fDeviceThread(&Device::RunStateMachine, this)
     {
         SetTransport(transport);
         test::Control(*this, test::Cycle::ToRun);


### PR DESCRIPTION
For #443.

Here I skip also the startup sequence. The plugin changes no states at all (device remains in Idle). Was that what we wanted to solve with this?

I've tested if the device still responds to signals with this and it does.


