### PR TITLE
Reduce bloat due to statics

### DIFF
--- a/fairmq/CMakeLists.txt
+++ b/fairmq/CMakeLists.txt
@@ -63,6 +63,7 @@ if(BUILD_FAIRMQ)
     Tools.h
     TransportFactory.h
     Transports.h
+    TransportEnum.h
     UnmanagedRegion.h
     options/FairMQProgOptions.h
     runDevice.h

--- a/fairmq/Channel.cxx
+++ b/fairmq/Channel.cxx
@@ -12,6 +12,7 @@
 #include <fairmq/Channel.h>
 #include <fairmq/Properties.h>
 #include <fairmq/Tools.h>
+#include <fairmq/Transports.h>
 #include <random>
 #include <regex>
 #include <set>
@@ -382,5 +383,11 @@ bool Channel::BindEndpoint(string& endpoint)
         }
     }
 }
+
+std::string Channel::GetTransportName() const { return TransportName(fTransportType); }
+
+Transport Channel::GetTransportType() const { return fTransportType; }
+
+void Channel::UpdateTransport(const std::string& transport) { fTransportType = TransportType(transport); Invalidate(); }
 
 } // namespace fair::mq

--- a/fairmq/Channel.h
+++ b/fairmq/Channel.h
@@ -14,7 +14,7 @@
 #include <fairmq/Properties.h>
 #include <fairmq/Socket.h>
 #include <fairmq/TransportFactory.h>
-#include <fairmq/Transports.h>
+#include <fairmq/TransportEnum.h>
 #include <fairmq/UnmanagedRegion.h>
 
 #include <cstdint>   // int64_t
@@ -145,11 +145,11 @@ class Channel
 
     /// Get channel transport name ("default", "zeromq" or "shmem")
     /// @return Returns channel transport name (e.g. "default", "zeromq" or "shmem")
-    std::string GetTransportName() const { return TransportName(fTransportType); }
+    std::string GetTransportName() const;
 
     /// Get channel transport type
     /// @return Returns channel transport type
-    mq::Transport GetTransportType() const { return fTransportType; }
+    mq::Transport GetTransportType() const;
 
     /// Get socket send buffer size (in number of messages)
     /// @return Returns socket send buffer size (in number of messages)
@@ -221,7 +221,7 @@ class Channel
 
     /// Set channel transport
     /// @param transport transport string ("default", "zeromq" or "shmem")
-    void UpdateTransport(const std::string& transport) { fTransportType = TransportType(transport); Invalidate(); }
+    void UpdateTransport(const std::string& transport);
 
     /// Set socket send buffer size
     /// @param sndBufSize Socket send buffer size (in number of messages)

--- a/fairmq/Device.cxx
+++ b/fairmq/Device.cxx
@@ -9,6 +9,7 @@
 // FairMQ
 #include <fairmq/Device.h>
 #include <fairmq/Tools.h>
+#include <fairmq/Transports.h>
 
 // boost
 #include <boost/algorithm/string.hpp>   // join/split

--- a/fairmq/Device.h
+++ b/fairmq/Device.h
@@ -19,7 +19,7 @@
 #include <fairmq/StateQueue.h>
 #include <fairmq/Tools.h>
 #include <fairmq/TransportFactory.h>
-#include <fairmq/Transports.h>
+#include <fairmq/TransportEnum.h>
 #include <fairmq/UnmanagedRegion.h>
 
 // logger

--- a/fairmq/Message.h
+++ b/fairmq/Message.h
@@ -10,7 +10,7 @@
 #define FAIR_MQ_MESSAGE_H
 
 #include <cstddef>   // for size_t
-#include <fairmq/Transports.h>
+#include <fairmq/TransportEnum.h>
 #include <memory>   // unique_ptr
 #include <stdexcept>
 

--- a/fairmq/TransportEnum.h
+++ b/fairmq/TransportEnum.h
@@ -1,0 +1,22 @@
+/********************************************************************************
+ * Copyright (C) 2014-2025 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ *                                                                              *
+ *              This software is distributed under the terms of the             *
+ *              GNU Lesser General Public Licence (LGPL) version 3,             *
+ *                  copied verbatim in the file "LICENSE"                       *
+ ********************************************************************************/
+
+#ifndef FAIR_MQ_TRANSPORTENUMS_H
+#define FAIR_MQ_TRANSPORTENUMS_H
+
+namespace fair::mq {
+
+enum class Transport {
+    DEFAULT,
+    ZMQ,
+    SHM
+};
+
+}
+
+#endif // FAIR_MQ_TRANSPORTENUMS_H

--- a/fairmq/TransportFactory.h
+++ b/fairmq/TransportFactory.h
@@ -14,7 +14,7 @@
 #include <fairmq/Message.h>
 #include <fairmq/Poller.h>
 #include <fairmq/Socket.h>
-#include <fairmq/Transports.h>
+#include <fairmq/TransportEnum.h>
 #include <fairmq/UnmanagedRegion.h>
 #include <memory>   // shared_ptr
 #include <stdexcept>

--- a/fairmq/Transports.h
+++ b/fairmq/Transports.h
@@ -10,6 +10,7 @@
 #define FAIR_MQ_TRANSPORTS_H
 
 #include <fairmq/tools/Strings.h>
+#include <fairmq/TransportEnum.h>
 #include <memory>
 #include <ostream>
 #include <stdexcept>
@@ -17,13 +18,6 @@
 #include <unordered_map>
 
 namespace fair::mq {
-
-enum class Transport
-{
-    DEFAULT,
-    ZMQ,
-    SHM
-};
 
 struct TransportError : std::runtime_error
 {

--- a/fairmq/UnmanagedRegion.h
+++ b/fairmq/UnmanagedRegion.h
@@ -9,7 +9,7 @@
 #ifndef FAIR_MQ_UNMANAGEDREGION_H
 #define FAIR_MQ_UNMANAGEDREGION_H
 
-#include <fairmq/Transports.h>
+#include <fairmq/TransportEnum.h>
 
 #include <cstddef>   // size_t
 #include <cstdint>   // uint32_t

--- a/fairmq/shmem/Message.h
+++ b/fairmq/shmem/Message.h
@@ -14,6 +14,7 @@
 #include "UnmanagedRegionImpl.h"
 #include <fairmq/Message.h>
 #include <fairmq/UnmanagedRegion.h>
+#include <fairmq/Transports.h>
 
 #include <fairlogger/Logger.h>
 

--- a/fairmq/shmem/Segment.h
+++ b/fairmq/shmem/Segment.h
@@ -10,6 +10,7 @@
 
 #include <fairmq/shmem/Common.h>
 #include <fairmq/shmem/Monitor.h>
+#include <fairmq/Transports.h>
 
 #include <cstdint>
 #include <string>

--- a/fairmq/shmem/UnmanagedRegion.h
+++ b/fairmq/shmem/UnmanagedRegion.h
@@ -13,6 +13,7 @@
 #include <fairmq/shmem/Monitor.h>
 #include <fairmq/tools/Strings.h>
 #include <fairmq/UnmanagedRegion.h>
+#include <fairmq/Transports.h>
 
 #include <fairlogger/Logger.h>
 


### PR DESCRIPTION
Avoid disseminating every compile unit including Message.h with TransportNames and
TransportTypes and the associated unordered_map helper methods (e.g.
murmur_hash).