### PR TITLE
[ALICE] Expose some shm API to allow shm message metadata to be passed through a side channel

### DIFF
--- a/fairmq/CMakeLists.txt
+++ b/fairmq/CMakeLists.txt
@@ -136,6 +136,7 @@ if(BUILD_FAIRMQ)
     shmem/Common.cxx
     shmem/Manager.cxx
     shmem/Monitor.cxx
+    shmem/TransportFactory.cxx
     tools/Network.cxx
     tools/Process.cxx
     tools/Semaphore.cxx

--- a/fairmq/shmem/Manager.cxx
+++ b/fairmq/shmem/Manager.cxx
@@ -51,4 +51,10 @@ bool Manager::SpawnShmMonitor(const std::string& id)
     return true;
 }
 
+char* Manager::GetDataAddressFromHandle(const boost::interprocess::managed_shared_memory::handle_t handle, uint16_t segmentId)
+{
+    GetSegment(segmentId);
+    return ShmHeader::UserPtr(GetAddressFromHandle(handle, segmentId));
+}
+
 }   // namespace fair::mq::shmem

--- a/fairmq/shmem/Manager.h
+++ b/fairmq/shmem/Manager.h
@@ -776,7 +776,7 @@ class Manager
 
     auto GetMetadataMsgSize() const noexcept { return fMetadataMsgSize; }
 
-    char* GetDataAddressFromHandle(const boost::interprocess::managed_shared_memory::handle_t handle, uint16_t segmentId);
+    char* GetDataAddressFromHandle(boost::interprocess::managed_shared_memory::handle_t handle, uint16_t segmentId);
 
     ~Manager()
     {

--- a/fairmq/shmem/Manager.h
+++ b/fairmq/shmem/Manager.h
@@ -776,6 +776,8 @@ class Manager
 
     auto GetMetadataMsgSize() const noexcept { return fMetadataMsgSize; }
 
+    char* GetDataAddressFromHandle(const boost::interprocess::managed_shared_memory::handle_t handle, uint16_t segmentId);
+
     ~Manager()
     {
         fRegionsGen += 1; // signal TL cache invalidation

--- a/fairmq/shmem/Message.h
+++ b/fairmq/shmem/Message.h
@@ -191,6 +191,11 @@ class Message final : public fair::mq::Message
         return static_cast<void*>(fLocalPtr);
     }
 
+    MetaHeader GetMeta() const
+    {
+        return {fSize, fHint, fHandle, fShared, fRegionId, fSegmentId, fManaged};
+    }
+
     size_t GetSize() const override { return fSize; }
 
     bool SetUsedSize(size_t newSize, Alignment alignment = Alignment{0}) override

--- a/fairmq/shmem/TransportFactory.cxx
+++ b/fairmq/shmem/TransportFactory.cxx
@@ -1,0 +1,197 @@
+/********************************************************************************
+ * Copyright (C) 2016-2017 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ *                                                                              *
+ *              This software is distributed under the terms of the             *
+ *              GNU Lesser General Public Licence (LGPL) version 3,             *
+ *                  copied verbatim in the file "LICENSE"                       *
+ ********************************************************************************/
+
+#include "TransportFactory.h"
+#include "Poller.h"
+#include "Socket.h"
+#include "UnmanagedRegionImpl.h"
+
+#include <fairmq/ProgOptions.h>
+#include <fairmq/tools/Strings.h>
+
+#include <fairlogger/Logger.h>
+#include <zmq.h>
+
+#include <memory> // unique_ptr, make_unique
+#include <stdexcept>
+
+namespace fair::mq::shmem
+{
+TransportFactory::TransportFactory(const std::string& deviceId, const ProgOptions* config)
+    : fair::mq::TransportFactory(deviceId)
+    , fZmqCtx(zmq_ctx_new())
+    , fManager(nullptr)
+{
+    int major = 0, minor = 0, patch = 0;
+    zmq_version(&major, &minor, &patch);
+    LOG(debug) << "Transport: Using ZeroMQ (" << major << "." << minor << "." << patch << ") & "
+               << "boost::interprocess (" << (BOOST_VERSION / 100000) << "." << (BOOST_VERSION / 100 % 1000) << "." << (BOOST_VERSION % 100) << ")";
+
+    if (!fZmqCtx) {
+        throw std::runtime_error(tools::ToString("failed creating context, reason: ", zmq_strerror(errno)));
+    }
+
+    int numIoThreads = 1;
+    std::string sessionName = "default";
+    size_t segmentSize = 2ULL << 30;
+    std::string allocationAlgorithm("rbtree_best_fit");
+    if (config) {
+        numIoThreads = config->GetProperty<int>("io-threads", numIoThreads);
+        sessionName = config->GetProperty<std::string>("session", sessionName);
+        segmentSize = config->GetProperty<size_t>("shm-segment-size", segmentSize);
+        allocationAlgorithm = config->GetProperty<std::string>("shm-allocation", allocationAlgorithm);
+    } else {
+        LOG(debug) << "ProgOptions not available! Using defaults.";
+    }
+
+    if (allocationAlgorithm != "rbtree_best_fit" && allocationAlgorithm != "simple_seq_fit") {
+        LOG(error) << "Provided shared memory allocation algorithm '" << allocationAlgorithm << "' is not supported. Supported are 'rbtree_best_fit'/'simple_seq_fit'";
+        throw SharedMemoryError(tools::ToString("Provided shared memory allocation algorithm '", allocationAlgorithm, "' is not supported. Supported are 'rbtree_best_fit'/'simple_seq_fit'"));
+    }
+
+    try {
+        if (zmq_ctx_set(fZmqCtx, ZMQ_IO_THREADS, numIoThreads) != 0) {
+            LOG(error) << "failed configuring context, reason: " << zmq_strerror(errno);
+        }
+
+                 // Set the maximum number of allowed sockets on the context.
+        if (zmq_ctx_set(fZmqCtx, ZMQ_MAX_SOCKETS, 10000) != 0) {
+            LOG(error) << "failed configuring context, reason: " << zmq_strerror(errno);
+        }
+
+        fManager = std::make_unique<Manager>(sessionName, segmentSize, config);
+    } catch (boost::interprocess::interprocess_exception& e) {
+        LOG(error) << "Could not initialize shared memory transport: " << e.what();
+        throw std::runtime_error(tools::ToString("Could not initialize shared memory transport: ", e.what()));
+    } catch (const std::exception& e) {
+        LOG(error) << "Could not initialize shared memory transport: " << e.what();
+        throw std::runtime_error(tools::ToString("Could not initialize shared memory transport: ", e.what()));
+    }
+}
+
+TransportFactory::~TransportFactory()
+{
+    LOG(debug) << "Destroying Shared Memory transport...";
+
+    if (fZmqCtx) {
+        while (true) {
+            if (zmq_ctx_term(fZmqCtx) != 0) {
+                if (errno == EINTR) {
+                    LOG(debug) << "zmq_ctx_term interrupted by system call, retrying";
+                    continue;
+                } else {
+                    fZmqCtx = nullptr;
+                }
+            }
+            break;
+        }
+    } else {
+        LOG(error) << "context not available for shutdown";
+    }
+}
+
+MessagePtr TransportFactory::CreateMessage()
+{
+    return std::make_unique<Message>(*fManager, this);
+}
+
+MessagePtr TransportFactory::CreateMessage(Alignment alignment)
+{
+    return std::make_unique<Message>(*fManager, alignment, this);
+}
+
+MessagePtr TransportFactory::CreateMessage(size_t size)
+{
+    return std::make_unique<Message>(*fManager, size, this);
+}
+
+MessagePtr TransportFactory::CreateMessage(size_t size, Alignment alignment)
+{
+    return std::make_unique<Message>(*fManager, size, alignment, this);
+}
+
+MessagePtr TransportFactory::CreateMessage(void* data, size_t size, fair::mq::FreeFn* ffn, void* hint)
+{
+    return std::make_unique<Message>(*fManager, data, size, ffn, hint, this);
+}
+
+MessagePtr TransportFactory::CreateMessage(UnmanagedRegionPtr& region, void* data, size_t size, void* hint)
+{
+    return std::make_unique<Message>(*fManager, region, data, size, hint, this);
+}
+
+SocketPtr TransportFactory::CreateSocket(const std::string& type, const std::string& name)
+{
+    return std::make_unique<Socket>(*fManager, type, name, GetId(), fZmqCtx, this);
+}
+
+PollerPtr TransportFactory::CreatePoller(const std::vector<Channel>& channels) const
+{
+    return std::make_unique<Poller>(channels);
+}
+
+PollerPtr TransportFactory::CreatePoller(const std::vector<Channel*>& channels) const
+{
+    return std::make_unique<Poller>(channels);
+}
+
+PollerPtr TransportFactory::CreatePoller(const std::unordered_map<std::string, std::vector<Channel>>& channelsMap, const std::vector<std::string>& channelList) const
+{
+    return std::make_unique<Poller>(channelsMap, channelList);
+}
+
+UnmanagedRegionPtr TransportFactory::CreateUnmanagedRegion(size_t size, RegionCallback callback, const std::string& path, int flags, fair::mq::RegionConfig cfg)
+{
+    cfg.path = path;
+    cfg.creationFlags = flags;
+    return CreateUnmanagedRegion(size, callback, nullptr, std::move(cfg));
+}
+
+UnmanagedRegionPtr TransportFactory::CreateUnmanagedRegion(size_t size, RegionBulkCallback bulkCallback, const std::string& path, int flags, fair::mq::RegionConfig cfg)
+{
+    cfg.path = path;
+    cfg.creationFlags = flags;
+    return CreateUnmanagedRegion(size, nullptr, bulkCallback, std::move(cfg));
+}
+
+UnmanagedRegionPtr TransportFactory::CreateUnmanagedRegion(size_t size, int64_t userFlags, RegionCallback callback, const std::string& path, int flags, fair::mq::RegionConfig cfg)
+{
+    cfg.path = path;
+    cfg.userFlags = userFlags;
+    cfg.creationFlags = flags;
+    return CreateUnmanagedRegion(size, callback, nullptr, std::move(cfg));
+}
+
+UnmanagedRegionPtr TransportFactory::CreateUnmanagedRegion(size_t size, int64_t userFlags, RegionBulkCallback bulkCallback, const std::string& path, int flags, fair::mq::RegionConfig cfg)
+{
+    cfg.path = path;
+    cfg.userFlags = userFlags;
+    cfg.creationFlags = flags;
+    return CreateUnmanagedRegion(size, nullptr, bulkCallback, std::move(cfg));
+}
+
+UnmanagedRegionPtr TransportFactory::CreateUnmanagedRegion(size_t size, RegionCallback callback, RegionConfig cfg)
+{
+    return CreateUnmanagedRegion(size, callback, nullptr, std::move(cfg));
+}
+UnmanagedRegionPtr TransportFactory::CreateUnmanagedRegion(size_t size, RegionBulkCallback bulkCallback, RegionConfig cfg)
+{
+    return CreateUnmanagedRegion(size, nullptr, bulkCallback, std::move(cfg));
+}
+
+UnmanagedRegionPtr TransportFactory::CreateUnmanagedRegion(size_t size, RegionCallback callback, RegionBulkCallback bulkCallback, fair::mq::RegionConfig cfg)
+{
+    return std::make_unique<UnmanagedRegionImpl>(*fManager, size, callback, bulkCallback, std::move(cfg), this);
+}
+
+void TransportFactory::SubscribeToRegionEvents(RegionEventCallback callback) { fManager->SubscribeToRegionEvents(callback); }
+bool TransportFactory::SubscribedToRegionEvents() { return fManager->SubscribedToRegionEvents(); }
+void TransportFactory::UnsubscribeFromRegionEvents() { fManager->UnsubscribeFromRegionEvents(); }
+std::vector<fair::mq::RegionInfo> TransportFactory::GetRegionInfo() { return fManager->GetRegionInfo(); }
+
+}

--- a/fairmq/shmem/TransportFactory.h
+++ b/fairmq/shmem/TransportFactory.h
@@ -12,23 +12,13 @@
 #include "Common.h"
 #include "Manager.h"
 #include "Message.h"
-#include "Poller.h"
-#include "Socket.h"
-#include "UnmanagedRegionImpl.h"
-#include <fairmq/ProgOptions.h>
-#include <fairmq/tools/Strings.h>
-#include <fairmq/TransportFactory.h>
 
-#include <fairlogger/Logger.h>
+#include <fairmq/TransportFactory.h>
 
 #include <boost/version.hpp>
 
-#include <zmq.h>
-
-#include <memory> // unique_ptr, make_unique
 #include <string>
 #include <vector>
-#include <stdexcept>
 
 namespace fair::mq::shmem
 {
@@ -36,164 +26,34 @@ namespace fair::mq::shmem
 class TransportFactory final : public fair::mq::TransportFactory
 {
   public:
-    TransportFactory(const std::string& deviceId = "", const ProgOptions* config = nullptr)
-        : fair::mq::TransportFactory(deviceId)
-        , fZmqCtx(zmq_ctx_new())
-        , fManager(nullptr)
-    {
-        int major = 0, minor = 0, patch = 0;
-        zmq_version(&major, &minor, &patch);
-        LOG(debug) << "Transport: Using ZeroMQ (" << major << "." << minor << "." << patch << ") & "
-                << "boost::interprocess (" << (BOOST_VERSION / 100000) << "." << (BOOST_VERSION / 100 % 1000) << "." << (BOOST_VERSION % 100) << ")";
-
-        if (!fZmqCtx) {
-            throw std::runtime_error(tools::ToString("failed creating context, reason: ", zmq_strerror(errno)));
-        }
-
-        int numIoThreads = 1;
-        std::string sessionName = "default";
-        size_t segmentSize = 2ULL << 30;
-        std::string allocationAlgorithm("rbtree_best_fit");
-        if (config) {
-            numIoThreads = config->GetProperty<int>("io-threads", numIoThreads);
-            sessionName = config->GetProperty<std::string>("session", sessionName);
-            segmentSize = config->GetProperty<size_t>("shm-segment-size", segmentSize);
-            allocationAlgorithm = config->GetProperty<std::string>("shm-allocation", allocationAlgorithm);
-        } else {
-            LOG(debug) << "ProgOptions not available! Using defaults.";
-        }
-
-        if (allocationAlgorithm != "rbtree_best_fit" && allocationAlgorithm != "simple_seq_fit") {
-            LOG(error) << "Provided shared memory allocation algorithm '" << allocationAlgorithm << "' is not supported. Supported are 'rbtree_best_fit'/'simple_seq_fit'";
-            throw SharedMemoryError(tools::ToString("Provided shared memory allocation algorithm '", allocationAlgorithm, "' is not supported. Supported are 'rbtree_best_fit'/'simple_seq_fit'"));
-        }
-
-        try {
-            if (zmq_ctx_set(fZmqCtx, ZMQ_IO_THREADS, numIoThreads) != 0) {
-                LOG(error) << "failed configuring context, reason: " << zmq_strerror(errno);
-            }
-
-            // Set the maximum number of allowed sockets on the context.
-            if (zmq_ctx_set(fZmqCtx, ZMQ_MAX_SOCKETS, 10000) != 0) {
-                LOG(error) << "failed configuring context, reason: " << zmq_strerror(errno);
-            }
-
-            fManager = std::make_unique<Manager>(sessionName, segmentSize, config);
-        } catch (boost::interprocess::interprocess_exception& e) {
-            LOG(error) << "Could not initialize shared memory transport: " << e.what();
-            throw std::runtime_error(tools::ToString("Could not initialize shared memory transport: ", e.what()));
-        } catch (const std::exception& e) {
-            LOG(error) << "Could not initialize shared memory transport: " << e.what();
-            throw std::runtime_error(tools::ToString("Could not initialize shared memory transport: ", e.what()));
-        }
-    }
+    TransportFactory(const std::string& deviceId = "", const ProgOptions* config = nullptr);
 
     TransportFactory(const TransportFactory&) = delete;
     TransportFactory(TransportFactory&&) = delete;
     TransportFactory& operator=(const TransportFactory&) = delete;
     TransportFactory& operator=(TransportFactory&&) = delete;
 
-    MessagePtr CreateMessage() override
-    {
-        return std::make_unique<Message>(*fManager, this);
-    }
-
-    MessagePtr CreateMessage(Alignment alignment) override
-    {
-        return std::make_unique<Message>(*fManager, alignment, this);
-    }
-
-    MessagePtr CreateMessage(size_t size) override
-    {
-        return std::make_unique<Message>(*fManager, size, this);
-    }
-
-    MessagePtr CreateMessage(size_t size, Alignment alignment) override
-    {
-        return std::make_unique<Message>(*fManager, size, alignment, this);
-    }
-
-    MessagePtr CreateMessage(void* data, size_t size, fair::mq::FreeFn* ffn, void* hint = nullptr) override
-    {
-        return std::make_unique<Message>(*fManager, data, size, ffn, hint, this);
-    }
-
-    MessagePtr CreateMessage(UnmanagedRegionPtr& region,
-                             void* data,
-                             size_t size,
-                             void* hint = nullptr) override
-    {
-        return std::make_unique<Message>(*fManager, region, data, size, hint, this);
-    }
-
-    SocketPtr CreateSocket(const std::string& type, const std::string& name) override
-    {
-        return std::make_unique<Socket>(*fManager, type, name, GetId(), fZmqCtx, this);
-    }
-
-    PollerPtr CreatePoller(const std::vector<Channel>& channels) const override
-    {
-        return std::make_unique<Poller>(channels);
-    }
-
-    PollerPtr CreatePoller(const std::vector<Channel*>& channels) const override
-    {
-        return std::make_unique<Poller>(channels);
-    }
-
-    PollerPtr CreatePoller(const std::unordered_map<std::string, std::vector<Channel>>& channelsMap, const std::vector<std::string>& channelList) const override
-    {
-        return std::make_unique<Poller>(channelsMap, channelList);
-    }
-
-    UnmanagedRegionPtr CreateUnmanagedRegion(size_t size, RegionCallback callback = nullptr, const std::string& path = "", int flags = 0, fair::mq::RegionConfig cfg = fair::mq::RegionConfig()) override
-    {
-        cfg.path = path;
-        cfg.creationFlags = flags;
-        return CreateUnmanagedRegion(size, callback, nullptr, std::move(cfg));
-    }
-
-    UnmanagedRegionPtr CreateUnmanagedRegion(size_t size, RegionBulkCallback bulkCallback = nullptr, const std::string& path = "", int flags = 0, fair::mq::RegionConfig cfg = fair::mq::RegionConfig()) override
-    {
-        cfg.path = path;
-        cfg.creationFlags = flags;
-        return CreateUnmanagedRegion(size, nullptr, bulkCallback, std::move(cfg));
-    }
-
-    UnmanagedRegionPtr CreateUnmanagedRegion(size_t size, int64_t userFlags, RegionCallback callback = nullptr, const std::string& path = "", int flags = 0, fair::mq::RegionConfig cfg = fair::mq::RegionConfig()) override
-    {
-        cfg.path = path;
-        cfg.userFlags = userFlags;
-        cfg.creationFlags = flags;
-        return CreateUnmanagedRegion(size, callback, nullptr, std::move(cfg));
-    }
-
-    UnmanagedRegionPtr CreateUnmanagedRegion(size_t size, int64_t userFlags, RegionBulkCallback bulkCallback = nullptr, const std::string& path = "", int flags = 0, fair::mq::RegionConfig cfg = fair::mq::RegionConfig()) override
-    {
-        cfg.path = path;
-        cfg.userFlags = userFlags;
-        cfg.creationFlags = flags;
-        return CreateUnmanagedRegion(size, nullptr, bulkCallback, std::move(cfg));
-    }
-
-    UnmanagedRegionPtr CreateUnmanagedRegion(size_t size, RegionCallback callback, RegionConfig cfg) override
-    {
-        return CreateUnmanagedRegion(size, callback, nullptr, std::move(cfg));
-    }
-    UnmanagedRegionPtr CreateUnmanagedRegion(size_t size, RegionBulkCallback bulkCallback, RegionConfig cfg) override
-    {
-        return CreateUnmanagedRegion(size, nullptr, bulkCallback, std::move(cfg));
-    }
-
-    UnmanagedRegionPtr CreateUnmanagedRegion(size_t size, RegionCallback callback, RegionBulkCallback bulkCallback, fair::mq::RegionConfig cfg)
-    {
-        return std::make_unique<UnmanagedRegionImpl>(*fManager, size, callback, bulkCallback, std::move(cfg), this);
-    }
-
-    void SubscribeToRegionEvents(RegionEventCallback callback) override { fManager->SubscribeToRegionEvents(callback); }
-    bool SubscribedToRegionEvents() override { return fManager->SubscribedToRegionEvents(); }
-    void UnsubscribeFromRegionEvents() override { fManager->UnsubscribeFromRegionEvents(); }
-    std::vector<fair::mq::RegionInfo> GetRegionInfo() override { return fManager->GetRegionInfo(); }
+    inline MessagePtr CreateMessage() override;
+    inline MessagePtr CreateMessage(Alignment alignment) override;
+    inline MessagePtr CreateMessage(size_t size) override;
+    inline MessagePtr CreateMessage(size_t size, Alignment alignment) override;
+    inline MessagePtr CreateMessage(void* data, size_t size, fair::mq::FreeFn* ffn, void* hint = nullptr) override;
+    inline MessagePtr CreateMessage(UnmanagedRegionPtr& region, void* data, size_t size, void* hint = nullptr) override;
+    inline SocketPtr CreateSocket(const std::string& type, const std::string& name) override;
+    inline PollerPtr CreatePoller(const std::vector<Channel>& channels) const override;
+    inline PollerPtr CreatePoller(const std::vector<Channel*>& channels) const override;
+    inline PollerPtr CreatePoller(const std::unordered_map<std::string, std::vector<Channel>>& channelsMap, const std::vector<std::string>& channelList) const override;
+    inline UnmanagedRegionPtr CreateUnmanagedRegion(size_t size, RegionCallback callback = nullptr, const std::string& path = "", int flags = 0, fair::mq::RegionConfig cfg = fair::mq::RegionConfig()) override;
+    inline UnmanagedRegionPtr CreateUnmanagedRegion(size_t size, RegionBulkCallback bulkCallback = nullptr, const std::string& path = "", int flags = 0, fair::mq::RegionConfig cfg = fair::mq::RegionConfig()) override;
+    inline UnmanagedRegionPtr CreateUnmanagedRegion(size_t size, int64_t userFlags, RegionCallback callback = nullptr, const std::string& path = "", int flags = 0, fair::mq::RegionConfig cfg = fair::mq::RegionConfig()) override;
+    inline UnmanagedRegionPtr CreateUnmanagedRegion(size_t size, int64_t userFlags, RegionBulkCallback bulkCallback = nullptr, const std::string& path = "", int flags = 0, fair::mq::RegionConfig cfg = fair::mq::RegionConfig()) override;
+    inline UnmanagedRegionPtr CreateUnmanagedRegion(size_t size, RegionCallback callback, RegionConfig cfg) override;
+    inline UnmanagedRegionPtr CreateUnmanagedRegion(size_t size, RegionBulkCallback bulkCallback, RegionConfig cfg) override;
+    inline UnmanagedRegionPtr CreateUnmanagedRegion(size_t size, RegionCallback callback, RegionBulkCallback bulkCallback, fair::mq::RegionConfig cfg);
+    inline void SubscribeToRegionEvents(RegionEventCallback callback) override;
+    inline bool SubscribedToRegionEvents() override;
+    inline void UnsubscribeFromRegionEvents() override;
+    inline std::vector<fair::mq::RegionInfo> GetRegionInfo() override;
 
     Transport GetType() const override { return fair::mq::Transport::SHM; }
 
@@ -201,26 +61,7 @@ class TransportFactory final : public fair::mq::TransportFactory
     void Resume() override { fManager->Resume(); }
     void Reset() override { fManager->Reset(); }
 
-    ~TransportFactory() override
-    {
-        LOG(debug) << "Destroying Shared Memory transport...";
-
-        if (fZmqCtx) {
-            while (true) {
-                if (zmq_ctx_term(fZmqCtx) != 0) {
-                    if (errno == EINTR) {
-                        LOG(debug) << "zmq_ctx_term interrupted by system call, retrying";
-                        continue;
-                    } else {
-                        fZmqCtx = nullptr;
-                    }
-                }
-                break;
-            }
-        } else {
-            LOG(error) << "context not available for shutdown";
-        }
-    }
+    ~TransportFactory() override;
 
     Manager* GetManager()
     {

--- a/fairmq/shmem/TransportFactory.h
+++ b/fairmq/shmem/TransportFactory.h
@@ -222,6 +222,11 @@ class TransportFactory final : public fair::mq::TransportFactory
         }
     }
 
+    Manager* GetManager()
+    {
+      return fManager.get();
+    }
+
   private:
     void* fZmqCtx;
     std::unique_ptr<Manager> fManager;


### PR DESCRIPTION
For a specific case where we want to have a cache of preallocated shared memory messages that is accessible by other devices through a time-based table, to avoid complicated synchronizations, we send a table with only the messages metadata. To access the objects in shared memory, referred to by this metadata, the target device needs to calculate the device-local pointer to the corresponding memory. This is achieved by exposing the shared memory manager API from the transport of the specific channel, that is used to send the metadata table. This approach allows us to centralize the cache management and re-use FairMQ-based shared memory management meaning the client code remains largely unchanged.

To summarize, shem message now exposes its metadata through a public method, that is then transferred to a target device, shmem transport exposes its shmem manager, that, in turn, exposes its API to get the local pointer from message handle and managed segment id for the target device. This is, of course, a draft, any suggestions as to how to handle this better (specifically, better aligned to the FairMQ architecture) are welcome. 

Since "shmem/TransportFactory.h" needs to be included in the client code, the class is out-of-lined so that we do not need to expose other internal headers or link to ZeroMQ directly.

@ktf 